### PR TITLE
Refresh the user token if expired

### DIFF
--- a/client/src/components/Download.js
+++ b/client/src/components/Download.js
@@ -19,7 +19,7 @@ import { isProjectID } from 'helpers/isProjectID'
 
 // Button and Modal to show when downloading
 export const Download = ({ icon, resource: initialResource }) => {
-  const { token, email, surveyListForm, createToken, validateToken } = useScPCAPortal()
+  const { token, email, surveyListForm, createToken } = useScPCAPortal()
   const { trackDownload } = useAnalytics()
   const [resource, setResource] = useState(initialResource)
   const [recommendedResource, setRecommendedResource] = useState(null)
@@ -108,7 +108,7 @@ export const Download = ({ icon, resource: initialResource }) => {
       } else {
         // NOTE: there isnt much we can do here to recover.
         console.error(
-          "An error occurred while trying to get the download url for:",
+          'An error occurred while trying to get the download url for:',
           publicComputedFile.id
         )
       }

--- a/client/src/components/Download.js
+++ b/client/src/components/Download.js
@@ -19,7 +19,7 @@ import { isProjectID } from 'helpers/isProjectID'
 
 // Button and Modal to show when downloading
 export const Download = ({ icon, resource: initialResource }) => {
-  const { token, email, surveyListForm } = useScPCAPortal()
+  const { token, email, surveyListForm, createToken, validateToken } = useScPCAPortal()
   const { trackDownload } = useAnalytics()
   const [resource, setResource] = useState(initialResource)
   const [recommendedResource, setRecommendedResource] = useState(null)
@@ -103,8 +103,14 @@ export const Download = ({ icon, resource: initialResource }) => {
         surveyListForm.submit({ email, scpca_last_download_date: formatDate() })
         window.open(downloadRequest.response.download_url)
         setDownload(downloadRequest.response)
+      } else if (downloadRequest.status === 403) {
+        await createToken()
       } else {
-        console.error('clear the token and go back to that view')
+        // NOTE: there isnt much we can do here to recover.
+        console.error(
+          "An error occurred while trying to get the download url for:",
+          publicComputedFile.id
+        )
       }
     }
 


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

- when trying to download, this will try to get a new token if the current one doesn't work

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

- recreated token locally when the [`403`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) error occurs on the client-side.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
