### PR TITLE
Remove links to python FAQ in READMEs used for SingleCellExperiment/RDS downloads

### DIFF
--- a/api/scpca_portal/templates/readme.md
+++ b/api/scpca_portal/templates/readme.md
@@ -30,7 +30,8 @@ See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_fil
 
 ## Usage
 
-For instructions on using the RDS files, please see [FAQ: How do I use the provided files in R?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-rds-files-in-r) or [FAQ: What if I want to use Python instead of R?](https://scpca.readthedocs.io/en/stable/faq.html#what-if-i-want-to-use-python-instead-of-r)
+For instructions on using the RDS files, please see [FAQ: How do I use the provided files in R?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-rds-files-in-r).
+For more information on working with the processed `SingleCellExperiment` objects, see [`Getting started with an ScPCA dataset`](https://scpca.readthedocs.io/en/stable/getting_started.html).
 
 ## CHANGELOG
 

--- a/api/scpca_portal/templates/readme_multiplexed.md
+++ b/api/scpca_portal/templates/readme_multiplexed.md
@@ -32,7 +32,7 @@ See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_fil
 
 ## Usage
 
-For instructions on using the RDS files, please see [FAQ: How do I use the provided files in R?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-rds-files-in-r) or [FAQ: What if I want to use Python instead of R?](https://scpca.readthedocs.io/en/stable/faq.html#what-if-i-want-to-use-python-instead-of-r)
+For instructions on using the RDS files, please see [FAQ: How do I use the provided files in R?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-rds-files-in-r).
 
 For information on how to use the demultiplexing results that the filtered data files contains, see the ["Getting started" section about multiplex samples](https://scpca.readthedocs.io/en/stable/getting_started.html#special-considerations-for-multiplexed-samples).
 


### PR DESCRIPTION
## Issue Number

#463 

## Purpose/Implementation Notes

Because we are now including an option to download files as either a SingleCellExperiment/RDS file or AnnData/HDF5 file, we no longer need the link to "What if I want to use Python" in the readme included with the RDS download. Also, the FAQ that is linked here, no longer exists in the docs so we want to remove it. 


## Types of changes

I modified the main README and the multiplexed README to remove the link to the Python FAQ that no longer exists. 

What types of changes does your code introduce?
- New feature (non-breaking change which adds functionality)


## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
