### PR TITLE
178 replace script tags with Script Wrapper Component

### DIFF
--- a/client/src/pages/_document.js
+++ b/client/src/pages/_document.js
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import Script from 'next/script'
 import React from 'react'
 import { ServerStyleSheet } from 'styled-components'
 
@@ -26,18 +27,19 @@ export default class MyDocument extends Document {
             rel="stylesheet"
           />
           {/* Google Analytics */}
-          <script
-            async
+          <Script
             src="https://www.googletagmanager.com/gtag/js?id=G-BYH3X5WS0V"
+            strategy="afterInteractive"
           />
           {/* Hotjar */}
-          <script
+          <Script
             async
             //  eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html:
                 "(function(h,o,t,j,a,r){h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};h._hjSettings={hjid:2569460,hjsv:6};a=o.getElementsByTagName('head')[0];r=o.createElement('script');r.async=1;r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;a.appendChild(r);})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');"
             }}
+            strategy="afterInteractive"
           />
           {this.props.styleTags}
         </Head>


### PR DESCRIPTION
## Issue Number

#178 

## Purpose/Implementation Notes
* Replaced the native HTML element <script> tags with Next.js built-in <Script /> Component(for ga/hotjar).

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests
List out the functional tests you've completed to verify your changes work locally.

## Checklist
- [x ] Lint and unit tests pass locally with my changes
