### PR TITLE
AnnData extensions change hdf5 -> h5ad

### DIFF
--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -139,13 +139,13 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             computed_file_name = project.output_merged_anndata_computed_file_name
             readme_file_path = ComputedFile.README_ANNDATA_MERGED_FILE_PATH
             project_file_mapping[
-                f"{project.input_merged_data_path}/{project.scpca_id}_merged_rna.hdf5"
-            ] = f"{project.scpca_id}_merged_rna.hdf5"
+                f"{project.input_merged_data_path}/{project.scpca_id}_merged_rna.h5ad"
+            ] = f"{project.scpca_id}_merged_rna.h5ad"
 
             if project.has_cite_seq_data:
                 project_file_mapping[
-                    f"{project.input_merged_data_path}/{project.scpca_id}_merged_adt.hdf5"
-                ] = f"{project.scpca_id}_merged_adt.hdf5"
+                    f"{project.input_merged_data_path}/{project.scpca_id}_merged_adt.h5ad"
+                ] = f"{project.scpca_id}_merged_adt.h5ad"
         else:
             if not project.includes_merged_sce:
                 return None
@@ -406,10 +406,10 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             file_name = sample.output_single_cell_anndata_computed_file_name
             readme_file_path = ComputedFile.README_ANNDATA_FILE_PATH
             common_file_suffixes = [
-                "filtered_rna.hdf5",
-                "processed_rna.hdf5",
+                "filtered_rna.h5ad",
+                "processed_rna.h5ad",
                 "qc.html",
-                "unfiltered_rna.hdf5",
+                "unfiltered_rna.h5ad",
             ]
         else:
             file_name = sample.output_single_cell_computed_file_name
