### PR TITLE
add download initial sorting fuctionality

### DIFF
--- a/client/src/components/ProjectSamplesTable.js
+++ b/client/src/components/ProjectSamplesTable.js
@@ -33,9 +33,11 @@ export const ProjectSamplesTable = ({
             <Text>{formatBytes(row.original.computed_file.size_in_bytes)}</Text>
           </Box>
         ) : (
-          'N/A'
-        ),
-      disableSortBy: true
+          <Box>
+            <Text>Not Available</Text>
+            <Text>For Download</Text>
+          </Box>
+        )
     },
     { Header: 'Sample ID', accessor: 'scpca_id' },
     {
@@ -69,7 +71,10 @@ export const ProjectSamplesTable = ({
         limit: 1000 // TODO:: 'all' option
       })
       if (samplesRequest.isOk) {
-        setSamples(samplesRequest.response.results)
+        const sortedSamples = samplesRequest.response.results.sort((a) =>
+          a.computed_file && a.computed_file.id ? -1 : 1
+        )
+        setSamples(sortedSamples)
         setLoaded(true)
       }
     }


### PR DESCRIPTION
## Issue Number
Related issue: #163 

## Purpose/Implementation Notes

* sample table: default sort order by (is downloadable / has computed_file)
* samples table: no download icon -> “Not Available \n For Download”


## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist


- [ x] Lint and unit tests pass locally with my changes

## Screenshots

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/31800566/158906353-16e2621a-fd64-402a-8de0-10d6bc78ed99.png">
