### PR TITLE
Do not set irrelevant attributes for spatial computed files

### DIFF
--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -219,8 +219,6 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
                 for file_path in file_paths:
                     zip_file.write(file_path, Path(file_path).relative_to(sample_path))
 
-        computed_file.has_bulk_rna_seq = project.has_bulk_rna_seq
-        computed_file.has_cite_seq_data = project.has_cite_seq_data
         computed_file.size_in_bytes = computed_file.zip_file_path.stat().st_size
 
         return computed_file

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -608,7 +608,7 @@ class TestLoadData(TransactionTestCase):
             project.spatial_computed_file.modality,
             ComputedFile.OutputFileModalities.SPATIAL,
         )
-        self.assertTrue(project.spatial_computed_file.has_bulk_rna_seq)
+        self.assertFalse(project.spatial_computed_file.has_bulk_rna_seq)
         self.assertFalse(project.spatial_computed_file.has_cite_seq_data)
 
         expected_keys = [


### PR DESCRIPTION
## Issue Number

Resolves #552 

## Purpose/Implementation Notes

The `ComputedFile::has_bulk_rna_seq` and `ComputedFile::has_cite_seq_data` flags shouldn't be set for spatial modality.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules