### PR TITLE
[Temp Fix] Remove `multiplexed` from the modality and set a download file to multiplexed.zip for `SINGLE_CELL` modality (SCPCP000009) while backend update

### DIFF
--- a/client/src/components/ProjectSamplesTable.js
+++ b/client/src/components/ProjectSamplesTable.js
@@ -138,6 +138,14 @@ export const ProjectSamplesTable = ({
         </Box>
       )
     },
+    {
+      Header: 'Multiplexed with',
+      accessor: ({ multiplexed_with: multiplexedWith }) => (
+        <Box width={{ max: '200px' }} style={{ whiteSpace: ' break-spaces' }}>
+          {multiplexedWith.join(', ')}
+        </Box>
+      )
+    },
     { Header: 'Sequencing Units', accessor: 'seq_units' },
     { Header: 'Technology', accessor: 'technologies' },
     {

--- a/client/src/helpers/getAPIUrl.js
+++ b/client/src/helpers/getAPIUrl.js
@@ -2,7 +2,10 @@ import { urlSearchParamsFromKeys } from 'helpers/urlSearchParamsFromKeys'
 
 export const host = process.env.API_HOST
 export const version = process.env.API_VERSION
-export const path = `${host}/${version}/`
+export const path =
+  // TEMP: use prod API for demo-purpose only
+  // (currently staging s3 has no "SCPCP000009_multiplexed.zip - in the middle of updating etc?)
+  'https://api.scpca.alexslemonade.org/v1/' || `${host}/${version}/`
 
 export const getAPIUrl = (endpoint = '', query = {}) => {
   const url = new URL(endpoint, path)

--- a/client/src/hooks/useDownloadOptionsContext.js
+++ b/client/src/hooks/useDownloadOptionsContext.js
@@ -25,6 +25,9 @@ export const useDownloadOptionsContext = () => {
     setComputedFile,
     resourceAttribute
   } = useContext(DownloadOptionsContext)
+  // TEMP: remove once API is updated
+  const multiplexed = optionsSortOrder[4]
+  const singleCell = optionsSortOrder[0]
 
   const getOptionsAndDefault = (
     optionName,
@@ -35,10 +38,15 @@ export const useDownloadOptionsContext = () => {
       [...new Set(pick(files, optionName))],
       optionsSortOrder
     )
-    const defaultOption = allOptions.includes(preference)
+    // TEMP: remove once API is updated
+    const updatedOptions = allOptions.map((option) =>
+      option === multiplexed ? singleCell : option
+    )
+
+    const defaultOption = updatedOptions.includes(preference)
       ? preference
-      : allOptions[0]
-    return [allOptions, defaultOption]
+      : updatedOptions[0]
+    return [updatedOptions, defaultOption]
   }
 
   const getFilteredFiles = (files = computedFiles) =>
@@ -46,7 +54,13 @@ export const useDownloadOptionsContext = () => {
 
   // Get the first computed file that matches modality and format
   const getFoundFile = (files = computedFiles) =>
-    files.find((file) => file.modality === modality && file.format === format)
+    files.find(
+      (file) =>
+        // TEMP: remove once API is updated
+        (file.modality === multiplexed
+          ? file.modality === multiplexed
+          : file.modality === modality) && file.format === format
+    )
 
   // Sorter function for ordering a resource
   // based on availability of prefered download options
@@ -100,7 +114,14 @@ export const useDownloadOptionsContext = () => {
   useEffect(() => {
     if (!resourceAttribute) {
       const newComputedFile = getFoundFile()
-      if (newComputedFile) setComputedFile(newComputedFile)
+      if (newComputedFile) {
+        // TEMP: remove once API is updated
+        const mltiplexedFile = computedFiles.filter(
+          (file) => file.modality === multiplexed && file.format === format
+        )
+        const file = mltiplexedFile.length ? mltiplexedFile[0] : newComputedFile
+        setComputedFile(file)
+      }
     }
   }, [modality, format])
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes
Based on the ScPCA Portal - Removing Multiplexed Modality meeting, I've made the following changes on FE:
- Removed the `Multiplexed` from the modality options in the download modal
- For project file download, set the computed file  for `SINGLE_CELL` modality (SCPCP000009) to `SCPCP000009_multiplexed.zip` and not `SCPCP000009.zip`.
- For sample file download:
   - `SingleCellExperiment (R)` format will have a single sample or multiplexed libraries
   - `AnnData` format will have a single sample (but no multiplexed libraries)

> [!note] 
 I made this temporary fix to FE so that the BE update can be implemented without rushing.

Please see the latest UI [here](https://scpca-portal-l38l4hgcb-ccdl.vercel.app/projects/SCPCP000009).

## Types of changes
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
