### PR TITLE
sort samples if not all downloadable

### DIFF
--- a/client/src/components/ProjectSamplesTable.js
+++ b/client/src/components/ProjectSamplesTable.js
@@ -71,9 +71,13 @@ export const ProjectSamplesTable = ({
         limit: 1000 // TODO:: 'all' option
       })
       if (samplesRequest.isOk) {
-        const sortedSamples = samplesRequest.response.results.sort((a) =>
-          a.computed_file && a.computed_file.id ? -1 : 1
-        )
+        // if not all samples are downloadable show downloadable first
+        const sortedSamples =
+          project.sample_count !== project.downloadable_sample_count
+            ? samplesRequest.response.results.sort((a) =>
+                a.computed_file && a.computed_file.id ? -1 : 1
+              )
+            : samplesRequest.response.results
         setSamples(sortedSamples)
         setLoaded(true)
       }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

* Adds a check to only sort initial downloads when there are more samples than downloadable samples

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
