### PR TITLE
add OP prefix to SENTRY_DSN

### DIFF
--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -30,7 +30,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "${{ secrets.OP_AWS_SECRET_ACCESS_KEY }}"
           SSH_PRIVATE_KEY: "${{ secrets.OP_SSH_PRIVATE_KEY }}"
           SSH_PUBLIC_KEY: "${{ secrets.OP_SSH_PUBLIC_KEY }}"
-          SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
+          SENTRY_DSN: "${{ secrets.OP_SENTRY_DSN }}"
 
 
       - name: Setup Terraform

--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -30,7 +30,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "${{ secrets.OP_AWS_SECRET_ACCESS_KEY }}"
           SSH_PRIVATE_KEY: "${{ secrets.OP_SSH_PRIVATE_KEY }}"
           SSH_PUBLIC_KEY: "${{ secrets.OP_SSH_PUBLIC_KEY }}"
-          SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
+          SENTRY_DSN: "${{ secrets.OP_SENTRY_DSN }}"
 
 
       - name: Setup Terraform


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

- forgot to prefix OP when adding sentry_dsn to 1password secrets.this fixes that

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
