### PR TITLE
Make sure the exit code of sportal matches the command it calls.

### DIFF
--- a/api/scpca_portal/test/views/test_computed_file.py
+++ b/api/scpca_portal/test/views/test_computed_file.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework import status
@@ -9,6 +10,14 @@ from faker import Faker
 from scpca_portal.test.factories import ComputedFileFactory
 
 fake = Faker()
+
+
+class MockS3Client:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def generate_presigned_url(self, *args, **kwargs):
+        return "This isn't really a presigned URL but it's good enough."
 
 
 class ComputedFilesTestCase(APITestCase):
@@ -26,6 +35,7 @@ class ComputedFilesTestCase(APITestCase):
 
         self.assertNotIn("download_url", response.json())
 
+    @patch("scpca_portal.models.computed_file.s3", MockS3Client())
     def test_get_with_token(self):
         # create token
         response = self.client.post(

--- a/bin/sportal
+++ b/bin/sportal
@@ -46,6 +46,12 @@ args = parser.parse_args()
 
 try:
     command = commands[args.command]
-    os.system(command.format(" ".join(args.command_args)))
+    out = os.system(command.format(" ".join(args.command_args)))
+
+    # The exit code of this script matches the command it called.
+    # os.system() outputs a waitstatus instead of an exitcode.
+    # In python3.9 this becomes the much more sane
+    # os.waitstatus_to_exitcode() function.
+    exit(os.WEXITSTATUS(out))
 except KeyError:
     print("Unknown Command")

--- a/bin/sportal
+++ b/bin/sportal
@@ -46,12 +46,12 @@ args = parser.parse_args()
 
 try:
     command = commands[args.command]
-    out = os.system(command.format(" ".join(args.command_args)))
+    waitstatus = os.system(command.format(" ".join(args.command_args)))
 
     # The exit code of this script matches the command it called.
     # os.system() outputs a waitstatus instead of an exitcode.
     # In python3.9 this becomes the much more sane
     # os.waitstatus_to_exitcode() function.
-    exit(os.WEXITSTATUS(out))
+    exit(os.WEXITSTATUS(waitstatus))
 except KeyError:
     print("Unknown Command")


### PR DESCRIPTION
## Issue Number

#55 

## Purpose/Implementation Notes

#55 should have failed, but it didn't because the exit code of `sportal` wasn't correct. This should prevent that from happening in the future.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've made sure `sportal test-api` with a failing test has an exit code of 1.
