### PR TITLE
Update project counts after samples import.

### DIFF
--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -70,7 +70,7 @@ class Sample(models.Model):
             subdiagnosis=data["subdiagnosis"],
             technologies=data.get("technologies", ""),
             tissue_location=data["tissue_location"],
-            treatment=data.get("treatment"),
+            treatment=data.get("treatment", ""),
         )
         sample.save()
 

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -29,6 +29,7 @@ class TestLoadData(TestCase):
         self.scpca_project_id = "SCPCP999999"
 
         self.expected_computed_file_count = 4
+        self.expected_downloadable_sample_count = 1
         self.expected_project_count = 1
         self.expected_sample_count = 1
         self.expected_summary_count = 4
@@ -89,6 +90,8 @@ class TestLoadData(TestCase):
         self.assertIsNotNone(sample.spatial_computed_file)
         self.assertGreater(sample.spatial_computed_file.size_in_bytes, 0)
         self.assertEqual(ComputedFile.objects.count(), self.expected_computed_file_count)
+
+        self.assertEqual(project.downloadable_sample_count, self.expected_downloadable_sample_count)
 
         return (
             project,

--- a/api/scpca_portal/test/views/test_filter_options.py
+++ b/api/scpca_portal/test/views/test_filter_options.py
@@ -9,12 +9,13 @@ class FilterOptionsTestCase(APITestCase):
     """Tests /project-options/ endpoint."""
 
     def setUp(self):
-        SampleFactory(
+        sample = SampleFactory(
             diagnosis="different",
             project=ProjectFactory(),
             seq_units="cell, bulk",
             technologies="10Xv4, 10Xv5",
         )
+        sample.project.update_counts()
 
         # Create a project with no samples.
         LeafProjectFactory()

--- a/api/scpca_portal/test/views/test_project.py
+++ b/api/scpca_portal/test/views/test_project.py
@@ -10,6 +10,7 @@ class ProjectsTestCase(APITestCase):
 
     def setUp(self):
         self.project = ProjectFactory()
+        self.project.update_counts()
 
     def test_get_single(self):
         url = reverse("projects-detail", args=[self.project.scpca_id])


### PR DESCRIPTION
## Issue Number

#219 

## Purpose/Implementation Notes
The counts mismatch is caused by the order of computed file instance / sample instance are creation (update counts is tied to sample creation). In order to fix this the project counts update process should be invoked after the computed file is created. 

Moreover, I don't see any reason why we need to update project counts every time we import a sample. It seems sufficient to run it once after the entire project is imported.

## Types of changes

What types of changes does your code introduce?
- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

