### PR TITLE
Add additional restrictions template for "research or academic purposes only" and where the language should go in READMEs

### DIFF
--- a/api/scpca_portal/templates/additional_terms_research_academic_only.md
+++ b/api/scpca_portal/templates/additional_terms_research_academic_only.md
@@ -1,0 +1,3 @@
+### Additional Restrictions
+
+This dataset is designated as research or academic purposes only.

--- a/api/scpca_portal/templates/readme.md
+++ b/api/scpca_portal/templates/readme.md
@@ -71,3 +71,5 @@ The Single-Cell Pediatric Cancer Atlas Portal, Alex’s Lemonade Stand Foundatio
 ## Terms of Use
 
 In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+{additional_terms}

--- a/api/scpca_portal/templates/readme_anndata.md
+++ b/api/scpca_portal/templates/readme_anndata.md
@@ -73,3 +73,5 @@ The Single-Cell Pediatric Cancer Atlas Portal, Alex’s Lemonade Stand Foundatio
 ## Terms of Use
 
 In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+{additional_terms}

--- a/api/scpca_portal/templates/readme_multiplexed.md
+++ b/api/scpca_portal/templates/readme_multiplexed.md
@@ -74,3 +74,5 @@ The Single-Cell Pediatric Cancer Atlas Portal, Alex’s Lemonade Stand Foundatio
 ## Terms of Use
 
 In using these data, you agree to our [Terms of Use.](https://scpca.alexslemonade.org/terms-of-use)
+
+{additional_terms}

--- a/api/scpca_portal/templates/readme_spatial.md
+++ b/api/scpca_portal/templates/readme_spatial.md
@@ -62,3 +62,5 @@ The Single-Cell Pediatric Cancer Atlas Portal, Alex’s Lemonade Stand Foundatio
 ## Terms of Use
 
 In using these data, you agree to our [Terms of Use.](https://scpca.alexslemonade.org/terms-of-use)
+
+{additional_terms}


### PR DESCRIPTION
## Issue Number

Closes #482 

## Purpose/Implementation Notes

I am making two changes:

1. I created a template – `api/scpca_portal/templates/additional_terms_research_academic_only.md` – that contains the language we want to insert into READMEs included in downloads when a project is designated as research or academic purposes only. Note that I've used `H3` because I expect it to be inserted under the Terms of Use header (`H2`).
2. I've added `{additional_terms}` where I expect the template language to be inserted into every README. As mentioned, it's under the Terms of Use header.

