### PR TITLE
Add input bucket as load data argument

### DIFF
--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -115,6 +115,7 @@ class Command(BaseCommand):
         subprocess.check_call(command_list)
 
     def add_arguments(self, parser):
+        parser.add_argument("--input-bucket-name", type=str, default="scpca-portal-inputs")
         parser.add_argument(
             "--clean-up-input-data", action=BooleanOptionalAction, default=settings.PRODUCTION
         )


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I want to try processing some data from an alternative bucket. This PR adds an additional argument `--input-bucket-name` for the `load_data` command that will allow us to override the bucket that is used to pull data from.

This overrides the default the default value of `input_bucket_name` which is `scpca-portal-inputs`. 

Will create an issue to document this change.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested overriding locally, havent tested pulling from the staging bucket.

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
