### PR TITLE
261 - Fix the invalid input in setup-python action(pre-commit workflow)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python: '3.8'
+          python-version: '3.8'
       - uses: pre-commit/action@v2.0.0
 
 


### PR DESCRIPTION
## Issue Number
#261 

## Purpose/Implementation Notes
Fixed the invalid input in setup-python action(pre-commit workflow) to remove the warning during the build process.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
