### PR TITLE
Add the `uniqueArray` for DRY

### DIFF
--- a/client/src/helpers/getReadableOptions.js
+++ b/client/src/helpers/getReadableOptions.js
@@ -1,5 +1,5 @@
 import { getReadable } from 'helpers/getReadable'
-
+import { uniqueArray } from 'helpers/uniqueArray'
 /*
   This function takes an array of values and returns a mapped version
   that contains the presentation label and value in an object.
@@ -7,7 +7,7 @@ import { getReadable } from 'helpers/getReadable'
   Automatically removes duplicate entries
 */
 export default (options = []) =>
-  [...new Set(options)].map((option) => ({
+  uniqueArray(options).map((option) => ({
     label: getReadable(option),
     value: option
   }))

--- a/client/src/helpers/uniqueArray.js
+++ b/client/src/helpers/uniqueArray.js
@@ -1,0 +1,12 @@
+/**
+ *  @name uniqueArray
+ *  @param {string|number[]} arr - an array to be filtered
+ *  @return {(string | number)[]}
+ *  @description returns a new array containing only the unique values of 'arr'
+ *  @usage
+ * uniqueArray([1,2,2,3,4,5,1,3,6]) // [1, 2, 3, 4, 5, 6]
+ *
+ */
+export const uniqueArray = (arr) => [...new Set(arr)]
+
+export default uniqueArray

--- a/client/src/hooks/useDownloadOptionsContext.js
+++ b/client/src/hooks/useDownloadOptionsContext.js
@@ -4,6 +4,7 @@ import pick from 'helpers/pick'
 import filterWhere from 'helpers/filterWhere'
 import { optionsSortOrder } from 'config/downloadOptions'
 import arrayListSort from 'helpers/arrayListSort'
+import { uniqueArray } from 'helpers/uniqueArray'
 
 export const useDownloadOptionsContext = () => {
   const {
@@ -70,7 +71,7 @@ export const useDownloadOptionsContext = () => {
     files = computedFiles
   ) => {
     const allOptions = arrayListSort(
-      [...new Set(pick(files, optionName))],
+      uniqueArray(pick(files, optionName)),
       optionsSortOrder
     )
     const defaultOption = allOptions.includes(preference)


### PR DESCRIPTION
## Issue Number
N/A

Merged PRs:
- #570 at commit https://github.com/AlexsLemonade/scpca-portal/pull/570/commits/b293efa9d061dca17caec75ba47caf1e81e1aa65 (line: 10)
- #574 at commit https://github.com/AlexsLemonade/scpca-portal/pull/574/commits/b966bda436b54c0b8e4e7e28a3f160b6befba19a (line: 87 in `useDownloadOptionsContext`)

## Purpose/Implementation Notes
`[...new Set (array)]` is added in two places at the above commits to get the unique values of an array, so I've created a new helper `uniqueArray` for DRY.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules