### PR TITLE
Sample.additional_metadata.multiplexed_with has moved to Sample.multiplexed_with

### DIFF
--- a/api/scpca_portal/serializers.py
+++ b/api/scpca_portal/serializers.py
@@ -157,6 +157,7 @@ class SampleLeafSerializer(serializers.ModelSerializer):
             "has_spatial_data",
             "includes_anndata",
             "modalities",
+            "multiplexed_with",
             "project",
             "sample_cell_count_estimate",
             "scpca_id",

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -85,6 +85,7 @@ class SampleFactory(factory.django.DjangoModelFactory):
     diagnosis = "pilocytic astrocytoma"
     disease_timing = "primary diagnosis"
     has_cite_seq_data = True
+    multiplexed_with = ["SCPCP000000"]
     project = factory.SubFactory(LeafProjectFactory)
     sample_cell_count_estimate = 42
     scpca_id = factory.Sequence(lambda n: "SCPCS0000%d" % n)

--- a/client/src/components/Download.js
+++ b/client/src/components/Download.js
@@ -34,7 +34,12 @@ export const Download = ({ icon, resource: initialResource }) => {
     : 'Download Sample'
 
   const defaultComputedFile = getDefaultComputedFile(resource)
-  const multipleComputedFiles = hasMultiple(resource.computed_files)
+
+  // TODO:: Remove filter when ANN_DATA lands
+  const multipleComputedFiles = hasMultiple(
+    resource.computed_files,
+    f => f.format !== 'ANN_DATA'
+  )
 
   const handleClick = () => {
     setShowing(true)

--- a/client/src/components/Download.js
+++ b/client/src/components/Download.js
@@ -35,7 +35,7 @@ export const Download = ({ icon, resource: initialResource }) => {
 
   const defaultComputedFile = getDefaultComputedFile(resource)
 
-  // TODO:: Remove filter when ANN_DATA lands
+  // TODO: Remove filter when ANN_DATA lands
   const multipleComputedFiles = hasMultiple(
     resource.computed_files,
     (f) => f.format !== 'ANN_DATA'

--- a/client/src/components/Download.js
+++ b/client/src/components/Download.js
@@ -38,7 +38,7 @@ export const Download = ({ icon, resource: initialResource }) => {
   // TODO:: Remove filter when ANN_DATA lands
   const multipleComputedFiles = hasMultiple(
     resource.computed_files,
-    f => f.format !== 'ANN_DATA'
+    (f) => f.format !== 'ANN_DATA'
   )
 
   const handleClick = () => {

--- a/client/src/components/DownloadOptions.js
+++ b/client/src/components/DownloadOptions.js
@@ -5,6 +5,8 @@ import { sortArrayByKey } from 'helpers/sortArrayByKey'
 
 export const DownloadOptions = ({ resource, handleSelectFile }) => {
   const { computed_files: computedFiles } = resource
+
+  // TODO: Remove filter when ANN_DATA lands
   const sortedComputedFiles = sortArrayByKey('type', computedFiles, [
     'PROJECT_ZIP',
     'SAMPLE_ZIP',
@@ -12,7 +14,7 @@ export const DownloadOptions = ({ resource, handleSelectFile }) => {
     'SAMPLE_SPATIAL_ZIP',
     'PROJECT_MULTIPLEXED_ZIP',
     'SAMPLE_MULTIPLEXED_ZIP'
-  ])
+  ]).filter(f => f.format !== 'ANN_DATA')
 
   return (
     <Grid columns={['auto', 'auto']} gap="large" pad={{ bottom: 'medium' }}>

--- a/client/src/components/DownloadOptions.js
+++ b/client/src/components/DownloadOptions.js
@@ -12,7 +12,7 @@ export const DownloadOptions = ({ resource, handleSelectFile }) => {
     'SAMPLE_SPATIAL_ZIP',
     'PROJECT_MULTIPLEXED_ZIP',
     'SAMPLE_MULTIPLEXED_ZIP'
-  ]).filter((cf) => cf.format !== 'ANN_DATA')
+  ])
 
   return (
     <Grid columns={['auto', 'auto']} gap="large" pad={{ bottom: 'medium' }}>

--- a/client/src/components/DownloadOptions.js
+++ b/client/src/components/DownloadOptions.js
@@ -14,7 +14,7 @@ export const DownloadOptions = ({ resource, handleSelectFile }) => {
     'SAMPLE_SPATIAL_ZIP',
     'PROJECT_MULTIPLEXED_ZIP',
     'SAMPLE_MULTIPLEXED_ZIP'
-  ]).filter(f => f.format !== 'ANN_DATA')
+  ]).filter((f) => f.format !== 'ANN_DATA')
 
   return (
     <Grid columns={['auto', 'auto']} gap="large" pad={{ bottom: 'medium' }}>

--- a/client/src/components/DownloadOptions.js
+++ b/client/src/components/DownloadOptions.js
@@ -9,8 +9,10 @@ export const DownloadOptions = ({ resource, handleSelectFile }) => {
     'PROJECT_ZIP',
     'SAMPLE_ZIP',
     'PROJECT_SPATIAL_ZIP',
-    'SAMPLE_SPATIAL_ZIP'
-  ])
+    'SAMPLE_SPATIAL_ZIP',
+    'PROJECT_MULTIPLEXED_ZIP',
+    'SAMPLE_MULTIPLEXED_ZIP'
+  ]).filter((cf) => cf.format !== 'ANN_DATA')
 
   return (
     <Grid columns={['auto', 'auto']} gap="large" pad={{ bottom: 'medium' }}>

--- a/client/src/components/DownloadStarted.js
+++ b/client/src/components/DownloadStarted.js
@@ -37,7 +37,11 @@ export const DownloadStarted = ({
     (cf) => cf.id !== computedFile.id
   )
 
-  const multipleComputedFiles = hasMultiple(resource.computed_files)
+  // TODO: Remove filter when ANN_DATA lands
+  const multipleComputedFiles = hasMultiple(
+    resource.computed_files,
+    f => f.format !== 'ANN_DATA'
+  )
   const inlineBorderStyle = multipleComputedFiles
     ? {
         side: 'bottom',

--- a/client/src/components/DownloadStarted.js
+++ b/client/src/components/DownloadStarted.js
@@ -101,9 +101,9 @@ export const DownloadStarted = ({
           {info && info.texts.multiplexed_with && (
             <Box margin={{ top: 'small', bottom: 'small' }}>
               <Text>{info.texts.multiplexed_with.text}</Text>
-              {resource.additional_metadata.multiplexed_with && (
+              {resource.multiplexed_with && (
                 <ul style={{ margin: '8px 0 4px 16px' }}>
-                  {resource.additional_metadata.multiplexed_with.map((item) => (
+                  {resource.multiplexed_with.map((item) => (
                     <li key={item} style={{ listStyle: 'inside square' }}>
                       {item}
                     </li>

--- a/client/src/components/DownloadStarted.js
+++ b/client/src/components/DownloadStarted.js
@@ -40,7 +40,7 @@ export const DownloadStarted = ({
   // TODO: Remove filter when ANN_DATA lands
   const multipleComputedFiles = hasMultiple(
     resource.computed_files,
-    f => f.format !== 'ANN_DATA'
+    (f) => f.format !== 'ANN_DATA'
   )
   const inlineBorderStyle = multipleComputedFiles
     ? {

--- a/client/src/config/downloadOptions.js
+++ b/client/src/config/downloadOptions.js
@@ -33,7 +33,7 @@ export const downloadOptions = {
     }
   },
   PROJECT_MULTIPLEXED_ZIP: {
-    header: 'Download Single-cell Data',
+    header: 'Download Multiplexed Data',
     data: 'Single-cell data',
     included: {
       has_multiplexed_data: 'Single-cell multiplexed data',
@@ -84,7 +84,7 @@ export const downloadOptions = {
     }
   },
   SAMPLE_MULTIPLEXED_ZIP: {
-    header: 'Download Single-cell Data',
+    header: 'Download Multiplexed Data',
     button_label: 'Download',
     data: '',
     included: {

--- a/client/src/helpers/hasMultiple.js
+++ b/client/src/helpers/hasMultiple.js
@@ -2,9 +2,11 @@
 @name hasMultiple
 @description returns true if an array contains more than one element, otherwise false
 @param {any[]} a - an array to be checked
+@param {function} filter - optional filter function to be applied to the array
 */
-export const hasMultiple = (a) => {
-  return a.length > 1
+export const hasMultiple = (a, filter) => {
+  const arr = filter ? a.filter(filter) : a
+  return arr.length > 1
 }
 
 export default hasMultiple

--- a/client/src/helpers/hasMultiple.js
+++ b/client/src/helpers/hasMultiple.js
@@ -4,7 +4,7 @@
 @param {any[]} a - an array to be checked
 */
 export const hasMultiple = (a) => {
-  return a.length > 1
+  return a.filter((cf) => cf.format !== 'ANN_DATA').length > 1
 }
 
 export default hasMultiple

--- a/client/src/helpers/hasMultiple.js
+++ b/client/src/helpers/hasMultiple.js
@@ -4,7 +4,7 @@
 @param {any[]} a - an array to be checked
 */
 export const hasMultiple = (a) => {
-  return a.filter((cf) => cf.format !== 'ANN_DATA').length > 1
+  return a.length > 1
 }
 
 export default hasMultiple


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

There were some things that needed to be cleaned up to have the AnnData changes laid on top. Notably, the `sample.multiplexed_with` was undefined, and this PR resolves that by adding to the serializer and updating the accessors on the client.

Additionally, as part of unbreaking staging before AnnData support is available, this PR will filter out AnnData computed files from presentation on the client side as they currently exist on staging. This change wont affect production and is safe to ship allowing us to support two different looking backends temporarily.

Also, this was a choice, I added a second parameter to the `hasMultiple` helper. This is optional and allows us to pass a filter function to be applied to the array before checking the length. I'm not concerned with this helper as it will most likely be removed due to lack of usage post AnnData.
____
The actual changes are summarized below:

1. Corrects the accessor of `multiplexed_with` on `DownloadStarted` component. 
2. `multiplexed_with`, was added to the sample serializer.
3. Updates tests to expect to see `multiplexed_with` on the serializer (tests now pass)
4. Modified the Header of the Download Modal to reflect that the data is multiplexed. (they looked the same)
5. Adds multiplexed variants of `computed_file.type` to the computed files sorter for completeness.
6. Added back temporary filter on AnnData so that staging will be unbroken until AnnData client changes land.
7. Added optional filter to `hasMultiple` helper to help expose that we are filtering out AnnData

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Running locally against staging data.

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
