### PR TITLE
Install zip command on API server

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -17,7 +17,7 @@ cat <<"EOF" > nginx.conf
 ${nginx_config}
 EOF
 apt-get update -y
-apt-get install nginx awscli -y
+apt-get install nginx awscli zip -y
 cp nginx.conf /etc/nginx/nginx.conf
 service nginx restart
 


### PR DESCRIPTION
## Issue Number

#109 

## Purpose/Implementation Notes

It failed because it didn't have `zip`!
