### PR TITLE
Fix multiplexed sample computed file generation when using multiple threads

### DIFF
--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -1,6 +1,6 @@
 import subprocess
-from multiprocessing import Lock
 from pathlib import Path
+from threading import Lock
 from zipfile import ZipFile
 
 from django.conf import settings

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -1,4 +1,5 @@
 import subprocess
+from multiprocessing import Lock
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -230,7 +231,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
 
     @classmethod
     def get_sample_multiplexed_file(
-        cls, sample, libraries, library_path_mapping, workflow_versions, file_format
+        cls, sample, libraries, library_path_mapping, workflow_versions, file_format, lock: Lock
     ):
         """
         Prepares a ready for saving single data file of sample's combined multiplexed data.
@@ -279,18 +280,22 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
                 else:
                     includes_celltype_report = True
 
-        if not computed_file.zip_file_path.exists():
-            with ZipFile(computed_file.zip_file_path, "w") as zip_file:
-                zip_file.write(
-                    ComputedFile.README_MULTIPLEXED_FILE_PATH,
-                    ComputedFile.OUTPUT_README_FILE_NAME,
-                )
-                zip_file.write(
-                    sample.output_multiplexed_metadata_file_path,
-                    ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME,
-                )
-                for file_name, file_path in file_name_path_mapping.items():
-                    zip_file.write(file_path, file_name)
+        # This check does not function as expected when multiple threads
+        # check before the compilation is complete. Here we use a lock that
+        # is specific to all samples that share the same zip_file_path.
+        with lock:
+            if not computed_file.zip_file_path.exists():
+                with ZipFile(computed_file.zip_file_path, "w") as zip_file:
+                    zip_file.write(
+                        ComputedFile.README_MULTIPLEXED_FILE_PATH,
+                        ComputedFile.OUTPUT_README_FILE_NAME,
+                    )
+                    zip_file.write(
+                        sample.output_multiplexed_metadata_file_path,
+                        ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME,
+                    )
+                    for file_name, file_path in file_name_path_mapping.items():
+                        zip_file.write(file_path, file_name)
 
         computed_file.has_bulk_rna_seq = False  # Sample downloads can't contain bulk data.
         computed_file.has_cite_seq_data = sample.has_cite_seq_data

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -295,7 +295,11 @@ class Project(CommonDataAttributes, TimestampedModel):
         if update_s3:
             logger.info(f"Uploading {computed_file}")
             computed_file.create_s3_file()
-        if clean_up_output_data:
+
+        # Don't clean up multiplexed sample zips until the project is done
+        is_multiplexed_sample = computed_file.sample and computed_file.sample.has_multiplexed_data
+
+        if clean_up_output_data and not is_multiplexed_sample:
             computed_file.zip_file_path.unlink(missing_ok=True)
 
         # Close DB connection for each thread.


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Main changes:
- Prevent deleting a multiplexed sample after one thread had created it so that it can be used when specifying to clean up output data, we clean up zips after created and every other file after the load_data script has completed. This is a problem for multiplexed because we re-use those files when processing the `multiplexed_with` samples.
- Make the checking of if a computed file exists thread safe. When creating multiplexed samples we reuse a computed file if it is already there. I added a change that creates a lock for each group of samples that are multiplexed together. This prevents a subsequent thread from trying to interpret the state of the generated zip before it is finished being written to.


Other notes:
- Our current implementation of concurrent processing of samples doesn't really scale. Writing to the disk is blocking regardless of how many threads you throw at it. I think what we should be handling concurrently is the generation of metadata as that would all be in memory. The writing of files can still be multithreaded but there is little benefit to that.
- I noticed that writing large files to a zip with `zipfile.ZipFile.write` is preposterously slow. This is particularly true when we create project zips. We should consider using a different module or call a sub-process directly.

ride along changes:
- Formatting

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A Processed multiplexed project locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
