### PR TITLE
612 - Escape backticks in markdown files

### DIFF
--- a/client/loaders/template-literal-loader.js
+++ b/client/loaders/template-literal-loader.js
@@ -2,6 +2,9 @@
 // markdown to be consumed by grommet/Markdown
 
 module.exports = (source) => {
+  // escape backticks to prevent build errors
+  const formatted = source.replaceAll('`', '\\`')
+
   // eslint-disable-next-line
-  return eval(`\`${source}\``)
+  return eval(`\`${formatted}\``)
 }


### PR DESCRIPTION
## Issue Number

Closing #612

## Purpose/Implementation Notes
I've add backslashes to backticks present in the markdown files before the eval in the template literal loader.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I tested the solution locally to make sure there are no build errors.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