@@ -425,9 +425,9 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             common_file_suffixes.append("celltype-report.html")
 
         cite_seq_anndata_file_suffixes = [
-            "filtered_adt.hdf5",
-            "processed_adt.hdf5",
-            "unfiltered_adt.hdf5",
+            "filtered_adt.h5ad",
+            "processed_adt.h5ad",
+            "unfiltered_adt.h5ad",
         ]
 
         computed_file = cls(

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1010,7 +1010,7 @@ class Project(CommonDataAttributes, TimestampedModel):
             sample_metadata["has_cite_seq_data"] = has_cite_seq_data
             sample_metadata["has_single_cell_data"] = has_single_cell_data
             sample_metadata["has_spatial_data"] = has_spatial_data
-            sample_metadata["includes_anndata"] = len(list(Path(sample_dir).glob("*.hdf5"))) > 0
+            sample_metadata["includes_anndata"] = len(list(Path(sample_dir).glob("*.h5ad"))) > 0
             sample_metadata["sample_cell_count_estimate"] = sample_cell_count_estimate
             sample_metadata["seq_units"] = ", ".join(sorted(sample_seq_units, key=str.lower))
             sample_metadata["technologies"] = ", ".join(sorted(sample_technologies, key=str.lower))

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -11,7 +11,7 @@ from scpca_portal.management.commands.load_data import Command
 from scpca_portal.models import ComputedFile, Project, ProjectSummary, Sample
 
 ALLOWED_SUBMITTERS = {"scpca"}
-INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-03-08/"
+INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-04-19/"
 
 
 class TestLoadData(TransactionTestCase):
@@ -194,7 +194,7 @@ class TestLoadData(TransactionTestCase):
             files = set(project_zip.namelist())
             self.assertEqual(len(files), 8)
             self.assertIn("SCPCP999992_merged.rds", files)
-            self.assertNotIn("SCPCP999992_merged_adt.hdf5", files)
+            self.assertNotIn("SCPCP999992_merged_adt.h5ad", files)
 
         self.assertGreater(project.single_cell_anndata_merged_computed_file.size_in_bytes, 0)
         self.assertEqual(
@@ -210,8 +210,8 @@ class TestLoadData(TransactionTestCase):
             # There are 7 files (including subdirectory names):
             # ├── README.md
             # ├── SCPCP999992_merged-summary-report.html
-            # ├── SCPCP999992_merged_adt.hdf5
-            # ├── SCPCP999992_merged_rna.hdf5
+            # ├── SCPCP999992_merged_adt.h5ad
+            # ├── SCPCP999992_merged_rna.h5ad
             # ├── individual_reports
             # │   ├── SCPCS999996
             # │   │   └── SCPCL999996_qc.html
@@ -222,8 +222,8 @@ class TestLoadData(TransactionTestCase):
             # └── single_cell_metadata.tsv
             files = set(project_zip.namelist())
             self.assertEqual(len(files), 9)
-            self.assertIn("SCPCP999992_merged_rna.hdf5", files)
-            self.assertIn("SCPCP999992_merged_adt.hdf5", files)
+            self.assertIn("SCPCP999992_merged_rna.h5ad", files)
+            self.assertIn("SCPCP999992_merged_adt.h5ad", files)
 
     def test_merged_project_anndata_no_cite_seq(self):
         project_id = "SCPCP999990"
@@ -288,7 +288,7 @@ class TestLoadData(TransactionTestCase):
             # There are 8 files (including subdirectory names):
             # ├── README.md
             # ├── SCPCP999990_merged-summary-report.html
-            # ├── SCPCP999990_merged_rna.hdf5
+            # ├── SCPCP999990_merged_rna.h5ad
             # ├── bulk_metadata.tsv
             # ├── bulk_quant.tsv
             # ├── individual_reports
@@ -301,7 +301,7 @@ class TestLoadData(TransactionTestCase):
             # └── single_cell_metadata.tsv
             files = set(project_zip.namelist())
             self.assertEqual(len(files), 10)
-            self.assertIn("SCPCP999990_merged_rna.hdf5", files)
+            self.assertIn("SCPCP999990_merged_rna.h5ad", files)
 
     def test_no_merged_single_cell(self):
         project_id = "SCPCP999991"
@@ -799,10 +799,10 @@ class TestLoadData(TransactionTestCase):
             "README.md",
             "single_cell_metadata.tsv",
             f"{library_id}_celltype-report.html",
-            f"{library_id}_filtered_rna.hdf5",
-            f"{library_id}_processed_rna.hdf5",
+            f"{library_id}_filtered_rna.h5ad",
+            f"{library_id}_processed_rna.h5ad",
             f"{library_id}_qc.html",
-            f"{library_id}_unfiltered_rna.hdf5",
+            f"{library_id}_unfiltered_rna.h5ad",
         }
         self.assertEqual(set(sample_zip.namelist()), expected_filenames)
 

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -11,6 +11,8 @@ from scpca_portal.management.commands.load_data import Command
 from scpca_portal.models import ComputedFile, Project, ProjectSummary, Sample
 
 ALLOWED_SUBMITTERS = {"scpca"}
+# NOTE: When INPUT_BUCKET_NAME is changed, please delete the contents of
+# api/test_data/input before testing to ensure test files are updated correctly.
 INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-04-19/"
 
 
@@ -712,7 +714,7 @@ class TestLoadData(TransactionTestCase):
         self.assertIsNone(sample.demux_cell_count_estimate)
         self.assertFalse(sample.has_bulk_rna_seq)
         self.assertFalse(sample.has_cite_seq_data)
-        self.assertEqual(sample.sample_cell_count_estimate, 3421)
+        self.assertEqual(sample.sample_cell_count_estimate, 3426)
         self.assertEqual(sample.seq_units, "cell")
         self.assertEqual(sample.technologies, "10Xv3")
         self.assertIsNotNone(sample.single_cell_computed_file)


### PR DESCRIPTION
## Issue Number

#667 

## Purpose/Implementation Notes

Honestly, this was just as simple as:
- pointing to the new test data bucket key `2024-04-19`
- Search replace of `hdf5` with `h5ad`

The tests pass and this is good to test on staging.

Note: This PR does *not* contain any updated markdown.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A
