### PR TITLE
Remove trailing _sce postfix from file names.

### DIFF
--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -99,8 +99,8 @@ def package_files_for_sample(
             for library in libraries:
                 # TODO: reenable _qc_report.html once it's there.
                 # https://github.com/AlexsLemonade/scpca-portal/issues/33
-                # for file_postfix in ["_unfiltered_sce.rds", "_filtered_sce.rds", "_qc_report.html"]:
-                for file_postfix in ["_unfiltered_sce.rds", "_filtered_sce.rds"]:
+                # for file_postfix in ["_unfiltered.rds", "_filtered.rds", "_qc_report.html"]:
+                for file_postfix in ["_unfiltered.rds", "_filtered.rds"]:
                     filename = f"{library['scpca_library_id']}{file_postfix}"
                     local_file_path = os.path.join(project_dir, "files", sample_id, filename)
                     file_paths.append(local_file_path)
@@ -334,11 +334,11 @@ class Command(BaseCommand):
         /project_metadata.csv
         /dyer_chen/libraries_metadata.csv
         /dyer_chen/samples_metadata.csv
-        /dyer_chen/files/SCPCS000109/SCPCL000126_filtered_sce.rds
-        /dyer_chen/files/SCPCS000109/SCPCL000126_unfiltered_sce.rds
+        /dyer_chen/files/SCPCS000109/SCPCL000126_filtered.rds
+        /dyer_chen/files/SCPCS000109/SCPCL000126_unfiltered.rds
         /dyer_chen/files/SCPCS000109/SCPCL000126_qc_report.html
-        /dyer_chen/files/SCPCS000109/SCPCL000127_filtered_sce.rds
-        /dyer_chen/files/SCPCS000109/SCPCL000127_unfiltered_sce.rds
+        /dyer_chen/files/SCPCS000109/SCPCL000127_filtered.rds
+        /dyer_chen/files/SCPCS000109/SCPCL000127_unfiltered.rds
         /dyer_chen/files/SCPCS000109/SCPCL000127_qc_report.html
 
     The files will be zipped up and stats will be calculated for them.

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -57,7 +57,4 @@ class ComputedFile(models.Model):
             )
             return False
 
-        self.s3_key = None
-        self.s3_bucket = None
-        self.save()
         return True

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -18,7 +18,7 @@ class LeafComputedFileFactory(factory.django.DjangoModelFactory):
 
     type = "FILTERED_COUNTS"
     s3_bucket = "scpca-portal-local"
-    s3_key = "SCPCR000126/filtered_sce.rds"
+    s3_key = "SCPCR000126/filtered.rds"
     workflow_version = "1.0.0"
     size_in_bytes = 100
 


### PR DESCRIPTION
## Issue Number

N/A Things broke when the input format changed

## Purpose/Implementation Notes

These used to have this in them, now they don't.

I also was getting `null value in column "s3_bucket" violates not-null constraint` errors when trying to purge a project because we were setting `s3_bucket` and `s3_key` to null when we deleted them from s3. I'd rather have the not null constraint than be able to set them to None right before we delete them though.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've run

```
sportal manage-api load_data --reload-existing --upload True
```

To update the local data bucket.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
