### PR TITLE
remove celltype reports from multiplexed

### DIFF
--- a/api/scpca_portal/templates/readme/multiplexed.md
+++ b/api/scpca_portal/templates/readme/multiplexed.md
@@ -18,7 +18,6 @@ The files associated with each library are (example shown for a library with ID 
 - A filtered counts file: `SCPCL000000_filtered.rds`,
 - A processed counts file: `SCPCL000000_processed.rds`,
 - A quality control report: `SCPCL000000_qc.html`,
-- A supplemental cell type report: `SCPCL000000_celltype-report.html`
 
 Also included in each download is a `single_cell_metadata.tsv`, a tab-separated table, with one row per sample/library pair and columns containing pertinent metadata corresponding to that sample and library.
 


### PR DESCRIPTION
## Issue Number

#627 

## Purpose/Implementation Notes

This is the temporary fix for #627 

This change checks if the cell type report exists and only if it does will it try to copy over to output zip.
Additionally, the readme has been updated to reflect that multiplexed files do not contain cell type reports.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A tested locally

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
