### PR TITLE
Add community contrib filter options

### DIFF
--- a/api/scpca_portal/views/filter_options.py
+++ b/api/scpca_portal/views/filter_options.py
@@ -11,7 +11,7 @@ class FilterOptionsViewSet(viewsets.ViewSet):
         seq_units_options = set()
         technologies_options = set()
         organisms_options = set()
-        models_options = ["includes_xenografts", "includes_cell_lines"]
+        models_options = {"includes_xenografts", "includes_cell_lines"}
 
         for project in Project.objects.values(
             "diagnoses", "modalities", "seq_units", "technologies", "organisms"
@@ -29,6 +29,6 @@ class FilterOptionsViewSet(viewsets.ViewSet):
                 "seq_units": sorted(seq_units_options),
                 "technologies": sorted(technologies_options),
                 "organisms": sorted(organisms_options),
-                "models": models_options,
+                "models": sorted(models_options),
             }
         )

--- a/api/scpca_portal/views/filter_options.py
+++ b/api/scpca_portal/views/filter_options.py
@@ -10,14 +10,17 @@ class FilterOptionsViewSet(viewsets.ViewSet):
         modalities = set()
         seq_units_options = set()
         technologies_options = set()
+        organisms_options = set()
+        models_options = ["includes_xenografts", "includes_cell_lines"]
 
         for project in Project.objects.values(
-            "diagnoses", "modalities", "seq_units", "technologies"
+            "diagnoses", "modalities", "seq_units", "technologies", "organisms"
         ):
             diagnoses_options.update((d for d in (project["diagnoses"] or "").split(", ") if d))
             modalities.update(project["modalities"])
             seq_units_options.update(su for su in (project["seq_units"] or "").split(", ") if su)
             technologies_options.update(t for t in (project["technologies"] or "").split(", ") if t)
+            organisms_options.update(o for o in project["organisms"] or "" if o)
 
         return JsonResponse(
             {
@@ -25,5 +28,7 @@ class FilterOptionsViewSet(viewsets.ViewSet):
                 "modalities": sorted(modalities),
                 "seq_units": sorted(seq_units_options),
                 "technologies": sorted(technologies_options),
+                "organisms": sorted(organisms_options),
+                "models": models_options,
             }
         )


### PR DESCRIPTION
## Issue Number

#527 #526 

## Purpose/Implementation Notes

Adds the new filter options to the `/project-options` endpoint.

Specifically:
- organisms
- models (includes_xenografts, includes_cell_lines)

This endpoint is only here until we switch over to elastic/opensearch. We could arguably move the hardcoded values for models to the project model but this is honestly fine for now.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested filtering on the projects that I have processed locally.

http://localhost:8000/v1/projects?includes_xenografts=true worked
http://localhost:8000/v1/projects?organismsHomo%20Sapiens worked

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
