### PR TITLE
Temp change to bump up available storage

### DIFF
--- a/infrastructure/api.tf
+++ b/infrastructure/api.tf
@@ -86,7 +86,7 @@ resource "aws_instance" "api_server_1" {
   # This should be approx x2 the size of the s3 data
   root_block_device {
     volume_type = "gp2"
-    volume_size = 100
+    volume_size = 300
     tags =  merge(
       var.default_tags,
       {


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

SCPCP000008 has at least 80gb of files that get processed, we had ~250 gigs of space when I tried to import the project last. I keep encountering no disk space available when trying to import them. I would assume that we would need ~3x storage capacity for this. (1x for originals : 1x for zip per sample : 1x for project zip).

This PR bumps the volume up to 300gb which after processing I will scale back down to ~100.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
