### PR TITLE
451 add citation information dates

### DIFF
--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -334,14 +334,15 @@ class ComputedFile(TimestampedModel):
         if self.s3_bucket and self.s3_key:
             # Append the download date to the filename on download.
             date = datetime.today().strftime(DATE_FORMAT)
-            filename = f"{self.s3_key}_{date}"
+            filename, extension = self.s3_key.split(".")
+            new_filename = f"{filename}_{date}.{extension}"
 
             return s3.generate_presigned_url(
                 ClientMethod="get_object",
                 Params={
                     "Bucket": self.s3_bucket,
                     "Key": self.s3_key,
-                    "ResponseContentDisposition": f"attachment; filename = {filename}",
+                    "ResponseContentDisposition": f"attachment; filename = {new_filename}",
                 },
                 ExpiresIn=(60 * 60 * 24 * 7),  # 7 days in seconds.
             )

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -101,8 +101,10 @@ class ComputedFile(TimestampedModel):
         )
 
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            readme = ComputedFile.get_readme_contents(ComputedFile.README_MULTIPLEXED_FILE_PATH)
-            zip_file.writestr(ComputedFile.README_MULTIPLEXED_FILE_NAME, readme)
+            zip_file.writestr(
+                ComputedFile.OUTPUT_README_FILE_NAME,
+                ComputedFile.get_readme_contents(ComputedFile.README_MULTIPLEXED_FILE_PATH),
+            )
             zip_file.write(
                 project.output_multiplexed_metadata_file_path, computed_file.metadata_file_name
             )
@@ -134,8 +136,10 @@ class ComputedFile(TimestampedModel):
         )
 
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            readme = ComputedFile.get_readme_contents(ComputedFile.README_FILE_PATH)
-            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
+            zip_file.writestr(
+                ComputedFile.OUTPUT_README_FILE_NAME,
+                ComputedFile.get_readme_contents(ComputedFile.README_FILE_PATH),
+            )
             zip_file.write(
                 project.output_single_cell_metadata_file_path, computed_file.metadata_file_name
             )
@@ -167,8 +171,10 @@ class ComputedFile(TimestampedModel):
         )
 
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            readme = ComputedFile.get_readme_contents(ComputedFile.README_SPATIAL_FILE_PATH)
-            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
+            zip_file.writestr(
+                ComputedFile.OUTPUT_README_FILE_NAME,
+                ComputedFile.get_readme_contents(ComputedFile.README_SPATIAL_FILE_PATH),
+            )
             zip_file.write(
                 project.output_spatial_metadata_file_path, computed_file.metadata_file_name
             )
@@ -209,8 +215,10 @@ class ComputedFile(TimestampedModel):
 
         if not os.path.exists(computed_file.zip_file_path):
             with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-                readme = ComputedFile.get_readme_contents(ComputedFile.README_MULTIPLEXED_FILE_PATH)
-                zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
+                zip_file.writestr(
+                    ComputedFile.OUTPUT_README_FILE_NAME,
+                    ComputedFile.get_readme_contents(ComputedFile.README_MULTIPLEXED_FILE_PATH),
+                )
                 zip_file.write(
                     sample.output_multiplexed_metadata_file_path,
                     ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME,
@@ -238,8 +246,10 @@ class ComputedFile(TimestampedModel):
 
         file_paths = []
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            readme = ComputedFile.get_readme_contents(ComputedFile.README_FILE_PATH)
-            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
+            zip_file.writestr(
+                ComputedFile.OUTPUT_README_FILE_NAME,
+                ComputedFile.get_readme_contents(ComputedFile.README_FILE_PATH),
+            )
             zip_file.write(
                 sample.output_single_cell_metadata_file_path,
                 ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME,
@@ -279,8 +289,10 @@ class ComputedFile(TimestampedModel):
 
         file_paths = []
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            readme = ComputedFile.get_readme_contents(ComputedFile.README_SPATIAL_FILE_PATH)
-            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
+            zip_file.writestr(
+                ComputedFile.OUTPUT_README_FILE_NAME,
+                ComputedFile.get_readme_contents(ComputedFile.README_SPATIAL_FILE_PATH),
+            )
             zip_file.write(
                 sample.output_spatial_metadata_file_path,
                 ComputedFile.MetadataFilenames.SPATIAL_METADATA_FILE_NAME,

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -167,8 +167,8 @@ class ComputedFile(TimestampedModel):
         )
 
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            spacial_readme = ComputedFile.get_readme_contents(ComputedFile.README_SPATIAL_FILE_PATH)
-            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, spacial_readme)
+            readme = ComputedFile.get_readme_contents(ComputedFile.README_SPATIAL_FILE_PATH)
+            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
             zip_file.write(
                 project.output_spatial_metadata_file_path, computed_file.metadata_file_name
             )

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -82,6 +82,13 @@ class ComputedFile(TimestampedModel):
         return f"Computed file for '{self.project or self.sample}'"
 
     @classmethod
+    def get_readme_contents(cls, readme: str) -> str:
+        with open(readme, "r") as readme_file:
+            date = datetime.today().strftime(DATE_FORMAT)
+            contents = f"Generated on: {date}\n\n{readme_file.read()}"
+            return contents
+
+    @classmethod
     def get_project_multiplexed_file(cls, project, sample_to_file_mapping, workflow_versions):
         """Prepares a ready for saving single data file of project's combined multiplexed data."""
 
@@ -94,9 +101,8 @@ class ComputedFile(TimestampedModel):
         )
 
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            zip_file.write(
-                ComputedFile.README_MULTIPLEXED_FILE_PATH, ComputedFile.OUTPUT_README_FILE_NAME
-            )
+            readme = ComputedFile.get_readme_contents(ComputedFile.README_MULTIPLEXED_FILE_PATH)
+            zip_file.writestr(ComputedFile.README_MULTIPLEXED_FILE_NAME, readme)
             zip_file.write(
                 project.output_multiplexed_metadata_file_path, computed_file.metadata_file_name
             )
