### PR TITLE
Temp: omit project merged computed files

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -73,7 +73,8 @@ class Project(CommonDataAttributes, TimestampedModel):
 
     @property
     def computed_files(self):
-        return self.project_computed_files.order_by("created_at")
+        # return self.project_computed_files.order_by("created_at")
+        return self.project_computed_files.filter(includes_merged=False).order_by("created_at")
 
     @property
     def input_data_path(self):

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -600,7 +600,8 @@ class TestLoadData(TransactionTestCase):
         self.assertEqual(project.summaries.first().sample_count, 1)
         self.assertEqual(project.unavailable_samples_count, 0)
         self.assertEqual(project.technologies, "10Xv3, visium")
-        self.assertEqual(len(project.computed_files), 5)
+        # TEMP: This should be 5 after merged projects are supported on the client
+        self.assertEqual(len(project.computed_files), 3)
         self.assertGreater(project.single_cell_computed_file.size_in_bytes, 0)
         self.assertEqual(project.single_cell_computed_file.workflow_version, "development")
         self.assertEqual(
@@ -836,7 +837,8 @@ class TestLoadData(TransactionTestCase):
         self.assertEqual(project.summaries.count(), 4)
         self.assertEqual(project.summaries.first().sample_count, 1)
         self.assertEqual(project.unavailable_samples_count, 0)
-        self.assertEqual(len(project.computed_files), 5)
+        # TEMP: This should be 5 after merged projects are supported on the client
+        self.assertEqual(len(project.computed_files), 3)
         self.assertGreater(project.spatial_computed_file.size_in_bytes, 0)
         self.assertEqual(project.spatial_computed_file.workflow_version, "development")
         self.assertEqual(


### PR DESCRIPTION
## Issue Number

N/A This is a temp change while we initially process merged objects.

## Purpose/Implementation Notes

We want to process merged objects on the API before making them available on the portal.
This change omits merged computed files for projects until we deploy the functionality to handle them on the client side.

This change will be removed in a subsequent PR.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
