### PR TITLE
Include `_processed.rds` in template README files

### DIFF
--- a/api/scpca_portal/templates/readme.md
+++ b/api/scpca_portal/templates/readme.md
@@ -13,6 +13,7 @@ See the [FAQ section about samples and libraries](https://scpca.readthedocs.io/e
 The files associated with each library are (example shown for a library with ID `SCPCL000000`):
 - An unfiltered counts file: `SCPCL000000_unfiltered.rds`,
 - A filtered counts file: `SCPCL000000_filtered.rds`,
+- A processed counts file: `SCPCL000000_processed.rds`,
 - A quality control report: `SCPCL000000_qc.html`
 
 Also included in each download is a `single_cell_metadata.tsv`, a tab-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.

--- a/api/scpca_portal/templates/readme_multiplexed.md
+++ b/api/scpca_portal/templates/readme_multiplexed.md
@@ -14,6 +14,7 @@ See the FAQ sections about [samples and libraries](https://scpca.readthedocs.io/
 The files associated with each library are (example shown for a library with ID `SCPCL000000`):
 - An unfiltered counts file: `SCPCL000000_unfiltered.rds`,
 - A filtered counts file: `SCPCL000000_filtered.rds`,
+- A processed counts file: `SCPCL000000_processed.rds`,
 - A quality control report: `SCPCL000000_qc.html`
 
 Also included in each download is a `single_cell_metadata.tsv`, a tab-separated table, with one row per sample/library pair and columns containing pertinent metadata corresponding to that sample and library.


### PR DESCRIPTION
## Issue Number
Closes #326 

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Here I just added the `_processed.rds` file to the list of files that are included in the download for both the main readme and the multiplexed readme. I didn't expand too much since we direct users to the docs. 



## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules