### PR TITLE
Update the `useScrollToTextContentHash` hook to take dynamic y-coordinate position

### DIFF
--- a/client/src/hooks/useScrollToTextContentHash.js
+++ b/client/src/hooks/useScrollToTextContentHash.js
@@ -2,13 +2,14 @@ import { useEffect } from 'react'
 import { slugify } from 'helpers/slugify'
 import { getHash } from 'helpers/getHash'
 
-// Given the hook is loaded at a location with a hash ie. #some-slug
-// This hook takes a DOM ref and css selector
-// Will iterate over matches on the css selector in the ref node
-// a match is a slug version of the textContent matching the slug from hash
-// If there is a match it will scroll to that element
+// This hook takes the following params:
+// - ref: a DOM ref
+// - selector: css selector for the querySelectorAll method
+// - y: (optional) y-coordinate for the scrollBy method, -90 by default
+// If there is a match (a slug version of textContent (for id name) matching a hash in URL),
+// it will scroll to the element with that id name on page load
 
-export const useScrollToTextContentHash = (ref, selector) => {
+export const useScrollToTextContentHash = (ref, selector, y = -90) => {
   const slug = getHash().replace('#', '')
 
   useEffect(() => {
@@ -23,6 +24,6 @@ export const useScrollToTextContentHash = (ref, selector) => {
     if (!section) return
 
     section.scrollIntoView(true)
-    window.scrollBy(0, -90)
+    window.scrollBy(0, y)
   }, [ref, selector])
 }


### PR DESCRIPTION
## Issue Number
N/A

Merged PR: #555 at commit https://github.com/AlexsLemonade/scpca-portal/pull/555/commits/aee90af3176ee4b0dd48e11587dad3b44f7bd3e4

## Purpose/Implementation Notes
Now that the logic is decoupled from the `MarkdownPage` component,  I've update the `useScrollToTextContentHash` hook to take the dynamic value of y-coordinate as a parameter, and set the hardcoded value `-90` as the default value for that parameter.

Please see the latest UI [here](https://scpca-portal-i7e2fq0xs-ccdl.vercel.app/).

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
