### PR TITLE
Bad tokens cause a 403 rather than just not providing a download URL.

### DIFF
--- a/api/scpca_portal/test/views/test_computed_file.py
+++ b/api/scpca_portal/test/views/test_computed_file.py
@@ -62,6 +62,11 @@ class ComputedFilesTestCase(APITestCase):
 
         self.assertIsNotNone("download_url", response.json())
 
+    def test_get_with_bad_token(self):
+        url = reverse("computed-files-detail", args=[self.computed_file.id])
+        response = self.client.get(url, HTTP_API_KEY="bad token")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_get_list(self):
         response = self.client.get(reverse("computed-files-list"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/scpca_portal/views/computed_file.py
+++ b/api/scpca_portal/views/computed_file.py
@@ -71,7 +71,7 @@ class ComputedFileViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
                 return {**serializer_context, "token": token}
             except (APIToken.DoesNotExist, ValidationError):
                 raise PermissionDenied(
-                    {"message": "Your token is not valid or activated.", "token_id": token_id}
+                    {"message": "Your token is not valid or not activated.", "token_id": token_id}
                 )
         else:
             return serializer_context


### PR DESCRIPTION
## Issue Number

N/A @davidsmejia thought something broke but it was just a bad token

## Purpose/Implementation Notes

Silent failures bad! If there's a token and it's not valid, return a 403.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've added a unit test.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
