### PR TITLE
339 - Update Frontend to support Publications + Contacts

### DIFF
--- a/client/src/components/ProjectPublicationsDetails.js
+++ b/client/src/components/ProjectPublicationsDetails.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Text } from 'grommet'
+import { Link } from 'components/Link'
+
+export const ProjectPublicationsDetail = ({ publications }) => (
+  <>
+    {publications.map((publication) => (
+      <Text key={publication.doi}>
+        {publication.citation.replace(publication.doi_url, '')}
+        <Link label={publication.doi_url} href={publication.doi_url} />
+      </Text>
+    ))}
+  </>
+)
+
+export default ProjectPublicationsDetail

--- a/client/src/components/ProjectSearchResult.js
+++ b/client/src/components/ProjectSearchResult.js
@@ -3,6 +3,7 @@ import { Box, Text } from 'grommet'
 import { Button } from 'components/Button'
 import { Link } from 'components/Link'
 import { ProjectHeader } from 'components/ProjectHeader'
+import { ProjectPublicationsDetail } from 'components/ProjectPublicationsDetails'
 
 export const ProjectSearchResult = ({ project }) => {
   const searchDetails = [
@@ -13,6 +14,15 @@ export const ProjectSearchResult = ({ project }) => {
     {
       title: 'Abstract',
       value: project.abstract
+    },
+    {
+      title: 'Publications',
+      value:
+        project.publications.length > 0 ? (
+          <ProjectPublicationsDetail publications={project.publications} />
+        ) : (
+          ''
+        )
     },
     {
       title: 'Additional Sample Metadata Fields',

--- a/client/src/helpers/getReadable.js
+++ b/client/src/helpers/getReadable.js
@@ -1,22 +1,19 @@
 export const readableNames = {
   abstract: 'Abstract',
-  pi_name: 'Primary Investigator',
-  human_readable_pi_name: 'Primary Investigator',
   computed_files: 'File',
-  samples: 'Samples',
-  summaries: 'Summaries',
-  title: 'Title',
-  contact: 'Contact',
-  contact_name: 'Contact Name',
-  contact_email: 'Contact Email',
-  has_bulk_rna_seq: 'Bulk RNA-Seq',
-  has_multiplexed_data: 'Multiplexed',
   disease_timings: 'Disease Timing',
   diagnoses: 'Diagnosis',
-  seq_units: 'Seq Units',
-  technologies: 'Technologies',
+  has_bulk_rna_seq: 'Bulk RNA-Seq',
+  has_multiplexed_data: 'Multiplexed',
+  human_readable_pi_name: 'Primary Investigator',
+  modalities: 'Modalities',
+  pi_name: 'Primary Investigator',
+  samples: 'Samples',
   sample_count: 'Sample Count',
-  modalities: 'Modalities'
+  seq_units: 'Seq Units',
+  summaries: 'Summaries',
+  technologies: 'Technologies',
+  title: 'Title'
 }
 
 export const getReadable = (key) => readableNames[key] || key

--- a/client/src/pages/projects/[scpca_id].js
+++ b/client/src/pages/projects/[scpca_id].js
@@ -3,6 +3,7 @@ import { Box, Tabs, Tab, Text } from 'grommet'
 import { useRouter } from 'next/router'
 import { ProjectHeader } from 'components/ProjectHeader'
 import { DetailsTable } from 'components/DetailsTable'
+import { ProjectPublicationsDetail } from 'components/ProjectPublicationsDetails'
 import { ProjectSamplesTable } from 'components/ProjectSamplesTable'
 import { ProjectSamplesSummaryTable } from 'components/ProjectSamplesSummaryTable'
 import { Link } from 'components/Link'
@@ -31,6 +32,34 @@ const Project = ({ project }) => {
                   data={project}
                   order={[
                     'abstract',
+                    {
+                      label: 'Publications',
+                      value:
+                        project.publications.length > 0 ? (
+                          <ProjectPublicationsDetail
+                            publications={project.publications}
+                          />
+                        ) : (
+                          ''
+                        )
+                    },
+                    {
+                      label: 'DOI',
+                      value:
+                        project.publications.length > 0 ? (
+                          <Text>
+                            {project.publications.map((publication) => (
+                              <Link
+                                key={publication.doi}
+                                label={publication.doi}
+                                href={publication.doi_url}
+                              />
+                            ))}
+                          </Text>
+                        ) : (
+                          ''
+                        )
+                    },
                     'disease_timings',
                     'sample_count',
                     'human_readable_pi_name',

--- a/client/src/pages/projects/[scpca_id].js
+++ b/client/src/pages/projects/[scpca_id].js
@@ -17,6 +17,7 @@ const Project = ({ project }) => {
   const [activeIndex, setActiveIndex] = useState(showSamples ? 1 : 0)
   const onActive = (nextIndex) => setActiveIndex(nextIndex)
   const { responsive } = useResponsive()
+
   return (
     <>
       <PageTitle title={project.title} />
@@ -35,12 +36,23 @@ const Project = ({ project }) => {
                     'human_readable_pi_name',
                     {
                       label: 'Contact Information',
-                      value: (
-                        <Link
-                          label={`${project.contact_name} <${project.contact_email}>`}
-                          href={`mailto:${project.contact_email}`}
-                        />
-                      )
+                      value:
+                        project.contacts.length > 0 ? (
+                          <>
+                            {project.contacts.map((contact, i) => (
+                              <Text>
+                                {i ? ', ' : ''}
+                                <Link
+                                  key={contact.name}
+                                  label={`${contact.name} <${contact.email}>`}
+                                  href={`mailto:${contact.email}`}
+                                />
+                              </Text>
+                            ))}
+                          </>
+                        ) : (
+                          ''
+                        )
                     }
                   ]}
                 />


### PR DESCRIPTION
## Issue Number
#339 

## Purpose/Implementation Notes
> We will be adding new relationships to the Project model: Publications and Contacts and we want to show them on the Project page.

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

- Included the publications and supported multiple contacts in the project detail tab 
- Included the publications in the project search result card

**NOTE:** Please reference the **SCPCP000005**, thank you!

## Types of changes
<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots
The following updates were made based on the talk;
(in the project detail tab)
- "Publications"(plural)" section with its citation text and hyperlinked DOI string
- "DOI" section with the hyperlinked DOI url(is the same link location as above hyperlinked DOI string)
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/31800566/208949097-27bc5aea-c1f4-485b-b8a7-387dd843224d.png">


(in the search result card)
"Publications"(plural)" section with its citation text and hyperlinked DOI string 
<img width="750" alt="image" src="https://user-images.githubusercontent.com/31800566/208963224-1fabf0a7-4eb6-489e-b2c5-2d19847d2f92.png">



