### PR TITLE
Actually save project_summaries as we update them

### DIFF
--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -117,6 +117,7 @@ def update_project_counts(sender, instance=None, created=False, update_fields=No
                 project=project, diagnosis=summary[0], seq_unit=summary[1], technology=summary[2]
             )
             project_summary.sample_count = count
+            project_summary.save()
         except ProjectSummary.DoesNotExist:
             ProjectSummary.objects.create(
                 project=project,


### PR DESCRIPTION
## Issue Number

#87 

## Purpose/Implementation Notes

I also had this in another branch. I just didn't save the project summary when it exists and needs to be incremented.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've tested this in the new import branch.
