### PR TITLE
Add generic parse_library_metadata method which handles parsing of single cell and spatial library metadata

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -4,7 +4,7 @@ import logging
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Dict, List, Set, Optional
+from typing import Dict, List, Optional, Set
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import connection, models

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -1,5 +1,6 @@
 """Misc utils."""
 from datetime import datetime
+from typing import Any, Dict, List
 
 
 def boolean_from_string(value):
@@ -28,3 +29,20 @@ def join_workflow_versions(workflow_versions):
 def get_today_string(format: str = "%Y-%m-%d"):
     """Returns today's date formatted. Defaults to ISO 8601."""
     return datetime.today().strftime(format)
+
+
+def sum_key(key: str, listOfDicts: List[Dict]) -> int:
+    """Returns the sum of values referenced by the same key within multiple dictionaries."""
+    return sum([dictionary.get(key, 0) for dictionary in listOfDicts])
+
+
+def filter_key(key: str, listOfDicts: List[Dict]) -> str:
+    """Iterates over a list of dictionaries, filters out the value of a chosen key,
+    and returns a list of all values."""
+    return [dictionary.get(key).strip() for dictionary in listOfDicts if key in dictionary]
+
+
+def key_value_exists(key: str, value: Any, listOfDicts: List[Dict]) -> bool:
+    """Returns True if provided key exists with provided value in list of dictionaries,
+    else returns False."""
+    return bool([dictionary.get(key) for dictionary in listOfDicts if dictionary.get(key) == value])


### PR DESCRIPTION
## Issue Number

Resolves https://github.com/AlexsLemonade/scpca-portal/issues/645

## Purpose/Implementation Notes

Created a generic function which handles parsing single cell and spatial json library metadata files. This was a simple refactoring of a piece of code that could be moved elsewhere as we work to thin out `Project::load_data`.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
  - Non-breaker refactor of two methods

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
