### PR TITLE
Check if single-cell SingleCellExperiment data exists before creating a computed file

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1051,11 +1051,7 @@ class Project(CommonDataAttributes, TimestampedModel):
                     workflow_versions = [library["workflow_version"] for library in libraries]
                     single_cell_workflow_versions.update(workflow_versions)
 
-                    file_formats = [ComputedFile.OutputFileFormats.SINGLE_CELL_EXPERIMENT]
-                    if sample.includes_anndata:
-                        file_formats.append(ComputedFile.OutputFileFormats.ANN_DATA)
-
-                    for file_format in file_formats:
+                    for file_format in sample.single_cell_file_formats:
                         tasks.submit(
                             ComputedFile.get_sample_single_cell_file,
                             sample,

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -198,3 +198,12 @@ class Sample(CommonDataAttributes, TimestampedModel):
             )
         except ComputedFile.DoesNotExist:
             pass
+
+    @property
+    def single_cell_file_formats(self):
+        file_formats = []
+        if self.has_single_cell_data:
+            file_formats.append(ComputedFile.OutputFileFormats.SINGLE_CELL_EXPERIMENT)
+        if self.includes_anndata:
+            file_formats.append(ComputedFile.OutputFileFormats.ANN_DATA)
+        return file_formats

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -79,7 +79,7 @@ class TestLoadData(TransactionTestCase):
             self.assertEqual(Project.objects.count(), 1)
             self.assertEqual(ProjectSummary.objects.count(), 5)
             self.assertEqual(Sample.objects.count(), 5)
-            self.assertEqual(ComputedFile.objects.count(), 10)
+            self.assertEqual(ComputedFile.objects.count(), 9)
 
         # First, just test that loading data works.
         self.loader.load_data(
@@ -718,7 +718,7 @@ class TestLoadData(TransactionTestCase):
         self.assertEqual(len(project_zip.namelist()), 19)
 
         sample = project.samples.filter(has_spatial_data=True).first()
-        self.assertEqual(len(sample.computed_files), 2)
+        self.assertEqual(len(sample.computed_files), 1)
         self.assertIsNone(sample.demux_cell_count_estimate)
         self.assertFalse(sample.has_bulk_rna_seq)
         self.assertFalse(sample.has_cite_seq_data)
@@ -735,6 +735,15 @@ class TestLoadData(TransactionTestCase):
         )
         self.assertFalse(sample.spatial_computed_file.has_bulk_rna_seq)
         self.assertFalse(sample.spatial_computed_file.has_cite_seq_data)
+
+        # Assert that single-cell modality computed files
+        # do not get created when `has_single_cell_data` is False.
+        self.assertFalse(sample.has_single_cell_data)
+        self.assertFalse(
+            sample.computed_files.filter(
+                modality=ComputedFile.OutputFileModalities.SINGLE_CELL
+            ).exists()
+        )
 
         expected_additional_metadata_keys = [
             "development_stage_ontology_term_id",


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

While testing the latest loaded project that contains spatial `SCPCP000006` to see if AnnData samples were being generated, I noticed that we were generating a `ComputedFile` for `single-cell` `SingleCellExperiment` on spatial only samples. This was due to an old assumption that `single-cell` would always exist for every sample.

This PR adds in 2 main changes:
- Add `Sample.single_cell_file_types` which does what it says on the label. It checks against the sample's properties for supported file types (anndata/sce) and is evaluated to a list that contains the correspoding `ComputedFile.OutputFileFormats` value. If no single-cell is available this property is evaluated as an empty array.
- Changes Project.load_data to iterate off of this value instead of the default `SINGLE_CELL_EXPERIMENT` and then optionally `AnnData`.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A ran locally for testing.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

n/a
