### PR TITLE
584 - Link to ScPCA Terms in Privacy Policy

### DIFF
--- a/client/src/config/privacy-policy.md
+++ b/client/src/config/privacy-policy.md
@@ -6,7 +6,7 @@ or any subdomains thereof (the **"ScPCADP"**), is supported by Alex’s
 Lemonade Stand Foundation (**"we,"** **"our,"** or **"us"**).
 
 Your access to, and use of, the ScPCADP is subject to our Terms of Use,
-located at [_http://refine.bio/terms_](https://www.refine.bio/terms)
+located at [_https://scpca.alexslemonade.org/terms-of-use_](https://scpca.alexslemonade.org/terms-of-use)
 (the **"Terms of Use"**). We have created this Privacy Policy (this
 **"Privacy Policy"**) to explain what information we gather when you
 visit or interact with the ScPCADP, how we and others may use your


### PR DESCRIPTION
## Issue Number
Closes #584

## Purpose/Implementation Notes
I've update the link for the refine.bio terms to the ScPCA terms (absolute path) in [privacy-policy.md](https://github.com/AlexsLemonade/scpca-portal/blob/dev/client/src/config/privacy-policy.md?plain=1#L9).

Please see the latest UI [here](https://scpca-portal-r1vig30ba-ccdl.vercel.app/privacy-policy).

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
