### PR TITLE
603 - Use the named import for the useState hook

### DIFF
--- a/client/src/components/ProjectSamplesTable.js
+++ b/client/src/components/ProjectSamplesTable.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { api } from 'api'
 import { config } from 'config'
 import { Box, Text } from 'grommet'
@@ -19,15 +19,15 @@ export const ProjectSamplesTable = ({
   samples: defaultSamples,
   stickies = 3
 }) => {
-  const [showDownloadOptions, setShowDownloadOptions] = React.useState(false)
+  const [showDownloadOptions, setShowDownloadOptions] = useState(false)
 
   // We only want to show the applied donwload options.
   // Also need some helpers for presentation.
   const { modality, format, getFoundFile, resourceSort } =
     useDownloadOptionsContext()
 
-  const [samples, setSamples] = React.useState(defaultSamples)
-  const [loaded, setLoaded] = React.useState(false)
+  const [samples, setSamples] = useState(defaultSamples)
+  const [loaded, setLoaded] = useState(false)
   const infoText =
     project && project.has_bulk_rna_seq
       ? 'Bulk RNA-seq data available only when you download the entire project'


### PR DESCRIPTION
> [!note]
> This PR can reviewed after the official AnnData deploy to `prod` (removing the AnnData loading banner), as it is a low priority.

## Issue Number
Closing #603

Merged PR:
- #572 at commit https://github.com/AlexsLemonade/scpca-portal/pull/572/commits/242f7db8e812e3b946cfc223a13a5fcc906bbcdf
## Purpose/Implementation Notes

I've used the named import for the `useState` hook and removed the dot notation.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules