### PR TITLE
Save ssl certs between deploys

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -22,26 +22,40 @@ cp nginx.conf /etc/nginx/nginx.conf
 service nginx restart
 
 if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
-    # Create and install SSL Certificate for the API.
-    # Only necessary on staging and prod.
-    # We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
-    apt-get install -y software-properties-common
-    add-apt-repository ppa:certbot/certbot
-    apt-get update
-    apt-get install -y python-certbot-nginx
+    # Check here for the cert in S3, if present install, if not run certbot.
+    if [[ $(aws s3 ls ${scpca_portal_cert_bucket} | wc -l) == "0" ]]; then
+	# Create and install SSL Certificate for the API.
+	# Only necessary on staging and prod.
+	# We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
+	apt-get install -y software-properties-common
+	add-apt-repository ppa:certbot/certbot
+	apt-get update
+	apt-get install -y python-certbot-nginx
 
-    # g3w4k4t5n3s7p7v8@alexslemonade.slack.com is the email address we
-    # have configured to forward mail to the #teamcontact channel in
-    # slack. Certbot will use it for "important account
-    # notifications".
+	# g3w4k4t5n3s7p7v8@alexslemonade.slack.com is the email address we
+	# have configured to forward mail to the #teamcontact channel in
+	# slack. Certbot will use it for "important account
+	# notifications".
 
-    # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
-    sleep 180
-    BASE_URL="scpca.alexslemonade.org"
-    if [[ ${stage} == "staging" ]]; then
-        certbot --nginx -d api.staging.$BASE_URL -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
-    elif [[ ${stage} == "prod" ]]; then
-        certbot --nginx -d api.$BASE_URL -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+	# The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
+	sleep 180
+	BASE_URL="scpca.alexslemonade.org"
+	if [[ ${stage} == "staging" ]]; then
+            certbot --nginx -d api.staging.$BASE_URL -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+	elif [[ ${stage} == "prod" ]]; then
+            certbot --nginx -d api.$BASE_URL -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+	fi
+
+	cd /etc/letsencrypt/
+	sudo zip -r ../letsencryptdir.zip ../$(basename $PWD)
+	cd -
+	mv /etc/letsencryptdir.zip .
+	aws s3 cp letsencryptdir.zip "s3://${scpca_portal_cert_bucket}/"
+	rm sslcert.zip
+    else
+	zip_filename=$(aws s3 ls ${scpca_portal_cert_bucket} | head -1 | awk '{print $4}')
+	aws s3 cp "s3://${scpca_portal_cert_bucket}/$zip_filename" letsencryptdir.zip
+	unzip letsencryptdir.zip -d /etc/
     fi
 fi
 

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -17,7 +17,7 @@ cat <<"EOF" > nginx.conf
 ${nginx_config}
 EOF
 apt-get update -y
-apt-get install nginx -y
+apt-get install nginx awscli -y
 cp nginx.conf /etc/nginx/nginx.conf
 service nginx restart
 
@@ -51,7 +51,7 @@ if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
 	cd -
 	mv /etc/letsencryptdir.zip .
 	aws s3 cp letsencryptdir.zip "s3://${scpca_portal_cert_bucket}/"
-	rm sslcert.zip
+	rm letsencryptdir.zip
     else
 	zip_filename=$(aws s3 ls ${scpca_portal_cert_bucket} | head -1 | awk '{print $4}')
 	aws s3 cp "s3://${scpca_portal_cert_bucket}/$zip_filename" letsencryptdir.zip

