### PR TITLE
367 - Improve load data script flags handling

### DIFF
--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -123,8 +123,8 @@ class Command(BaseCommand):
             "--clean-up-output-data", action=BooleanOptionalAction, default=settings.PRODUCTION
         )
         parser.add_argument("--max-workers", type=int, default=10)
-        parser.add_argument("--reload-all", action="store_true")
-        parser.add_argument("--reload-existing", action="store_true")
+        parser.add_argument("--reload-all", action="store_true", default=False)
+        parser.add_argument("--reload-existing", action="store_true", default=False)
         parser.add_argument("--s3-max-bandwidth", type=int, default=None, help="In MB/s")
         parser.add_argument("--s3-max-concurrent-requests", type=int, default=10)
         parser.add_argument("--s3-multipart-chunk-size", type=int, default=8, help="In MB")


### PR DESCRIPTION
## Issue Number

[#367](https://github.com/AlexsLemonade/scpca-portal/issues/367)

## Purpose/Implementation Notes

- Added default value of `False` to `--reload-all` and `--reload-existing` flags, in order that they should default to the anticipated `False` value, and not to type `None`. 
> Aside: This is also meant to clarify the convention for the `load_data` script flags of type `Boolean`, where all non environment dependent[^1] default values fall back on `False`, while the caller is given the ability to explicitly override this functionality when desired by passing the flag to the command. With those flags that do have environment dependent default values, we use the `argparse.BooleanOptionalAction` action, which creates a unified interface for both `--arg` and `--no-arg` to be handled by the command, irrespective of the environment's default value.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A

[^1]: *Environment dependent* default values are flags who's default value change between development and production environments