### PR TITLE
Staging API possible fix - out of index arguments list

### DIFF
--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -114,7 +114,7 @@ class Common(Configuration):
     DEBUG = strtobool(os.getenv("DJANGO_DEBUG", "no"))
 
     # Indicates running in test environment.
-    TEST = sys.argv[1] == "test"
+    TEST = len(sys.argv) > 1 and sys.argv[1] == "test"
 
     # Logging.
     LOGGING = {


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

The staging API wasn't able to load the python application via uwsgi. I went on to the server and while poking around stopped and restarted the container. Starting the container sent some error logs where I saw the out of index error. I don't think this would occur locally because of how we initialize the application (with arguments).

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
