### PR TITLE
add support for displaying external accessions

### DIFF
--- a/client/src/components/ProjectExternalAccessionsDetail.js
+++ b/client/src/components/ProjectExternalAccessionsDetail.js
@@ -8,7 +8,7 @@ export const ProjectExternalAccessionsDetail = ({ inline = false, externalAccess
   if (inline) {
     return externalAccessions.map(({ accession, url }, i) => (
       <React.Fragment key={accession}>
-        {i != 0 && ', '}
+        {i !== 0 && ', '}
         <Link label={accession} href={url} />
       </React.Fragment>
     ))

--- a/client/src/components/ProjectExternalAccessionsDetail.js
+++ b/client/src/components/ProjectExternalAccessionsDetail.js
@@ -2,7 +2,10 @@ import React from 'react'
 import { Box } from 'grommet'
 import { Link } from 'components/Link'
 
-export const ProjectExternalAccessionsDetail = ({ inline = false, externalAccessions }) => {
+export const ProjectExternalAccessionsDetail = ({
+  inline = false,
+  externalAccessions = []
+}) => {
 
   // Comma separated list.
   if (inline) {

--- a/client/src/components/ProjectExternalAccessionsDetail.js
+++ b/client/src/components/ProjectExternalAccessionsDetail.js
@@ -6,7 +6,6 @@ export const ProjectExternalAccessionsDetail = ({
   inline = false,
   externalAccessions = []
 }) => {
-
   // Comma separated list.
   if (inline) {
     return externalAccessions.map(({ accession, url }, i) => (

--- a/client/src/components/ProjectExternalAccessionsDetail.js
+++ b/client/src/components/ProjectExternalAccessionsDetail.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Box } from 'grommet'
+import { Link } from 'components/Link'
+
+export const ProjectExternalAccessionsDetail = ({ inline = false, externalAccessions }) => {
+
+  // Comma separated list.
+  if (inline) {
+    return externalAccessions.map(({ accession, url }, i) => (
+      <React.Fragment key={accession}>
+        {i != 0 && ', '}
+        <Link label={accession} href={url} />
+      </React.Fragment>
+    ))
+  }
+
+  // One external accession per line.
+  return externalAccessions.map(({ accession, url }, i) => (
+    <Box key={accession} margin={{ top: i ? 'small' : 'none' }}>
+      <Link label={accession} href={url} />
+    </Box>
+  ))
+}
+
+export default ProjectExternalAccessionsDetail

--- a/client/src/components/ProjectPublicationsDetail.js
+++ b/client/src/components/ProjectPublicationsDetail.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box, Text } from 'grommet'
 import { Link } from 'components/Link'
 
-export const ProjectPublicationsDetail = ({ publications }) => (
+export const ProjectPublicationsDetail = ({ publications = [] }) => (
   <>
     {publications.map((publication, i) => (
       <Box key={publication.doi} margin={{ top: i ? 'small' : 'none' }}>

--- a/client/src/components/ProjectSearchResult.js
+++ b/client/src/components/ProjectSearchResult.js
@@ -5,6 +5,7 @@ import { Link } from 'components/Link'
 import { ProjectHeader } from 'components/ProjectHeader'
 import { ProjectAbstractDetail } from 'components/ProjectAbstractDetail'
 import { ProjectPublicationsDetail } from 'components/ProjectPublicationsDetail'
+import { ProjectExternalAccessionsDetail } from 'components/ProjectExternalAccessionsDetail'
 
 export const ProjectSearchResult = ({ project }) => {
   const searchDetails = [
@@ -24,6 +25,14 @@ export const ProjectSearchResult = ({ project }) => {
         ) : (
           ''
         )
+    },
+    {
+      title: 'Also deposited under',
+      value: project.external_accessions.length > 0 ? (
+        <ProjectExternalAccessionsDetail inline externalAccessions={project.external_accessions} />
+      ) : (
+        ''
+      )
     },
     {
       title: 'Additional Sample Metadata Fields',

--- a/client/src/components/ProjectSearchResult.js
+++ b/client/src/components/ProjectSearchResult.js
@@ -28,14 +28,15 @@ export const ProjectSearchResult = ({ project }) => {
     },
     {
       title: 'Also deposited under',
-      value: project.external_accessions.length > 0 ? (
-        <ProjectExternalAccessionsDetail
-          inline
-          externalAccessions={project.external_accessions}
-        />
-      ) : (
-        ''
-      )
+      value:
+        project.external_accessions.length > 0 ? (
+          <ProjectExternalAccessionsDetail
+            inline
+            externalAccessions={project.external_accessions}
+          />
+        ) : (
+          ''
+        )
     },
     {
       title: 'Additional Sample Metadata Fields',

--- a/client/src/components/ProjectSearchResult.js
+++ b/client/src/components/ProjectSearchResult.js
@@ -29,7 +29,10 @@ export const ProjectSearchResult = ({ project }) => {
     {
       title: 'Also deposited under',
       value: project.external_accessions.length > 0 ? (
-        <ProjectExternalAccessionsDetail inline externalAccessions={project.external_accessions} />
+        <ProjectExternalAccessionsDetail
+          inline
+          externalAccessions={project.external_accessions}
+        />
       ) : (
         ''
       )

--- a/client/src/components/ProjectSearchResult.js
+++ b/client/src/components/ProjectSearchResult.js
@@ -54,7 +54,7 @@ export const ProjectSearchResult = ({ project }) => {
               <Text>{d.value}</Text>
             ) : (
               <Text italic color="black-tint-30">
-                Not Available
+                Not Specified
               </Text>
             )}
           </Box>

--- a/client/src/pages/projects/[scpca_id].js
+++ b/client/src/pages/projects/[scpca_id].js
@@ -5,6 +5,7 @@ import { ProjectHeader } from 'components/ProjectHeader'
 import { DetailsTable } from 'components/DetailsTable'
 import { ProjectAbstractDetail } from 'components/ProjectAbstractDetail'
 import { ProjectPublicationsDetail } from 'components/ProjectPublicationsDetail'
+import { ProjectExternalAccessionsDetail } from 'components/ProjectExternalAccessionsDetail'
 import { ProjectSamplesTable } from 'components/ProjectSamplesTable'
 import { ProjectSamplesSummaryTable } from 'components/ProjectSamplesSummaryTable'
 import { Link } from 'components/Link'
@@ -44,6 +45,17 @@ const Project = ({ project }) => {
                         project.publications.length > 0 ? (
                           <ProjectPublicationsDetail
                             publications={project.publications}
+                          />
+                        ) : (
+                          ''
+                        )
+                    },
+                    {
+                      label: 'Also deposited under',
+                      value:
+                        project.external_accessions.length > 0 ? (
+                          <ProjectExternalAccessionsDetail
+                            externalAccessions={project.external_accessions}
                           />
                         ) : (
                           ''

--- a/client/src/theme/table.js
+++ b/client/src/theme/table.js
@@ -37,7 +37,6 @@ export default {
     tr td, tr th {
       background-color: #fff;
       box-shadow: 1px 0 0 0 #ccc inset, 0 1px 0 0 #ccc inset;
-      vertical-align: middle;
     }
     tr th {
       box-shadow: 1px 0 0 0 #ccc inset,


### PR DESCRIPTION
## Issue Number

#455 

## Purpose/Implementation Notes

Adds support for displaying external accessions with the other project details.
We support two flavors of external accessions; comma separated list for search results, and one per line for project detail page.

Additionally adds a default array for publications for consistency and aligns table keys with values at the top like the comps.

Note: we need to do some cleanup on the API before this is ok to merge. (done 11/13)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested locally

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots
Search results with:
<img width="336" alt="Screen Shot 2023-11-10 at 4 38 54 PM" src="https://github.com/AlexsLemonade/scpca-portal/assets/1075609/d3696933-6964-4347-8efa-a9f9d9ed6d44">

Search results w/o:
<img width="278" alt="Screen Shot 2023-11-10 at 4 39 36 PM" src="https://github.com/AlexsLemonade/scpca-portal/assets/1075609/981872bd-34a1-425a-9c1a-f0313ec7967f">

Project Detail Page with:
<img width="379" alt="Screen Shot 2023-11-10 at 4 40 04 PM" src="https://github.com/AlexsLemonade/scpca-portal/assets/1075609/779644a4-7c6f-4a54-8bb8-f5246fe190ba">


Project Detail Page w/o:
<img width="335" alt="Screen Shot 2023-11-10 at 4 41 00 PM" src="https://github.com/AlexsLemonade/scpca-portal/assets/1075609/eb7eebcd-14bf-4dd7-a7f8-22616db11236">



