### PR TITLE
Add urls and config for API docs.

### DIFF
--- a/api/scpca_portal/urls.py
+++ b/api/scpca_portal/urls.py
@@ -2,12 +2,41 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path, re_path, reverse_lazy
 from django.views.generic.base import RedirectView
+from rest_framework import permissions
 
-from rest_framework_extensions.routers import ExtendedSimpleRouter
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework_extensions.routers import ExtendedDefaultRouter
 
 from scpca_portal.views import APITokenViewSet, ComputedFileViewSet, ProjectViewSet, SampleViewSet
 
-router = ExtendedSimpleRouter()
+schema_view = get_schema_view(
+    openapi.Info(
+        title="ScPCA Portal API",
+        default_version="v1",
+        description="""
+The Single-cell Pediatrc Cancer Atlas is a collection of pediatric cancer projects that collected single-cell sequencing data and were processed using the workflows contained in https://github.com/AlexsLemonade/alsf-scpca.
+
+The swagger-ui view can be found [here](http://api.scpca.alexslemonade.org/swagger/).
+
+The ReDoc view can be found [here](http://api.scpca.alexslemonade.org/).
+
+Additional documentation can be found at [docs.scpca.alexslemonade.org](http://docs.scpca.alexslemonade.org/en/latest/).
+
+### Questions/Feedback?
+
+If you have a question or comment, please [file an issue on GitHub](https://github.com/AlexsLemonade/scpca/issues) or send us an email at [requests@ccdatalab.org](mailto:requests@ccdatalab.org).
+        """,
+        terms_of_service="https://scpca.alexslemonade.org/terms",
+        contact=openapi.Contact(email="requests@ccdatalab.org"),
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+    url="https://api.scpca.alexslemonade.org",
+)
+
+router = ExtendedDefaultRouter()
 router.trailing_slash = "/?"
 
 router.register(r"computed-files", ComputedFileViewSet, basename="computed-files")
@@ -16,7 +45,22 @@ router.register(r"samples", SampleViewSet, basename="samples")
 router.register(r"tokens", APITokenViewSet, basename="tokens")
 
 urlpatterns = [
-    path("v1/", include(router.urls)),
+    path(
+        "v1/",
+        include(
+            router.urls
+            + [
+                re_path(
+                    r"^swagger/$",
+                    schema_view.with_ui("swagger", cache_timeout=0),
+                    name="schema_swagger_ui",
+                ),
+                re_path(
+                    r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema_redoc"
+                ),
+            ]
+        ),
+    ),
     # the 'api-root' from django rest-frameworks default router
     # http://www.django-rest-framework.org/api-guide/routers/#defaultrouter
     re_path(r"^$", RedirectView.as_view(url=reverse_lazy("api-root"), permanent=False)),


### PR DESCRIPTION
## Issue Number

#18 

## Purpose/Implementation Notes

This gives us 3 HTML interfaces for the API. Probably too many. I've attached screenshots of them all. I'd appreciate some opinions about what interface should be exposed via what route.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I've run things locally to create the following screenshots.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

As this PR stands, the following URLs will show the following pages:

http://0.0.0.0:8000/v1/
![base](https://user-images.githubusercontent.com/4026833/131393058-9b1a1f34-6969-463b-a141-023cc6633e88.png)

http://0.0.0.0:8000/v1/redoc/
![redoc](https://user-images.githubusercontent.com/4026833/131393078-18926bc5-9bca-4264-9816-b74c5f1ee0e2.png)

http://0.0.0.0:8000/v1/swagger/
![swagger](https://user-images.githubusercontent.com/4026833/131393100-d2a35b27-bb9d-4970-9da8-ea171ef07f3a.png)
