### PR TITLE
444- Increase Project title font size to 21px

### DIFF
--- a/client/src/components/ProjectHeader.js
+++ b/client/src/components/ProjectHeader.js
@@ -29,7 +29,7 @@ export const ProjectHeader = ({ project, linked = false }) => {
         <Box flex="shrink" pad={{ right: 'medium' }}>
           {linked ? (
             <Link href={`/projects/${project.scpca_id}`}>
-              <Text weight="bold" color="brand">
+              <Text weight="bold" color="brand" size="large">
                 {project.title}
               </Text>
             </Link>


### PR DESCRIPTION
## Issue Number
Closes #444

## Purpose/Implementation Notes

Based on the design update, increased the project title font size to 21px in the project card header.

@dvenprasad please review the latest UI [here](https://scpca-portal-git-nozomione-444-increase-project-tit-d5efbf-ccdl.vercel.app/projects).

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
