### PR TITLE
Fix Storybook after upgrading deps

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -14,12 +14,9 @@ module.exports = {
     config.resolve.modules.push(path.resolve(__dirname, './../src'))
 
     // Add env vars for helpers
-    const plugin = config.plugins.find(
-      (plugin) => plugin.definitions?.['process.env']
-    )
-
     Object.keys(envVars).forEach((key) => {
-      plugin.definitions['process.env'][key] = JSON.stringify(envVars[key])
+      config.plugins.DefinePlugin.definitions[`process.env.${key}`] =
+        JSON.stringify(envVars[key])
     })
 
     return config

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "babel-plugin-inline-react-svg": "^2.0.1",
     "babel-preset-airbnb": "^5.0.0",
     "babel-preset-next": "^1.4.0",
+    "dotenv-webpack": "^7.1.0",
     "eslint": "^8.13.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-next": "11.1.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4833,12 +4833,26 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
 dotenv-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
-dotenv@^8.0.0:
+dotenv-webpack@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-7.1.0.tgz#211fefac6bf500bf3bb66b286e1b12a23a2a70c0"
+  integrity sha512-+aUOe+nqgLerA/n611oyC15fY79BIkGm2fOxJAcHDonMZ7AtDpnzv/Oe591eHAenIE0t6w03UyxDnLs/YUxx5Q==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
+dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Storybook wasn't able to build due to the latest upgrade to the environment plugin changing.

* adds dotenv-webpack to dev requirements
* fixes how env vars are assigned to the env

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

loaded up storybook locally

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
