### PR TITLE
Fix - Remove the duplicated Last Updated line from the Privacy Policy page

### DIFF
--- a/client/src/pages/privacy-policy.js
+++ b/client/src/pages/privacy-policy.js
@@ -3,9 +3,13 @@ import { MarkdownPage } from 'components/MarkdownPage'
 import { LastUpdated } from 'components/LastUpdated'
 import privacyPolicy from '../config/privacy-policy.md'
 
+// TEMP: The Last Updated line is not commented out in this markdown, so temporarily adding this fix
+// TODO: handle this with regex
+const content = privacyPolicy.replace('Last Updated: 2021-11-03', '')
+
 export const PrivacyPolicy = () => (
   <>
-    <MarkdownPage markdown={privacyPolicy} />
+    <MarkdownPage markdown={content} />
     <LastUpdated date={process.env.PRIVACY_POLICY_RELEASE} />
   </>
 )


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes
I've temporarily added this fix to the Privacy Policy markdown to remove the old date (the 1st line of the screenshot - highlighted).

The last updated date should match the value of the env var `PRIVACY_POLICY_RELEASE` which is the latest deploy date (the 2nd line of the screenshot). 

(screenshot via `prod`)

![Screenshot 2024-04-08 at 8 57 00 AM](https://github.com/AlexsLemonade/scpca-portal/assets/31800566/a12ebf43-6160-46a8-9912-914a3c34907b)

Please see the latest UI [here](https://scpca-portal-1rpvzbji2-ccdl.vercel.app/privacy-policy). 

@davidsmejia I see that both env vars `PRIVACY_POLICY_RELEASE`  and `TOS_RELEASE` values were updated to `April 7th, 2024` in Vercel 2 days ago. 

For the Terms of Use's markdown content, the old last updated date was commented out but the Privacy Policy. So I added this quick fix to remove the old date. Or please let me know otherwise.

We'll either: 
- Comment out the `LastUpdated` component in `pages/privacy-policy` and the  and re-deploy `prod` to keep the old date.
- Merge this fix to `main` and re-deploy `prod` to render the new date. 

Also, do you think we can handle it with regex?(I am thinking similar to https://github.com/AlexsLemonade/scpca-portal/pull/566/commits/1e8e7ff79f63faf936e4f0951ae29dbd9b28ec42 in merged PR #566 which was not used). In the case like this, it could be really handy. I can create a PR for that today if you'd like, please let me know!

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
