### PR TITLE
Fix fragment on which projects are merged docs link

### DIFF
--- a/client/src/config/index.js
+++ b/client/src/config/index.js
@@ -19,7 +19,7 @@ export const config = {
     when_downloading_merged_objects:
       'https://scpca.readthedocs.io/en/stable/faq.html#when-should-i-download-a-project-as-a-merged-object',
     which_projects_are_merged_objects:
-      'https://scpca.readthedocs.io/en/stable/faq.html#which-projects-can-i-download-as-a-merged-objects',
+      'https://scpca.readthedocs.io/en/stable/faq.html#which-projects-can-i-download-as-merged-objects',
     how_processed:
       'https://scpca.readthedocs.io/en/stable/processing_information.html',
     how_processed_multiplexed:


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Tested the docs links against the preview before they are released. Linking to the FAQ section for `Which projects can I download as merged objects?` was incorrect. This PR addresses that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
