### PR TITLE
Fix data paths for production docker images

### DIFF
--- a/api/Dockerfile.local
+++ b/api/Dockerfile.local
@@ -28,6 +28,10 @@ ARG PORT
 
 ENV SYSTEM_VERSION $SYSTEM_VERSION
 
+# Adds our application code to the image, which is needed even though
+# we use the code dir for the readme template.
+COPY . .
+
 USER user
 
 WORKDIR /home/user/code

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -323,8 +323,8 @@ def load_data_from_s3(
     reload_existing: bool,
     reload_all: bool,
     input_bucket_name="scpca-portal-inputs",
-    data_dir="/home/user/code/data/",
-    readme_path="/home/user/code/scpca_portal/config/readme_template.md",
+    data_dir="/home/user/data/",
+    readme_path="/home/user/scpca_portal/config/readme_template.md",
 ):
     if reload_all:
         purge_all_projects(should_upload)

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -90,6 +90,13 @@ cat <<"EOF" > environment
 ${api_environment}
 EOF
 
+# Install the script to load data
+cat <<"EOF" > load_data.sh
+${load_data_script}
+EOF
+
+chmod +x ./load_data.sh
+
 # Install the API startup script
 cat <<"EOF" > start_api_with_migrations.sh
 ${start_api_with_migrations}

--- a/infrastructure/api-configuration/load_data.tpl.sh
+++ b/infrastructure/api-configuration/load_data.tpl.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Pull the API image.
+api_docker_image=${dockerhub_repo}/scpca_portal_api:latest
+docker pull $api_docker_image
+
+
+# Start the API image.
+docker run \
+       --env-file environment \
+       --name=scpca_portal_loader \
+       -d $api_docker_image
+
+docker exec scpca_portal_api pwd

--- a/infrastructure/api-configuration/load_data.tpl.sh
+++ b/infrastructure/api-configuration/load_data.tpl.sh
@@ -9,6 +9,6 @@ docker pull $api_docker_image
 docker run \
        --env-file environment \
        --name=scpca_portal_loader \
-       -d $api_docker_image
+       -d $api_docker_image python3 manage.py load_data "$@"
 
 docker exec scpca_portal_api pwd

--- a/infrastructure/api.tf
+++ b/infrastructure/api.tf
@@ -64,6 +64,11 @@ resource "aws_instance" "api_server_1" {
           log_group = aws_cloudwatch_log_group.scpca_portal_log_group.name
           log_stream = aws_cloudwatch_log_stream.log_stream_api.name
         })
+      load_data_script = templatefile(
+        "api-configuration/load_data.tpl.sh",
+        {
+          dockerhub_repo = var.dockerhub_repo
+        })
       user = var.user
       stage = var.stage
       region = var.region


### PR DESCRIPTION
## Issue Number

#102 

## Purpose/Implementation Notes

We don't have a `/home/user/code` directory in the prod image, that's just for development code. This fixes the default paths for production.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I'm testing this with a dev stack.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
