### PR TITLE
Remove redundant bulk data filter option

### DIFF
--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -22,7 +22,7 @@ class Sample(TimestampedModel):
         SPATIAL = "SPATIAL"
 
         NAME_MAPPING = {
-            BULK_RNA_SEQ: "Bulk",
+            BULK_RNA_SEQ: "Bulk RNA-seq",
             CITE_SEQ: "CITE-seq",
             MULTIPLEXED: "Multiplexed",
             SPATIAL: "Spatial Data",
@@ -112,12 +112,13 @@ class Sample(TimestampedModel):
             "has_spatial_data": Sample.Modalities.SPATIAL,
         }
 
-        modalities = list()
-        for attr_name, modality_name in attr_name_modality_mapping.items():
-            if getattr(self, attr_name):
-                modalities.append(Sample.Modalities.NAME_MAPPING[modality_name])
-
-        return sorted(modalities)
+        return sorted(
+            [
+                Sample.Modalities.NAME_MAPPING[modality_name]
+                for attr_name, modality_name in attr_name_modality_mapping.items()
+                if getattr(self, attr_name)
+            ]
+        )
 
     @property
     def computed_files(self):

--- a/client/src/components/ProjectSearchFilter.js
+++ b/client/src/components/ProjectSearchFilter.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { Box, Text, CheckBox } from 'grommet'
 import { Loader } from 'components/Loader'
 import { api } from 'api'
-import { getReadable } from 'helpers/getReadable'
 import { useAnalytics } from 'hooks/useAnalytics'
 
 export const ProjectSearchFilter = ({
@@ -101,16 +100,6 @@ export const ProjectSearchFilter = ({
                 onChange={() => toggleFilterOption(f, o)}
               />
             ))}
-            {f === 'modalities' && (
-              <>
-                <CheckBox
-                  label={getReadable('has_bulk_rna_seq')}
-                  value
-                  checked={hasFilterOption('has_bulk_rna_seq')}
-                  onChange={() => toggleFilterOption('has_bulk_rna_seq')}
-                />
-              </>
-            )}
           </Box>
         </Box>
       ))}

--- a/client/src/config/downloadOptions.js
+++ b/client/src/config/downloadOptions.js
@@ -13,7 +13,7 @@ export const downloadOptions = {
       texts: {},
       learn_more: {
         label: 'here',
-        text: 'Learn more about what you can expect in your download file ',
+        text: 'Learn more about what you can expect in your download file.',
         url: config.links.what_downloading_project
       }
     }
@@ -27,7 +27,7 @@ export const downloadOptions = {
       texts: {},
       learn_more: {
         label: 'here',
-        text: 'Learn more about what you can expect in your download file ',
+        text: 'Learn more about what you can expect in your download file.',
         url: config.links.what_downloading_spatial
       }
     }
@@ -64,7 +64,7 @@ export const downloadOptions = {
       texts: {},
       learn_more: {
         label: 'here',
-        text: 'Learn more about what you can expect in your download file ',
+        text: 'Learn more about what you can expect in your download file.',
         url: config.links.what_downloading_sample
       }
     }
@@ -78,7 +78,7 @@ export const downloadOptions = {
       texts: {},
       learn_more: {
         label: 'here',
-        text: 'Learn more about what you can expect in your download file ',
+        text: 'Learn more about what you can expect in your download file.',
         url: config.links.what_downloading_spatial
       }
     }
@@ -97,7 +97,7 @@ export const downloadOptions = {
       texts: {
         text_only: 'This is a multiplexed sample.',
         multiplexed_with: {
-          text: 'It has been multiplexed with the followig samples.'
+          text: 'It has been multiplexed with the following samples.'
         }
       },
       learn_more: {
@@ -106,7 +106,7 @@ export const downloadOptions = {
         url: config.links.what_downloading_mulitplexed
       },
       warning_text: {
-        text: 'If you are planning to work with more than one multiplexed sample, we reccommend downloading the entire project.'
+        text: 'If you are planning to work with more than one multiplexed sample, we recommend downloading the entire project.'
       }
     }
   }


### PR DESCRIPTION
## Issue Number

#424 

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Remove redundant bulk data filter option:
  - Rename backend label from "Bulk" to "Bulk RNA-seq"
  - Remove project search filter extra option (was causing the duplication)
  - Fix some typos

## Types of changes

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
<img width="239" alt="Screenshot 2023-08-31 at 8 58 27 AM" src="https://github.com/AlexsLemonade/scpca-portal/assets/2201626/d1cb9de5-5bc2-48de-8344-1af874785bf3">
