### PR TITLE
Add description of bulk files to README template

### DIFF
--- a/api/scpca_portal/config/readme_template.md
+++ b/api/scpca_portal/config/readme_template.md
@@ -19,9 +19,9 @@ Also included in each download is a `single_cell_metadata.tsv`, a comma-separate
 
 Gene expression files, available as RDS files containing a `SingleCellExperiment` object, house the expression data, cell and gene metrics, associated metadata, and in the case of multi-modal data like CITE-seq, data from the additional cell-based assays (see [Single-cell gene expression file contents](https://scpca.readthedocs.io/en/latest/sce_file_contents.html) for more information).
 
-If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download. 
+If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download.
 The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
-The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data. 
+The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
 
 See the [Downloadable files](https://scpca.readthedocs.io/en/latest/download_files.html) section in our documentation for more detailed information on files included in the download.
 

--- a/api/scpca_portal/config/readme_template.md
+++ b/api/scpca_portal/config/readme_template.md
@@ -13,12 +13,15 @@ See the [FAQ section about samples and libraries](https://scpca.readthedocs.io/e
 The files associated with each library are (example shown for a library with ID `SCPCL000000`):
 - An unfiltered counts file: `SCPCL000000_unfiltered.rds`,
 - A filtered counts file: `SCPCL000000_filtered.rds`,
-- A quality control report: `SCPCL000000_qc.html`,
-- A metadata file: `SCPCL000000_metadata.json`.
+- A quality control report: `SCPCL000000_qc.html`
 
-Also included in each download is a `libraries_metadata.csv`, a comma-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.
+Also included in each download is a `single_cell_metadata.tsv`, a comma-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.
 
 Gene expression files, available as RDS files containing a `SingleCellExperiment` object, house the expression data, cell and gene metrics, associated metadata, and in the case of multi-modal data like CITE-seq, data from the additional cell-based assays (see [Single-cell gene expression file contents](https://scpca.readthedocs.io/en/latest/sce_file_contents.html) for more information).
+
+If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download. 
+The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
+The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data. 
 
 See the [Downloadable files](https://scpca.readthedocs.io/en/latest/download_files.html) section in our documentation for more detailed information on files included in the download.
 


### PR DESCRIPTION
## Issue Number
Closes #144 

## Purpose/Implementation Notes
Here I'm adding the description of the files that are included in a download if a project has bulk RNA-seq. I just took the sentences that describe what the files are from the download files section of the docs, since here we are only describing the contents of the download. I didn't think there was anything else to expand on other than listing the two files, what they contain, and then we have the link to the download section of the docs. 

I also removed the `metadata.json` from the list of files included in the single cell download since we do not include that file anymore and updated the name for the `single_cell_metadata.tsv` file. 


