### PR TITLE
Update utils::get_today_string format

### DIFF
--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -1,3 +1,6 @@
+from datetime import date
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from scpca_portal import utils
@@ -37,3 +40,10 @@ class TestJoinWorkflowVersions(TestCase):
     def test_join_single_item(self):
         items = ("single item",)
         self.assertEqual(utils.join_workflow_versions(items), items[0])
+
+
+class TestGetToday(TestCase):
+    @patch("scpca_portal.utils.datetime")
+    def test_format(self, mock_date):
+        mock_date.today.return_value = date(2022, 10, 8)
+        self.assertEqual(utils.get_today_string(), "2022-10-08")

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -25,6 +25,6 @@ def join_workflow_versions(workflow_versions):
     return ", ".join(sorted(set(workflow_versions)))
 
 
-def get_today_string(format: str = "%Y-%M-%d"):
+def get_today_string(format: str = "%Y-%m-%d"):
     """Returns today's date formatted. Defaults to ISO 8601."""
     return datetime.today().strftime(format)


### PR DESCRIPTION
## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Update utils::get_today_string format -- replace minute (M) with mont (m)

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules