### PR TITLE
Adding new Ann Data Context and components

### DIFF
--- a/client/src/components/DownloadOptionsModal.js
+++ b/client/src/components/DownloadOptionsModal.js
@@ -1,0 +1,100 @@
+import { Box, Button, FormField, Select, Text } from 'grommet'
+import { Modal, ModalBody } from 'components/Modal'
+import { HelpLink } from 'components/HelpLink'
+import { useDownloadOptionsContext } from 'hooks/useDownloadOptionsContext'
+import getReadableOptions from 'helpers/getReadableOptions'
+import config from 'config'
+import styled from 'styled-components'
+
+const BlueButton = styled(Button)`
+   color: ${({ theme }) => theme.global.colors.brand.light};
+`
+
+export const DownloadOptionsModal = ({
+  label = "Change",
+  title = "Set Download Options",
+  showing = false,
+  setShowing = () => { },
+  onSave = () => { }
+}) => {
+
+  const {
+    modalityOptions,
+    formatOptions,
+    selectedModality,
+    setSelectedModality,
+    selectedFormat,
+    setSelectedFormat,
+    applySelection
+  } = useDownloadOptionsContext()
+
+  const handleOptionsSave = () => {
+    applySelection()
+    onSave()
+  }
+
+  return (
+    <>
+      <BlueButton
+        label={label}
+        plain
+        color="brand"
+        onClick={() => setShowing(!showing)}
+      />
+      <Modal
+        title={title}
+        showing={showing}
+        setShowing={setShowing}>
+        <ModalBody>
+          <Text>
+            These options will be applied to all the samples in this project
+          </Text>
+          <Box>
+            <Box
+              direction="row"
+              alignContent="between"
+              gap="large"
+              pad={{ bottom: 'large' }}
+            >
+              <FormField label="Modality">
+                <Select
+                  options={getReadableOptions(modalityOptions)}
+                  labelKey="label"
+                  valueKey={{ key: "value", reduce: true }}
+                  value={selectedModality}
+                  onChange={({ value }) => setSelectedModality(value)}
+                />
+              </FormField>
+              <FormField
+                label={
+                  <HelpLink
+                    label="Data Format"
+                    link={config.links.what_downloading}
+                  />
+                }
+              >
+                <Select
+                  options={getReadableOptions(formatOptions)}
+                  labelKey="label"
+                  valueKey={{ key: "value", reduce: true }}
+                  value={selectedFormat}
+                  onChange={({ value }) => setSelectedFormat(value)}
+                />
+              </FormField>
+            </Box>
+            <Box direction="row" gap="medium" justify="end">
+              <Button label="Cancel" onClick={() => setShowing(false)} />
+              <Button
+                label="Save"
+                primary
+                onClick={handleOptionsSave}
+              />
+            </Box>
+          </Box>
+        </ModalBody>
+      </Modal >
+    </>
+  )
+}
+
+export default DownloadOptionsModal

--- a/client/src/components/HelpLink.js
+++ b/client/src/components/HelpLink.js
@@ -1,0 +1,19 @@
+import { Icon } from 'components/Icon'
+import { Text, Anchor, Stack, Box } from 'grommet'
+
+export const HelpLink = ({ label, link }) => {
+  return (
+    <Box align='start'>
+      <Stack anchor="bottom-right">
+        <Box width="auto">
+          <Text>{label}</Text>
+        </Box>
+        <Box margin={{ left: '100%' }} pad="small">
+          <Anchor href={link} target="_blank">
+            <Icon name="Help" />
+          </Anchor>
+        </Box>
+      </Stack >
+    </Box >
+  )
+}

--- a/client/src/contexts/DownloadOptionsContext.js
+++ b/client/src/contexts/DownloadOptionsContext.js
@@ -1,0 +1,81 @@
+import { createContext, useState, useEffect, useContext } from 'react'
+import { ScPCAPortalContext } from 'contexts/ScPCAPortalContext'
+import pick from 'helpers/pick'
+
+export const DownloadOptionsContext = createContext({})
+
+export const DownloadOptionsContextProvider = ({
+  resource,
+  attribute: resourceAttribute = '',
+  children
+}) => {
+
+  // Save users last used as preference.
+  const {
+    userModality,
+    setUserModality,
+    userFormat,
+    setUserFormat
+  } = useContext(ScPCAPortalContext)
+
+  // Download Options
+  const [modality, setModality] = useState(null)
+  const [format, setFormat] = useState(null)
+
+  // Selected Download Options
+  const [selectedModality, setSelectedModality] = useState(modality)
+  const [selectedFormat, setSelectedFormat] = useState(format)
+
+  // Potential Values for Download Options
+  const [modalityOptions, setModalityOptions] = useState([])
+  const [formatOptions, setFormatOptions] = useState([])
+
+  // Computed Files used to derive available options.
+  const [computedFiles, setComputeFiles] = useState([])
+
+  // Automatically updated computed file for resource
+  // This does *not* work when attribute specified.
+  const [computedFile, setComputedFile] = useState(null)
+
+  // Only on mount or when resource / collection name change
+  useEffect(() => {
+    if (resource) {
+
+    setComputeFiles(() => {
+      if (!resourceAttribute) return resource.computed_files
+      return pick(resource[resourceAttribute], 'computed_files').flat()
+    })
+    }
+  }, [resource, resourceAttribute])
+
+  return (
+    <DownloadOptionsContext.Provider
+      value={{
+        userModality,
+        setUserModality,
+        userFormat,
+        setUserFormat,
+        modality,
+        setModality,
+        format,
+        setFormat,
+        modalityOptions,
+        formatOptions,
+        computedFile,
+        resource,
+        resourceAttribute,
+        setModalityOptions,
+        setFormatOptions,
+        computedFiles,
+        selectedModality,
+        setComputedFile,
+        setSelectedFormat,
+        setSelectedModality,
+        selectedFormat,
+        resourceAttribute
+      }}
+    >
+      {children}
+    </DownloadOptionsContext.Provider>
+  )
+}

--- a/client/src/hooks/useDownloadOptionsContext.js
+++ b/client/src/hooks/useDownloadOptionsContext.js
@@ -1,0 +1,125 @@
+import { useContext, useEffect } from 'react'
+import { DownloadOptionsContext } from 'contexts/DownloadOptionsContext'
+import pick from 'helpers/pick'
+import filterWhere from 'helpers/filterWhere'
+
+export const useDownloadOptionsContext = (autoApply = false) => {
+
+
+  // Shared Context
+  const {
+    resource,
+    userModality,
+    setUserModality,
+    userFormat,
+    setUserFormat,
+    modality,
+    setModality,
+    format,
+    setFormat,
+    modalityOptions,
+    formatOptions,
+    computedFile,
+    getSelectedFilteredFiles,
+    setModalityOptions,
+    setFormatOptions,
+    computedFiles,
+    selectedModality,
+    setComputedFile,
+    setSelectedFormat,
+    setSelectedModality,
+    selectedFormat,
+    resourceAttribute
+  } = useContext(DownloadOptionsContext)
+
+  // If the direct consumer of this hook
+  // wants to update download options when selections change.
+  useEffect(() => {
+    if (autoApply) applySelection()
+  }, [selectedModality, selectedFormat])
+
+  // When computed files change, update modality to ensure it is possible
+  // Initialize the context when computed files change
+  useEffect(() => {
+    const [newModality, newModalityOptions] = getOptionsAndDefault('modality', userModality)
+    setModalityOptions(newModalityOptions)
+    setSelectedModality(newModality)
+    setModality(newModality)
+  }, [computedFiles])
+
+  // Update format when modality changes to ensure that it is possible
+  useEffect(() => {
+    if (selectedModality) {
+      const modalityMatchedFiles = filterWhere(computedFiles, { modality: selectedModality })
+      const [newFormat, newFormatOptions] = getOptionsAndDefault('format', userFormat, modalityMatchedFiles)
+      setFormatOptions(newFormatOptions)
+      setSelectedFormat(newFormat)
+      // Only assign format when unset
+      if (!format) setFormat(newFormat)
+    }
+  }, [selectedModality])
+
+  // Update computed file when download options resolves to a computed file
+  // This only needs to be updated when the user is configuring the passed in resource.
+  // Otherwise you can call useDownloadOptionsContext.getFoundFile directy ex. samples table
+  useEffect(() => {
+    if (!resourceAttribute) {
+      const newComputedFile = getFoundFile()
+      if (newComputedFile) setComputedFile(newComputedFile)
+    }
+  }, [modality, format])
+
+
+  const getOptionsAndDefault = (optionName, preference, files = computedFiles) => {
+    const allOptions = [...new Set(pick(files, optionName))]
+    const defaultOption = allOptions.includes(preference) ? preference : allOptions[0]
+    return [defaultOption, allOptions]
+  }
+
+  const getFilteredFiles = (files = computedFiles) => filterWhere(files, { modality, format })
+
+  // Get the first computed file that matches modality and format
+  const getFoundFile = (files = computedFiles) => files.find(
+    (file) => file.modality === modality && file.format === format
+  )
+
+  // Sort resources by how compatible they are with download settings
+  const resourceSort = (
+    { computed_files: firstFiles },
+    { computed_files: secondFiles }
+  ) => {
+    const firstFiltered = getFilteredFiles(firstFiles)
+    const secondFiltered = getFilteredFiles(secondFiles)
+    return firstFiltered.length < secondFiltered.length
+  }
+
+  // Apply current selection to
+  const applySelection = () => {
+    // Set Context Settings
+    setModality(selectedModality)
+    setFormat(selectedFormat)
+
+    // Set user preferences
+    setUserModality(selectedModality)
+    setUserFormat(selectedFormat)
+  }
+
+  return {
+    modality,
+    setModality,
+    modalityOptions,
+    format,
+    setFormat,
+    formatOptions,
+    computedFile,
+    getFoundFile,
+    selectedModality,
+    setSelectedModality,
+    selectedFormat,
+    setSelectedFormat,
+    applySelection,
+    getSelectedFilteredFiles,
+    resourceSort,
+    resource
+  }
+}


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

This adds support for the Samples table modal to select users download options as well as the context for the updated project download flow. Those changes will be in a future PR.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A these should still be breaking until the project stuff lands.

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
