### PR TITLE
[AnnData Code Review] Add support for the `undefined` case to the `pick` helper  

### DIFF
--- a/client/src/contexts/DownloadOptionsContext.js
+++ b/client/src/contexts/DownloadOptionsContext.js
@@ -1,6 +1,6 @@
 import React, { createContext, useState, useEffect, useContext } from 'react'
 import { ScPCAPortalContext } from 'contexts/ScPCAPortalContext'
-import pick from 'helpers/pick'
+import { pick } from 'helpers/pick'
 
 export const DownloadOptionsContext = createContext({})
 

--- a/client/src/helpers/pick.js
+++ b/client/src/helpers/pick.js
@@ -1,1 +1,23 @@
-export default (arr = [], key) => arr.map((i) => i[key])
+/**
+ *  @name pick
+ *  @param {any[]} arr - an array of objects
+ *  @param {string} key - a key to find
+ *  @return {any[]}
+ *  @description returns a new array containing the value(s) of the given 'key' found in 'arr'
+ *  @usage
+ *  pick([{ a: 'a', b: 'b'}, {b: 'b', c: 'c'},{c: 'c', d: 'd'}], 'c' )) // ['c', 'c']
+ *  pick(
+ *    [
+ *     { format: "SINGLE_CELL_EXPERIMENT" },
+ *     { format: "ANN_DATA" }
+ *    ], 'format'
+ *   ) // [ 'SINGLE_CELL_EXPERIMENT', 'ANN_DATA' ]
+ * */
+
+export const pick = (arr = [], key) =>
+  arr.reduce((acc, cur) => {
+    if (cur[key]) acc.push(cur[key])
+    return acc
+  }, [])
+
+export default pick

--- a/client/src/hooks/useDownloadOptionsContext.js
+++ b/client/src/hooks/useDownloadOptionsContext.js
@@ -1,9 +1,9 @@
 import { useContext, useEffect } from 'react'
 import { DownloadOptionsContext } from 'contexts/DownloadOptionsContext'
-import pick from 'helpers/pick'
-import filterWhere from 'helpers/filterWhere'
 import { optionsSortOrder } from 'config/downloadOptions'
 import arrayListSort from 'helpers/arrayListSort'
+import filterWhere from 'helpers/filterWhere'
+import { pick } from 'helpers/pick'
 
 export const useDownloadOptionsContext = () => {
   const {


### PR DESCRIPTION
## Issue Number
N/A

Merged PR: #570 at commit https://github.com/AlexsLemonade/scpca-portal/pull/570/commits/7d6de88a63246d0becbe08df6c82ee9eda9b489e

## Purpose/Implementation Notes
I've tweaked the [`/helpers/pick.js`](https://github.com/AlexsLemonade/scpca-portal/blob/dev/client/src/helpers/pick.js) file as follows:

-  Replaced `map` with  `reduce` so that it returns an empty array instead of an array of `undefined` values when the given key is not found in the given array (so that we can easily check for an empty array using `length` etc).
- Added a named export to match the export pattern of the existing helpers. 

Let's create a new issue to bulk update the helper named export with `default export` 👍 

Please see the examples below:

```js
// Before
pick([{ a: 'a', b: 'b'}, {b: 'b', c: 'c'},{c: 'c', d: 'd'}], 'e' ) // [undefined, undefined, undefined], length 3
pick([
    { has_bulk_rna_seq: false, format: "SINGLE_CELL_EXPERIMENT" },
    { has_bulk_rna_seq: false }],
    'format'
) // ['SINGLE_CELL_EXPERIMENT', undefined], length 2

// After
pick([{ a: 'a', b: 'b'}, {b: 'b', c: 'c'},{c: 'c', d: 'd'}], 'e' ) // [], length 0
pick([
    { has_bulk_rna_seq: false, format: "SINGLE_CELL_EXPERIMENT" },
    { has_bulk_rna_seq: false }],
    'format'
) // ['SINGLE_CELL_EXPERIMENT'], length 1
```

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