@@ -128,7 +134,8 @@ class ComputedFile(TimestampedModel):
         )
 
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            zip_file.write(ComputedFile.README_FILE_PATH, ComputedFile.OUTPUT_README_FILE_NAME)
+            readme = ComputedFile.get_readme_contents(ComputedFile.README_FILE_PATH)
+            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
             zip_file.write(
                 project.output_single_cell_metadata_file_path, computed_file.metadata_file_name
             )
@@ -160,9 +167,8 @@ class ComputedFile(TimestampedModel):
         )
 
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            zip_file.write(
-                ComputedFile.README_SPATIAL_FILE_PATH, ComputedFile.OUTPUT_README_FILE_NAME
-            )
+            spacial_readme = ComputedFile.get_readme_contents(ComputedFile.README_SPATIAL_FILE_PATH)
+            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, spacial_readme)
             zip_file.write(
                 project.output_spatial_metadata_file_path, computed_file.metadata_file_name
             )
@@ -203,9 +209,8 @@ class ComputedFile(TimestampedModel):
 
         if not os.path.exists(computed_file.zip_file_path):
             with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-                zip_file.write(
-                    ComputedFile.README_MULTIPLEXED_FILE_PATH, ComputedFile.OUTPUT_README_FILE_NAME
-                )
+                readme = ComputedFile.get_readme_contents(ComputedFile.README_MULTIPLEXED_FILE_PATH)
+                zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
                 zip_file.write(
                     sample.output_multiplexed_metadata_file_path,
                     ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME,
@@ -233,7 +238,8 @@ class ComputedFile(TimestampedModel):
 
         file_paths = []
         with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-            zip_file.write(ComputedFile.README_FILE_PATH, ComputedFile.OUTPUT_README_FILE_NAME)
+            readme = ComputedFile.get_readme_contents(ComputedFile.README_FILE_PATH)
+            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
             zip_file.write(
                 sample.output_single_cell_metadata_file_path,
                 ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME,
@@ -272,11 +278,10 @@ class ComputedFile(TimestampedModel):
         )
 
         file_paths = []
-        with ZipFile(computed_file.zip_file_path, "w") as zip_object:
-            zip_object.write(
-                ComputedFile.README_SPATIAL_FILE_PATH, ComputedFile.OUTPUT_README_FILE_NAME
-            )
-            zip_object.write(
+        with ZipFile(computed_file.zip_file_path, "w") as zip_file:
+            readme = ComputedFile.get_readme_contents(ComputedFile.README_SPATIAL_FILE_PATH)
+            zip_file.writestr(ComputedFile.OUTPUT_README_FILE_NAME, readme)
+            zip_file.write(
                 sample.output_spatial_metadata_file_path,
                 ComputedFile.MetadataFilenames.SPATIAL_METADATA_FILE_NAME,
             )
@@ -289,7 +294,7 @@ class ComputedFile(TimestampedModel):
                     )
                 )
                 for item in library_path.rglob("*"):  # Add the entire directory contents.
-                    zip_object.write(item, item.relative_to(library_path.parent))
+                    zip_file.write(item, item.relative_to(library_path.parent))
                     file_paths.append(f"{Path(library_path, item.relative_to(library_path))}")
 
         computed_file.size_in_bytes = os.path.getsize(computed_file.zip_file_path)

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -1,4 +1,5 @@
 """Misc utils."""
+from datetime import datetime
 
 
 def boolean_from_string(value):
@@ -22,3 +23,8 @@ def join_workflow_versions(workflow_versions):
     """Returns list of sorted unique workflow versions."""
 
     return ", ".join(sorted(set(workflow_versions)))
+
+
+def get_today_string(format: str = "%Y-%M-%d"):
+    """Returns today's date formatted. Defaults to ISO 8601."""
+    return datetime.today().strftime(format)


### PR DESCRIPTION
## Issue Number

#451

## Purpose/Implementation Notes

We will be adding instructions to the readme for how to cite. Part of what will be added will reference the access date and generation date.

Access Date:
- When creating the download url for a computed file we append the download date to the file.
  - `SCPCP0000.zip` -> `SCPCP0000_2023-10-27.zip`

Generation Date:
- When loading data before writing a readme to a zip directory, we now prepend the generation date of the processed date to the top of the readme file.


## Comment for reviewer
I wasn't sure what would be a good way to test the download url, if you have any ideas I'd be interested to hear them.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

- Tested downloading a file with new name
- Tested loading data and inspected readme of project and sample downloads

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots

n/a
