### PR TITLE
Add has_multiplexed_data to computed file serializer

### DIFF
--- a/api/scpca_portal/views/computed_file.py
+++ b/api/scpca_portal/views/computed_file.py
@@ -16,6 +16,7 @@ class ComputedFileDetailSerializer(serializers.ModelSerializer):
             "format",
             "has_bulk_rna_seq",
             "has_cite_seq_data",
+            "has_multiplexed_data",
             "id",
             "modality",
             "project",


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Adds the `has_mutliplexed_data` attribute to the `ComputedFile` serializer. We are ready to do the FE updates so this is needed now.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
