### PR TITLE
Move Nginx logs to `/var/log/nginx` to avoid permission denied error.

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -79,13 +79,13 @@ cat <<EOF >awslogs.conf
 [general]
 state_file = /var/lib/awslogs/agent-state
 
-[/tmp/error.log]
-file = /tmp/error.log
+[/var/log/nginx/error.log]
+file = /var/log/nginx/error.log
 log_group_name = ${log_group}
 log_stream_name = log-stream-api-nginx-error-${user}-${stage}
 
-[/tmp/access.log]
-file = /tmp/access.log
+[/var/log/nginx/access.log]
+file = /var/log/nginx/access.log
 log_group_name = ${log_group}
 log_stream_name = log-stream-api-nginx-access-${user}-${stage}
 
@@ -96,7 +96,7 @@ wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setu
 python3 ./awslogs-agent-setup.py --region ${region} --non-interactive --configfile awslogs.conf
 # Rotate the logs, delete after 3 days.
 echo "
-/tmp/error.log {
+/var/log/nginx/error.log {
     missingok
     notifempty
     compress
@@ -105,7 +105,7 @@ echo "
     maxage 3
 }" >> /etc/logrotate.conf
 echo "
-/tmp/access.log {
+/var/log/nginx/access.log {
     missingok
     notifempty
     compress

--- a/infrastructure/api-configuration/nginx_config.conf
+++ b/infrastructure/api-configuration/nginx_config.conf
@@ -1,10 +1,10 @@
-worker_processes  auto;
+worker_processes auto;
 
-error_log  /tmp/error.log  error;
+error_log /var/log/nginx/error.log error;
 
 events {
     # Set this to ulimit -n
-    worker_connections  1024;
+    worker_connections 1024;
 
     # If we need more perf, check this out:
     # https://www.revsys.com/12days/nginx-tuning/
@@ -13,41 +13,41 @@ events {
 }
 
 http {
-    include       mime.types;
-    default_type  application/octet-stream;
+    include mime.types;
+    default_type application/octet-stream;
     client_header_buffer_size 64k;
     large_client_header_buffers 4 64k;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /tmp/access.log  main;
+    access_log /var/log/nginx/access.log main;
 
-    sendfile        on;
+    sendfile on;
     client_body_timeout 12;
     client_header_timeout 12;
     keepalive_timeout 15;
     send_timeout 10;
 
-    gzip             on;
-    gzip_comp_level  2;
-    gzip_min_length  1000;
-    gzip_proxied     expired no-cache no-store private auth;
-    gzip_types       text/plain application/x-javascript text/xml text/css application/xml application/json text/html;
+    gzip on;
+    gzip_comp_level 2;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain application/x-javascript text/xml text/css application/xml application/json text/html;
 
     # Configuration containing list of application servers
-    upstream app{
+    upstream app {
         server 127.0.0.1:8081;
     }
 
     server {
-        listen       80 default_server;
-        server_name  localhost;
+        listen 80 default_server;
+        server_name localhost;
 
         location /static {
             autoindex on;
-            alias /tmp/volumes_static/;
+            alias /var/www/volumes_static;
         }
 
         location / {
@@ -61,6 +61,4 @@ http {
             proxy_send_timeout 30s;
         }
     }
-
-    include servers/*;
 }

--- a/infrastructure/api-configuration/start_api_with_migrations.tpl.sh
+++ b/infrastructure/api-configuration/start_api_with_migrations.tpl.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-chown -R ubuntu /home/ubuntu
+chown -R ubuntu:ubuntu /home/ubuntu
 
-STATIC_VOLUMES=/tmp/volumes_static
-mkdir -p /tmp/volumes_static
-chmod a+rwx /tmp/volumes_static
+STATIC_VOLUMES=/var/www/volumes_static
+mkdir -p "$STATIC_VOLUMES"
+chown -R ubuntu:ubuntu "$STATIC_VOLUMES"
 
 # Pull the API image.
 api_docker_image=${dockerhub_repo}/scpca_portal_api:latest
@@ -12,26 +12,29 @@ docker pull $api_docker_image
 
 # Migrate first.
 docker run \
-       --env-file environment \
-       -v "$STATIC_VOLUMES":/tmp/www/static \
-       --log-driver=awslogs \
-       --log-opt awslogs-region=${region} \
-       --log-opt awslogs-group=${log_group} \
-       --log-opt awslogs-stream=${log_stream} \
-       -p 8081:8081 \
-       --name=scpca_portal_migrations \
-       $api_docker_image python3 manage.py migrate
+    --env-file environment \
+    --log-driver=awslogs \
+    --log-opt awslogs-region=${region} \
+    --log-opt awslogs-group=${log_group} \
+    --log-opt awslogs-stream=${log_stream} \
+    --name=scpca_portal_migrations \
+    --platform linux/amd64 \
+    $api_docker_image python3 manage.py migrate
 
 # Start the API image.
 docker run \
-       --env-file environment \
-       -v "$STATIC_VOLUMES":/tmp/www/static \
-       --log-driver=awslogs \
-       --log-opt awslogs-region=${region} \
-       --log-opt awslogs-group=${log_group} \
-       --log-opt awslogs-stream=${log_stream} \
-       -p 8081:8081 \
-       --name=scpca_portal_api \
-       -d $api_docker_image
+    --env-file environment \
+    --log-driver=awslogs \
+    --log-opt awslogs-region=${region} \
+    --log-opt awslogs-group=${log_group} \
+    --log-opt awslogs-stream=${log_stream} \
+    --name=scpca_portal_api \
+    --platform linux/amd64 \
+    --restart unless-stopped \
+    -d \
+    -p 8081:8081 \
+    -v "$STATIC_VOLUMES":/tmp/www/static \
+    $api_docker_image
 
+# Collect static.
 docker exec scpca_portal_api python3 manage.py collectstatic --noinput


### PR DESCRIPTION
Summary of significant changes:
  - Move Django static volume to `/var/www`.
  - Reformat Nginx config files (auto).
  - Remove unused includes from Nginx config.
  - Remove unused options from API migration container run command. 
  - Add `--platform` and `--restart` options to API docker container run command.

## Purpose/Implementation Notes
Fix the Nginx log writing permission denied issue.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests
Tested using dev deploy.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

