### PR TITLE
Remove temp omission of merged computed files on project

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -73,8 +73,7 @@ class Project(CommonDataAttributes, TimestampedModel):
 
     @property
     def computed_files(self):
-        # return self.project_computed_files.order_by("created_at")
-        return self.project_computed_files.filter(includes_merged=False).order_by("created_at")
+        return self.project_computed_files.order_by("created_at")
 
     @property
     def input_data_path(self):

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -600,8 +600,7 @@ class TestLoadData(TransactionTestCase):
         self.assertEqual(project.summaries.first().sample_count, 1)
         self.assertEqual(project.unavailable_samples_count, 0)
         self.assertEqual(project.technologies, "10Xv3, visium")
-        # TEMP: This should be 5 after merged projects are supported on the client
-        self.assertEqual(len(project.computed_files), 3)
+        self.assertEqual(len(project.computed_files), 5)
         self.assertGreater(project.single_cell_computed_file.size_in_bytes, 0)
         self.assertEqual(project.single_cell_computed_file.workflow_version, "development")
         self.assertEqual(
@@ -837,8 +836,7 @@ class TestLoadData(TransactionTestCase):
         self.assertEqual(project.summaries.count(), 4)
         self.assertEqual(project.summaries.first().sample_count, 1)
         self.assertEqual(project.unavailable_samples_count, 0)
-        # TEMP: This should be 5 after merged projects are supported on the client
-        self.assertEqual(len(project.computed_files), 3)
+        self.assertEqual(len(project.computed_files), 5)
         self.assertGreater(project.spatial_computed_file.size_in_bytes, 0)
         self.assertEqual(project.spatial_computed_file.workflow_version, "development")
         self.assertEqual(


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Production has been deployed so we can add this back in on staging to test the client updates.

This just removes the filter that omited project.computed_files from including computed_files where includes_merged is true.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
