### PR TITLE
Move spatial samples outside of single-cell condition

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1068,23 +1068,21 @@ class Project(CommonDataAttributes, TimestampedModel):
                             else update_ann_data
                         )
 
-                        if sample.has_spatial_data:
-                            libraries = [
-                                library
-                                for library in combined_spatial_metadata
-                                if library["scpca_sample_id"] == sample.scpca_id
-                            ]
-                            workflow_versions = [
-                                library["workflow_version"] for library in libraries
-                            ]
-                            spatial_workflow_versions.update(workflow_versions)
-                            tasks.submit(
-                                ComputedFile.get_sample_spatial_file,
-                                sample,
-                                libraries,
-                                workflow_versions,
-                                ComputedFile.OutputFileFormats.SINGLE_CELL_EXPERIMENT,
-                            ).add_done_callback(update_spatial_data)
+                    if sample.has_spatial_data:
+                        libraries = [
+                            library
+                            for library in combined_spatial_metadata
+                            if library["scpca_sample_id"] == sample.scpca_id
+                        ]
+                        workflow_versions = [library["workflow_version"] for library in libraries]
+                        spatial_workflow_versions.update(workflow_versions)
+                        tasks.submit(
+                            ComputedFile.get_sample_spatial_file,
+                            sample,
+                            libraries,
+                            workflow_versions,
+                            ComputedFile.OutputFileFormats.SINGLE_CELL_EXPERIMENT,
+                        ).add_done_callback(update_spatial_data)
 
                 if sample.has_multiplexed_data:
                     libraries = [


### PR DESCRIPTION
## Issue Number

N/A

When generating samples for single-cell that also contain spatial data we were accidentally calling the spatial sample creation code with single-cell `AnnData` libraries. This was causing an error on the portal that made it look like we we're not generating single-cell `AnnData` samples.

## Purpose/Implementation Notes

Fixes single-cell anndata computed files when spatial present by "outdenting" the spatial computed file creation block so that it doesn't try and find spatial libraries on single-cell anndata directories.

This really should have a test for it, but realistically it would take a significant rewrite to ensure this code block isn't indented.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

Please attach any screenshots that illustrate these changes.
