### PR TITLE
Add spatial readme template

### DIFF
--- a/api/scpca_portal/config/spatial_readme_template.md
+++ b/api/scpca_portal/config/spatial_readme_template.md
@@ -9,20 +9,20 @@ This download includes gene expression data from libraries processed using spati
 Each sample folder (indicated by the `SCPCS` prefix) contains the files for all spatial transcriptomics libraries (`SCPCL` prefix) derived from that biological sample.
 See the [FAQ section about samples and libraries](https://scpca.readthedocs.io/en/latest/faq.html#what-is-the-difference-between-samples-and-libraries) for more information.
 
-For all spatial transcriptomics libraries, a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder in the download. 
-Inside that folder will be the following folders and files: 
+For all spatial transcriptomics libraries, a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder in the download.
+Inside that folder will be the following folders and files:
 
 - A `raw_feature_bc_matrix` folder containing the [unfiltered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
 - A `filtered_feature_bc_matrix` folder containing the [filtered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
 - A `spatial` folder containing [images and position information](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/images)
 - A `SCPCL000000_spaceranger_summary.html` file containing the [summary html report provided by Space Ranger](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/summary)
-- A `SCPCL000000_metadata.json` file containing library processing information. 
+- A `SCPCL000000_metadata.json` file containing library processing information.
 
 Also included in each download is a `spatial_metadata.tsv`, a tab separated values table, with one row per library and columns containing pertinent metadata corresponding to that library.
 
 See the [Downloadable files](https://scpca.readthedocs.io/en/latest/download_files.html) section in our documentation for more detailed information on files included in the download.
 
-For more information on how the spatial libraries were processed, see the [Spatial Transcriptomics section in the Processing information](https://scpca.readthedocs.io/en/latest/processing_information.html#spatial-transcriptomics) page of the ScPCA Portal documentation. 
+For more information on how the spatial libraries were processed, see the [Spatial Transcriptomics section in the Processing information](https://scpca.readthedocs.io/en/latest/processing_information.html#spatial-transcriptomics) page of the ScPCA Portal documentation.
 
 ## Contact
 

--- a/api/scpca_portal/config/spatial_readme_template.md
+++ b/api/scpca_portal/config/spatial_readme_template.md
@@ -1,0 +1,37 @@
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes gene expression data from libraries processed using spatial transcriptomics and associated metadata for samples from project [{project_accession}]({project_url}) in the ScPCA portal.
+
+Each sample folder (indicated by the `SCPCS` prefix) contains the files for all spatial transcriptomics libraries (`SCPCL` prefix) derived from that biological sample.
+See the [FAQ section about samples and libraries](https://scpca.readthedocs.io/en/latest/faq.html#what-is-the-difference-between-samples-and-libraries) for more information.
+
+For all spatial transcriptomics libraries, a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder in the download. 
+Inside that folder will be the following folders and files: 
+
+- A `raw_feature_bc_matrix` folder containing the [unfiltered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
+- A `filtered_feature_bc_matrix` folder containing the [filtered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
+- A `spatial` folder containing [images and position information](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/images)
+- A `SCPCL000000_spaceranger_summary.html` file containing the [summary html report provided by Space Ranger](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/summary)
+- A `SCPCL000000_metadata.json` file containing library processing information. 
+
+Also included in each download is a `spatial_metadata.tsv`, a tab separated values table, with one row per library and columns containing pertinent metadata corresponding to that library.
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/latest/download_files.html) section in our documentation for more detailed information on files included in the download.
+
+For more information on how the spatial libraries were processed, see the [Spatial Transcriptomics section in the Processing information](https://scpca.readthedocs.io/en/latest/processing_information.html#spatial-transcriptomics) page of the ScPCA Portal documentation. 
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citing
+
+To cite data from {project_accession}, please see the citation information at [{project_accession} page.]({project_url})
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use.](https://scpca.alexslemonade.org/terms-of-use)

--- a/api/scpca_portal/config/spatial_readme_template.md
+++ b/api/scpca_portal/config/spatial_readme_template.md
@@ -6,11 +6,10 @@ The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a d
 
 This download includes gene expression data from libraries processed using spatial transcriptomics and associated metadata for samples from project [{project_accession}]({project_url}) in the ScPCA portal.
 
-Each sample folder (indicated by the `SCPCS` prefix) contains the files for all spatial transcriptomics libraries (`SCPCL` prefix) derived from that biological sample.
+For all spatial transcriptomics libraries (indicated by the `SCPCL` prefix) , a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder (`SCPCS` prefix) in the download.
 See the [FAQ section about samples and libraries](https://scpca.readthedocs.io/en/latest/faq.html#what-is-the-difference-between-samples-and-libraries) for more information.
 
-For all spatial transcriptomics libraries, a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder in the download.
-Inside that folder will be the following folders and files:
+Inside the `SCPCL000000_spatial` folder will be the following folders and files:
 
 - A `raw_feature_bc_matrix` folder containing the [unfiltered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
 - A `filtered_feature_bc_matrix` folder containing the [filtered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)


### PR DESCRIPTION
## Issue Number
Closes #204 

## Purpose/Implementation Notes
Here I have added in a new template readme that will specifically be for spatial downloads. I named the file `spatial_readme_template.md` and stored it in the same folder as the original `readme_template.md`. 

## Types of changes

For the most part I took what was in the original readme and copied that over, keeping the same introduction, contact, citing, and terms of use. The main difference between the spatial readme and the readme used for all other downloads is the contents section which now includes the contents of a spatial folder, rather than the single-cell gene expression contents. Here I mostly took what we have in the [spatial docs](https://github.com/AlexsLemonade/scpca-docs/blob/main/docs/download_files.md#spatial-transcriptomics-libraries), listing the contents of the spatial folder and then linking to the docs for more information. I also included a link to the processing information for spatial libraries as well.  

Some questions I have: 

- Is the file name and location okay? @davidsmejia @arkid15r 
- Are there any other contents that are missing related to spatial files that we should include? 


## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

