### PR TITLE
Add github actions workflow for prod deploy.

### DIFF
--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -1,0 +1,32 @@
+name: prod-backend
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: prod-backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.12.26
+
+      - name: Deploy
+        run: cd infrastructure && python3 deploy.py -e prod -u deployer -d ccdl -v $(git rev-parse HEAD)
+        env:
+          DATABASE_PASSWORD: ${{ secrets.PROD_DATABASE_PASSWORD }}
+          DJANGO_SECRET_KEY: ${{ secrets.PROD_DJANGO_SECRET_KEY }}
+          DOCKER_ID: ${{ secrets.DOCKER_ID }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          API_SSH_KEY: ${{ secrets.API_SSH_KEY }}
+          SENTRY_IO_URL: ${{ secrets.SENTRY_IO_URL }}
+          SENTRY_ENV: prod-api


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/16

## Purpose/Implementation Notes

This should get prod deploying on pushes to master. Once we run a deploy I can use the EIP address created to setup the DNS for the prod API.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Can't really until we merge to master.
