### PR TITLE
Update link in spatial readme to link directly to spatial download section

### DIFF
--- a/api/scpca_portal/templates/readme_spatial.md
+++ b/api/scpca_portal/templates/readme_spatial.md
@@ -19,7 +19,7 @@ Inside the `SCPCL000000_spatial` folder will be the following folders and files:
 
 Also included in each download is a `spatial_metadata.tsv`, a tab separated values table, with one row per library and columns containing pertinent metadata corresponding to that library.
 
-See the [Downloadable files](https://scpca.readthedocs.io/en/latest/download_files.html) section in our documentation for more detailed information on files included in the download.
+See the [Downloadable files](https://scpca.readthedocs.io/en/latest/download_files.html#spatial-transcriptomics-libraries) section in our documentation for more detailed information on files included in the download for spatial transcriptomics libraries.
 
 For more information on how the spatial libraries were processed, see the [Spatial Transcriptomics section in the Processing information](https://scpca.readthedocs.io/en/latest/processing_information.html#spatial-transcriptomics) page of the ScPCA Portal documentation.
 


### PR DESCRIPTION
## Issue Number
Closes #208 

## Purpose/Implementation Notes
When creating the spatial readme template, the docs weren't building properly so we had put a link to the download section, but could not include a link directly to the section that describes the spatial downloads.

## Types of changes

Here, I updated the link to go specifically to the spatial section of the download rather than the top of the download files page. 

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)
