### PR TITLE
Add API-KEY to allowed CORS headers.

### DIFF
--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -4,6 +4,7 @@ from os.path import join
 
 import dj_database_url
 from configurations import Configuration
+from corsheaders.defaults import default_headers
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -149,5 +150,6 @@ class Common(Configuration):
     }
     # CORS - unrestricted
     CORS_ORIGIN_ALLOW_ALL = True
+    CORS_ALLOW_HEADERS = default_headers + ("API-KEY",)
 
     TERMS_AND_CONDITIONS = "PLACEHOLDER"

--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -150,6 +150,7 @@ class Common(Configuration):
     }
     # CORS - unrestricted
     CORS_ORIGIN_ALLOW_ALL = True
-    CORS_ALLOW_HEADERS = default_headers + ("api-key",)
+    API_KEY_HEADER = "api-key"
+    CORS_ALLOW_HEADERS = default_headers + (API_KEY_HEADER,)
 
     TERMS_AND_CONDITIONS = "PLACEHOLDER"

--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -150,6 +150,6 @@ class Common(Configuration):
     }
     # CORS - unrestricted
     CORS_ORIGIN_ALLOW_ALL = True
-    CORS_ALLOW_HEADERS = default_headers + ("API-KEY",)
+    CORS_ALLOW_HEADERS = default_headers + ("api-key",)
 
     TERMS_AND_CONDITIONS = "PLACEHOLDER"

--- a/api/scpca_portal/test/views/test_computed_file.py
+++ b/api/scpca_portal/test/views/test_computed_file.py
@@ -33,7 +33,7 @@ class ComputedFilesTestCase(APITestCase):
         url = reverse("computed-files-detail", args=[self.computed_file.id])
         # The presence of the origin header triggers CORS middleware,
         # but its content don't matter for this test.
-        response = self.client.options(url, HTTP_ORIGIN="foo")
+        response = self.client.options(url, HTTP_ORIGIN="example.com")
 
         self.assertIn(
             settings.API_KEY_HEADER, response.get("Access-Control-Allow-Headers").split(", ")

--- a/api/scpca_portal/test/views/test_computed_file.py
+++ b/api/scpca_portal/test/views/test_computed_file.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import patch
 
+from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -27,6 +28,16 @@ class ComputedFilesTestCase(APITestCase):
 
     def setUp(self):
         self.computed_file = ComputedFileFactory()
+
+    def test_options(self):
+        url = reverse("computed-files-detail", args=[self.computed_file.id])
+        # The presence of the origin header triggers CORS middleware,
+        # but its content don't matter for this test.
+        response = self.client.options(url, HTTP_ORIGIN="foo")
+
+        self.assertIn(
+            settings.API_KEY_HEADER, response.get("Access-Control-Allow-Headers").split(", ")
+        )
 
     def test_get_single(self):
         url = reverse("computed-files-detail", args=[self.computed_file.id])


### PR DESCRIPTION
## Issue Number

N/A just came up for @davidsmejia 

## Purpose/Implementation Notes

Adds the API-KEY header to CORS to allow API tokens to be accepted.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

mmmm @davidsmejia how do I test this?

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
