### PR TITLE
Add `skip-input-bucket-sync` flag.

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -133,6 +133,12 @@ For a specific sample update use --scpca-sample-ids flag (accepts multiple value
 sportal load-data --scpca-sample-ids SCPCS000001
 ```
 
+If you don't want the data to be re-synced from the input bucket use --skip-input-bucket-sync flag:
+
+```
+sportal load-data --scpca-sample-ids SCPCS000001 --skip-input-bucket-sync
+```
+
 If you would like to purge a project and remove its files from the S3 bucket, you can use:
 
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -133,10 +133,10 @@ For a specific sample update use --scpca-sample-ids flag (accepts multiple value
 sportal load-data --scpca-sample-ids SCPCS000001
 ```
 
-If you don't want the data to be re-synced from the input bucket use --skip-input-bucket-sync flag:
+If you don't want the data to be re-synced from the input bucket use --skip-sync flag:
 
 ```
-sportal load-data --scpca-sample-ids SCPCS000001 --skip-input-bucket-sync
+sportal load-data --scpca-sample-ids SCPCS000001 --skip-sync
 ```
 
 If you would like to purge a project and remove its files from the S3 bucket, you can use:

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
         parser.add_argument("--reload-existing", action="store_true")
         parser.add_argument("--scpca-project-ids", action="extend", nargs="+", type=str)
         parser.add_argument("--scpca-sample-ids", action="extend", nargs="+", type=str)
-        parser.add_argument("--skip-input-bucket-sync", action="store_true", default=False)
+        parser.add_argument("--skip-sync", action="store_true", default=False)
         parser.add_argument("--update-s3", action="store_true", default=settings.UPDATE_S3_DATA)
 
     def handle(self, *args, **options):
@@ -71,7 +71,7 @@ class Command(BaseCommand):
             options["reload_existing"],
             options["scpca_project_ids"],
             options["scpca_sample_ids"],
-            skip_input_bucket_sync=options["skip_input_bucket_sync"],
+            skip_input_bucket_sync=options["skip_sync"],
         )
         cleanup_output_data_dir()
 

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -61,6 +61,7 @@ class Command(BaseCommand):
         parser.add_argument("--reload-existing", action="store_true")
         parser.add_argument("--scpca-project-ids", action="extend", nargs="+", type=str)
         parser.add_argument("--scpca-sample-ids", action="extend", nargs="+", type=str)
+        parser.add_argument("--skip-input-bucket-sync", action="store_true", default=False)
         parser.add_argument("--update-s3", action="store_true", default=settings.UPDATE_S3_DATA)
 
     def handle(self, *args, **options):
@@ -70,6 +71,7 @@ class Command(BaseCommand):
             options["reload_existing"],
             options["scpca_project_ids"],
             options["scpca_sample_ids"],
+            skip_input_bucket_sync=options["skip_input_bucket_sync"],
         )
         cleanup_output_data_dir()
 
@@ -89,6 +91,7 @@ def load_data_from_s3(
     scpca_sample_ids=None,
     allowed_submitters=ALLOWED_SUBMITTERS,
     input_bucket_name="scpca-portal-inputs",
+    skip_input_bucket_sync=False,
 ):
     """Loads data from S3. Creates projects and loads data for them."""
 
@@ -105,17 +108,18 @@ def load_data_from_s3(
     shutil.rmtree(common.OUTPUT_DATA_DIR, ignore_errors=True)
     os.mkdir(common.OUTPUT_DATA_DIR)
 
-    command_list = [
-        "aws",
-        "s3",
-        "sync",
-        "--delete",
-        f"s3://{input_bucket_name}",
-        common.INPUT_DATA_DIR,
-    ]
-    if "public-test" in input_bucket_name:
-        command_list.append("--no-sign-request")
-    subprocess.check_call(command_list)
+    if not skip_input_bucket_sync:
+        command_list = [
+            "aws",
+            "s3",
+            "sync",
+            "--delete",
+            f"s3://{input_bucket_name}",
+            common.INPUT_DATA_DIR,
+        ]
+        if "public-test" in input_bucket_name:
+            command_list.append("--no-sign-request")
+        subprocess.check_call(command_list)
 
     with open(Project.get_input_project_metadata_file_path()) as project_csv:
         project_list = list(csv.DictReader(project_csv))


### PR DESCRIPTION
Add a flag to skip input bucket data sync when it's not needed.

- New feature (non-breaking change which adds functionality)
- [x] Lint and unit tests pass locally with my changes