### PR TITLE
add new parameter group

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -1,8 +1,33 @@
 # This terraform file hosts the resources directly related to the
 # postgres RDS instance.
 
+# to remove after upgrade to postgres 12.5 is complete
 resource "aws_db_parameter_group" "postgres_parameters" {
   name = "scpca-portal-postgres-parameters-${var.user}-${var.stage}"
+  description = "Postgres Parameters ${var.user} ${var.stage}"
+  family = "postgres9.6"
+
+  parameter {
+    name = "deadlock_timeout"
+    value = "60000" # 60000ms = 60s
+  }
+
+  parameter {
+    name = "statement_timeout"
+    value = "60000" # 60000ms = 60s
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.default_tags
+}
+
+# use family to distinguish between major versions
+# this is useful for upgrades
+resource "aws_db_parameter_group" "postgres12_parameters" {
+  name = "scpca-portal-postgres12-parameters-${var.user}-${var.stage}"
   description = "Postgres Parameters ${var.user} ${var.stage}"
   family = "postgres12"
 
@@ -28,7 +53,7 @@ resource "aws_db_instance" "postgres_db" {
   allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
-  engine_version = "12.10"
+  engine_version = "12.5"
   auto_minor_version_upgrade = false
   instance_class = var.database_instance_type
   name = "scpca_portal"
@@ -37,7 +62,7 @@ resource "aws_db_instance" "postgres_db" {
   password = var.database_password
 
   db_subnet_group_name = aws_db_subnet_group.scpca_portal.name
-  parameter_group_name = aws_db_parameter_group.postgres_parameters.name
+  parameter_group_name = aws_db_parameter_group.postgres12_parameters.name
 
   # TF is broken, but we do want this protection in prod.
   # Related: https://github.com/hashicorp/terraform/issues/5417


### PR DESCRIPTION
## Issue Number

#138 

## Purpose/Implementation Notes

Adds a new parameter group because the lifecycle create_before_destroy does not seem to create before destroying.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
