### PR TITLE
Fix Apple M1 Docker image build error.

### DIFF
--- a/api/Dockerfile.local
+++ b/api/Dockerfile.local
@@ -2,7 +2,7 @@
 # This is useful for local development, because as the files are changed the server
 # can detect that and use the newer code without being restarted.
 
-FROM python:3.8
+FROM --platform=linux/amd64 python:3.8
 ENV PYTHONUNBUFFERED 1
 
 RUN groupadd user && useradd --create-home --home-dir /home/user -g user user


### PR DESCRIPTION
## Purpose/Implementation Notes

Make ScPCA portal unit test running successfully.

The

`test_load_data_from_s3 (scpca_portal.test.management.commands.test_load_data.TestLoadData) ... qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
ERROR`

was causing 

`subprocess.CalledProcessError: Command '['aws', 's3', 'sync', '--delete', 's3://scpca-portal-public-test-inputs', '/home/user/code/test_data/input', '--no-sign-request']' returned non-zero exit status 255.`

error on ARM machine.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
