### PR TITLE
add ann data processing banner

### DIFF
--- a/client/src/components/AnnDataProcessingBanner.js
+++ b/client/src/components/AnnDataProcessingBanner.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { useResponsive } from 'hooks/useResponsive'
+import { Box, Paragraph } from 'grommet'
+import { Banner } from 'components/Banner'
+import { Link } from 'components/Link'
+import { Icon } from 'components/Icon'
+import { config } from 'config'
+
+export const AnnDataProcessingBanner = ({
+  id = 'ann-data-processing',
+  ...props
+}) => {
+  const { responsive } = useResponsive()
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Banner id={id} background="alexs-lemonade-tint-75" {...props}>
+      <Box pad={{ vertical: 'large' }}>
+        <Box
+          direction={responsive('column', 'row')}
+          align="center"
+          justify="center"
+          flex="grow"
+        >
+          <Icon
+            color="error"
+            name="WarningNoFill"
+            size="24px"
+            aria-hidden="true"
+          />
+          <Paragraph
+            color="black"
+            margin={{ left: 'xsmall' }}
+            size={responsive('medium', 'large')}
+            textAlign="center"
+          >
+            We are making{' '}
+            <Link
+              color="black"
+              href={config.links.recruitment_hsform}
+              label="AnnData"
+            />{' '}
+            available on the portal and it will take several hours to complete.
+          </Paragraph>
+        </Box>
+        <Box pad={{ horizontal: 'medium' }}>
+          <Paragraph
+            color="black"
+            size={responsive('medium', 'large')}
+            textAlign="center"
+          >
+            During this time, AnnData might not be available for all projects
+            and you might experience some disruptions to normal service.
+          </Paragraph>
+        </Box>
+      </Box>
+    </Banner>
+  )
+}
+
+export default AnnDataProcessingBanner

--- a/client/src/components/Layout.js
+++ b/client/src/components/Layout.js
@@ -1,25 +1,18 @@
 import React, { useRef, useState, useCallback } from 'react'
 import { useRouter } from 'next/router'
-import { useBanner } from 'hooks/useBanner'
+// import { useBanner } from 'hooks/useBanner'
 import { useResizeObserver } from 'hooks/useResizeObserver'
 import { Box, Main } from 'grommet'
-import { ContributeBanner } from 'components/ContributeBanner'
 import { Footer } from 'components/Footer'
 import { Header } from 'components/Header'
 import { PageLoader } from 'components/PageLoader'
-import { RecruitNFBanner } from 'components/RecruitNFBanner'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
+import AnnDataProcessingBanner from 'components/AnnDataProcessingBanner'
 
 const FixedBox = styled(Box)`
   position: fixed;
   width: 100%;
   z-index: 3;
-  // padding-bottom: 8px;
-  ${({ showMargin }) =>
-    showMargin &&
-    css`
-      box-shadow: 0px 2px 5px 5px #fdfdfd;
-    `}
 `
 
 const ProgressBar = styled(PageLoader)`
@@ -33,8 +26,6 @@ const ProgressBar = styled(PageLoader)`
 
 export const Layout = ({ children }) => {
   const router = useRouter()
-  const { banner } = useBanner()
-
   // get the height of FixedBox for to preserve the margin
   const [fixedBoxHeight, setFixedBoxHeight] = useState('0px')
   const fixedBoxRef = useRef(null)
@@ -53,39 +44,25 @@ export const Layout = ({ children }) => {
   const widePaths = ['/', '/about']
   const showWide = widePaths.includes(router.pathname)
 
-  // exclude the padding / and box shadow on the following pages
-  const excludPadPaths = ['/', '/about', '/contribute']
-  const showMargin = !excludPadPaths.includes(router.pathname)
-
-  // add the top margin to the following pages when the contribution banner is hidden
-  const addTopMarginPaths = ['/projects', '/projects/[scpca_id]']
-  const addTopMargin =
-    addTopMarginPaths.includes(router.pathname) &&
-    showMargin &&
-    !banner['contribute-banner']
-
-  // include the contribue banner on the following pages
-  const includeContributeBanner = []
-  const showContributeBanner = includeContributeBanner.includes(router.pathname)
+  // show banner on all pages
+  const showBanner = true
 
   return (
     <Box height={{ min: '100vh' }}>
       <Box height={fixedBoxHeight}>
-        <FixedBox background="white" ref={fixedBoxRef} showMargin={showMargin}>
-          <RecruitNFBanner hidden />
+        <FixedBox background="white" ref={fixedBoxRef}>
+          {showBanner && <AnnDataProcessingBanner />}
           <Header margin={{ bottom: 'small' }} donate={showDonate} />
           <ProgressBar />
         </FixedBox>
       </Box>
-      {showContributeBanner && <ContributeBanner />}
       <Main
         width={showWide ? 'full' : 'xlarge'}
         alignSelf="center"
         overflow="visible"
         align="center"
         justify="center"
-        margin={{ top: addTopMargin ? 'xlarge' : '' }}
-        pad={{ top: showMargin ? 'xlarge' : '' }}
+        pad={{ top: showWide ? '' : 'xlarge' }}
       >
         {children}
       </Main>

--- a/client/src/components/Layout.js
+++ b/client/src/components/Layout.js
@@ -7,7 +7,7 @@ import { Footer } from 'components/Footer'
 import { Header } from 'components/Header'
 import { PageLoader } from 'components/PageLoader'
 import styled from 'styled-components'
-import AnnDataProcessingBanner from 'components/AnnDataProcessingBanner'
+import { AnnDataProcessingBanner } from 'components/AnnDataProcessingBanner'
 
 const FixedBox = styled(Box)`
   position: fixed;

--- a/client/src/contexts/BannerContext.js
+++ b/client/src/contexts/BannerContext.js
@@ -15,9 +15,8 @@ export const BannerContextProvider = ({ children }) => {
     }))
 
   const hideBanner = (id) =>
-    setBanner((prev) => {
-      delete prev[id]
-      return { ...prev }
+    setBanner(({ [id]: _, ...rest }) => {
+      return rest
     })
 
   return (

--- a/client/src/contexts/BannerContext.js
+++ b/client/src/contexts/BannerContext.js
@@ -16,10 +16,8 @@ export const BannerContextProvider = ({ children }) => {
 
   const hideBanner = (id) =>
     setBanner((prev) => {
-      const temp = { ...prev }
-      delete temp[id]
-
-      return temp
+      delete prev[id]
+      return { ...prev }
     })
 
   return (


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

Adds a temporary banner to alert users that AnnData is currently being processed.

This banner is dismissible but will reappear on refresh.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a tested locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

<img width="1299" alt="Screen Shot 2024-03-07 at 4 00 45 PM" src="https://github.com/AlexsLemonade/scpca-portal/assets/1075609/7cac95d6-68ac-43f1-ae16-92984b1b7135">

