### PR TITLE
temp comment out sample.is_cell_line migration

### DIFF
--- a/api/scpca_portal/migrations/0038_auto_20240320_2042.py
+++ b/api/scpca_portal/migrations/0038_auto_20240320_2042.py
@@ -10,11 +10,11 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="sample",
-            name="is_cell_line",
-            field=models.BooleanField(default=False),
-        ),
+        # migrations.AddField(
+        #     model_name="sample",
+        #     name="is_cell_line",
+        #     field=models.BooleanField(default=False),
+        # ),
         migrations.AddField(
             model_name="sample",
             name="is_xenograft",


### PR DESCRIPTION
## Issue Number

This is a fix for the staging database which currently has a migration applied which is no longer in the docker container's codebase. I assume that two deploys occurred in quick succession which led to a partially applied migration. Most likely the PR was reverted too quickly. The github action was finished but the deployment process was not complete.

Currently on staging this migration fails because the column already exists and the migration errors out so it can't be competed.

After this PR is merged, I will wait for the migrations to complete then revert the change. There will be no effect because the migration has already been applied so no additional changes will occur. However we want this to not be commented out when deploying to production which has no idea that this is happening.

This PR *SHOULD* fail because it makes no changes to the tests which are created from scratch and wont have `sample.is_cell_line`. This will be resolved when reverted.