### PR TITLE
Account for supplemental cell type report in readme

### DIFF
--- a/api/scpca_portal/templates/readme.md
+++ b/api/scpca_portal/templates/readme.md
@@ -16,7 +16,8 @@ The files associated with each library are (example shown for a library with ID 
 - An unfiltered counts file: `SCPCL000000_unfiltered.rds`,
 - A filtered counts file: `SCPCL000000_filtered.rds`,
 - A processed counts file: `SCPCL000000_processed.rds`,
-- A quality control report: `SCPCL000000_qc.html`
+- A quality control report: `SCPCL000000_qc.html`,
+- A supplemental cell type report: `SCPCL000000_celltype-report.html`
 
 Also included in each download is `single_cell_metadata.tsv`, a tab-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.
 

--- a/api/scpca_portal/templates/readme_anndata.md
+++ b/api/scpca_portal/templates/readme_anndata.md
@@ -16,7 +16,8 @@ The files associated with each library are (example shown for a library with ID 
 - An unfiltered counts file: `SCPCL000000_unfiltered_rna.hdf5`,
 - A filtered counts file: `SCPCL000000_filtered_rna.hdf5`,
 - A processed counts file: `SCPCL000000_processed_rna.hdf5`,
-- A quality control report: `SCPCL000000_qc.html`
+- A quality control report: `SCPCL000000_qc.html`,
+- A supplemental cell type report: `SCPCL000000_celltype-report.html`
 
 Also included in each download is `single_cell_metadata.tsv`, a tab-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.
 

--- a/api/scpca_portal/templates/readme_multiplexed.md
+++ b/api/scpca_portal/templates/readme_multiplexed.md
@@ -17,7 +17,8 @@ The files associated with each library are (example shown for a library with ID 
 - An unfiltered counts file: `SCPCL000000_unfiltered.rds`,
 - A filtered counts file: `SCPCL000000_filtered.rds`,
 - A processed counts file: `SCPCL000000_processed.rds`,
-- A quality control report: `SCPCL000000_qc.html`
+- A quality control report: `SCPCL000000_qc.html`,
+- A supplemental cell type report: `SCPCL000000_celltype-report.html`
 
 Also included in each download is a `single_cell_metadata.tsv`, a tab-separated table, with one row per sample/library pair and columns containing pertinent metadata corresponding to that sample and library.
 


### PR DESCRIPTION
## Issue Number

#457 

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Here I added a line for the inclusion of the supplemental cell type report in all of the README's for downloads that should include this file. This applies to every download except for the spatial download. 
Note that I branched this off `feature/community-contributed-data` since cell types will be launched at the same time. 

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

Not applicable 

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
