### PR TITLE
383 - Multiple publications are concatenated on the frontend

### DIFF
--- a/client/src/components/ProjectPublicationsDetail.js
+++ b/client/src/components/ProjectPublicationsDetail.js
@@ -1,14 +1,14 @@
 import React from 'react'
-import { Text } from 'grommet'
+import { Box, Text } from 'grommet'
 import { Link } from 'components/Link'
 
 export const ProjectPublicationsDetail = ({ publications }) => (
   <>
-    {publications.map((publication) => (
-      <Text key={publication.doi}>
-        {publication.citation.replace(publication.doi_url, '')}
+    {publications.map((publication, i) => (
+      <Box key={publication.doi} margin={{ top: i ? 'small' : 'none' }}>
+        <Text>{publication.citation.replace(publication.doi_url, '')}</Text>
         <Link label={publication.doi_url} href={publication.doi_url} />
-      </Text>
+      </Box>
     ))}
   </>
 )


### PR DESCRIPTION
## Issue Number

#383

## Purpose/Implementation Notes
> Both Publications and DOI can be displayed on separate lines.

Based on the above requirement, formatted the publications section. Please review the UI [here](https://scpca-portal-d0skj99qd-ccdl.vercel.app/projects?diagnoses=Retinoblastoma).

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x]  Lint and unit tests pass locally with my changes