### PR TITLE
Add template for project README file 

### DIFF
--- a/api/scpca_portal/config/readme-template.md
+++ b/api/scpca_portal/config/readme-template.md
@@ -21,7 +21,7 @@ Also included in each download is a `libraries_metadata.csv`, a comma-separated 
 Gene expression files, available as RDS files containing a `SingleCellExperiment` object, house the expression data, cell and gene metrics, associated metadata, and in the case of multi-modal data like CITE-seq, data from the additional cell-based assays (see [Single-cell gene expression file contents](https://scpca.readthedocs.io/en/latest/sce_file_contents.html) for more information).
 
 See the [Downloadable files](https://scpca.readthedocs.io/en/latest/download_files.html) section in our documentation for more detailed information on files included in the download.
-   
+
 ## Usage
 
 For instructions on using the RDS files, please see [FAQ: How do I use the provided files in R?](https://scpca.readthedocs.io/en/latest/faq.html#how-do-i-use-the-provided-rds-files-in-r) or [FAQ: What if I want to use Python instead of R?](https://scpca.readthedocs.io/en/latest/faq.html#what-if-i-want-to-use-python-instead-of-r)


### PR DESCRIPTION
## Issue Number
#49 

## Purpose/Implementation Notes

Here I am adding in a template for the README file that will be included in each download. After discussion with @jaclyn-taroni we decided to make a template that includes a `project_accession` and `project_url` and then we were hoping the template could be programmatically filled in to create each of the project specific README files. @kurtwheeler would this be possible and if so what would be most helpful to include in the template to make that feasible? 

For the most part I tried to mostly link to the docs for information about the file contents and download contents, but included some basic information. Reviewers, please let me know if I can pare down more information and if its too repetitive to what is in the docs already. 

For now, I only included a link to the main terms and conditions page, but we may need to add project specific links to the terms and conditions in the future.

An additional question I have is where is the best place for this to be stored? Right now I created a folder, `project-readme` and placed the template there, but @kurtwheeler please let me know if there is a better place that you would prefer this to go?  

## Types of changes

Addition of README template to include in each download