--- a/infrastructure/api.tf
+++ b/infrastructure/api.tf
@@ -35,27 +35,29 @@ resource "aws_instance" "api_server_1" {
     aws_db_instance.postgres_db,
     aws_security_group_rule.scpca_portal_api_http,
     aws_security_group_rule.scpca_portal_api_outbound,
-    aws_key_pair.scpca_portal
+    aws_key_pair.scpca_portal,
+    aws_s3_bucket.scpca_portal_cert_bucket
   ]
 
   user_data = templatefile(
     "api-configuration/api-server-instance-user-data.tpl.sh",
     {
       nginx_config = data.local_file.api_nginx_config.content
+      scpca_portal_cert_bucket = aws_s3_bucket.scpca_portal_cert_bucket.id
       api_environment = templatefile(
         "api-configuration/environment.tpl",
-        {
-          django_secret_key = var.django_secret_key
-          database_host = aws_db_instance.postgres_db.address
-          database_port = aws_db_instance.postgres_db.port
-          database_user = aws_db_instance.postgres_db.username
-          database_name = aws_db_instance.postgres_db.name
-          database_password = var.database_password
-          aws_region  = var.region
-          aws_s3_bucket_name = aws_s3_bucket.scpca_portal_bucket.id
-          sentry_io_url = var.sentry_io_url
-          sentry_env = var.sentry_env
-        })
+	{
+	  django_secret_key = var.django_secret_key
+	  database_host = aws_db_instance.postgres_db.address
+	  database_port = aws_db_instance.postgres_db.port
+	  database_user = aws_db_instance.postgres_db.username
+	  database_name = aws_db_instance.postgres_db.name
+	  database_password = var.database_password
+	  aws_region  = var.region
+	  aws_s3_bucket_name = aws_s3_bucket.scpca_portal_bucket.id
+	  sentry_io_url = var.sentry_io_url
+	  sentry_env = var.sentry_env
+	})
       start_api_with_migrations = templatefile(
         "api-configuration/start_api_with_migrations.tpl.sh",
         {

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -95,8 +95,10 @@ resource "aws_iam_policy" "s3_access_policy" {
             "s3:ListBucket",
             "s3:GetBucketLocation"
          ],
-         "Resource": "arn:aws:s3:::${aws_s3_bucket.scpca_portal_bucket.bucket}",
-         "Resource": "arn:aws:s3:::${aws_s3_bucket.scpca_portal_cert_bucket.bucket}"
+         "Resource": [
+            "arn:aws:s3:::${aws_s3_bucket.scpca_portal_bucket.bucket}",
+            "arn:aws:s3:::${aws_s3_bucket.scpca_portal_cert_bucket.bucket}"
+         ]
       },
       {
          "Effect":"Allow",

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -95,7 +95,8 @@ resource "aws_iam_policy" "s3_access_policy" {
             "s3:ListBucket",
             "s3:GetBucketLocation"
          ],
-         "Resource": "arn:aws:s3:::${aws_s3_bucket.scpca_portal_bucket.bucket}"
+         "Resource": "arn:aws:s3:::${aws_s3_bucket.scpca_portal_bucket.bucket}",
+         "Resource": "arn:aws:s3:::${aws_s3_bucket.scpca_portal_cert_bucket.bucket}"
       },
       {
          "Effect":"Allow",
@@ -105,7 +106,8 @@ resource "aws_iam_policy" "s3_access_policy" {
             "s3:DeleteObject"
          ],
           "Resource": [
-            "arn:aws:s3:::${aws_s3_bucket.scpca_portal_bucket.bucket}/*"
+            "arn:aws:s3:::${aws_s3_bucket.scpca_portal_bucket.bucket}/*",
+            "arn:aws:s3:::${aws_s3_bucket.scpca_portal_cert_bucket.bucket}/*"
           ]
       }
    ]

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -24,6 +24,17 @@ resource "aws_s3_bucket" "scpca_portal_cert_bucket" {
   acl = "private"
   force_destroy = var.stage == "prod" ? false : true
 
+  lifecycle_rule {
+    id = "auto-delete-after-30-days-${var.user}-${var.stage}"
+    prefix = ""
+    enabled = true
+    abort_incomplete_multipart_upload_days = 1
+
+    expiration {
+      days = 30
+    }
+  }
+
   tags = merge(
     var.default_tags,
     {

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -18,3 +18,24 @@ resource "aws_s3_bucket_public_access_block" "scpca_portal_bucket" {
   block_public_acls   = true
   block_public_policy = true
 }
+
+resource "aws_s3_bucket" "scpca_portal_cert_bucket" {
+  bucket = "scpca-portal-cert-${var.user}-${var.stage}"
+  acl = "private"
+  force_destroy = var.stage == "prod" ? false : true
+
+  tags = merge(
+    var.default_tags,
+    {
+      Name = "scpca-portal-cert-${var.user}-${var.stage}"
+      Environment = var.stage
+    }
+  )
+}
+
+resource "aws_s3_bucket_public_access_block" "scpca_portal_cert_bucket" {
+  bucket = aws_s3_bucket.scpca_portal_cert_bucket.id
+
+  block_public_acls   = true
+  block_public_policy = true
+}


### PR DESCRIPTION
## Issue Number

I think there is one somewhere but I can't find it.

## Purpose/Implementation Notes

This will store our SSL certs into S3 when they're created with an expiration of 30 days. If they haven't expired yet, then they'll be used instead of making new ones.

This way we won't hit certbot limits.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I've tested these things as best as I can by looking at the prod API instance and testing on a dev one, but I can't test it for real until at least staging.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

This is from a test object I uploaded to the bucket
![image](https://user-images.githubusercontent.com/4026833/142694433-71c1a249-f2b7-48ff-9f64-56dfa84be1b3.png)
