### PR TITLE
allow major version upgrade

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -27,6 +27,10 @@ resource "aws_db_instance" "postgres_db" {
   identifier = "scpca-portal-${var.user}-${var.stage}"
   allocated_storage = 100
   storage_type = "gp2"
+  # start temp upgrade options
+  allow_major_version_upgrade = true
+  apply_immediately = true
+  # end temp upgrade options
   engine = "postgres"
   engine_version = "12.10"
   auto_minor_version_upgrade = false


### PR DESCRIPTION
## Issue Number

#138 

## Purpose/Implementation Notes

Temporarily sets `allow_major_upgrade_version` to `true` also adds `apply_immediately` which will cause some downtime.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
