### PR TITLE
Add has_multiplexed_data to related computed files

### DIFF
--- a/api/scpca_portal/serializers.py
+++ b/api/scpca_portal/serializers.py
@@ -30,6 +30,7 @@ class ComputedFileSerializer(serializers.ModelSerializer):
             "format",
             "has_bulk_rna_seq",
             "has_cite_seq_data",
+            "has_multiplexed_data",
             "id",
             "includes_merged",
             "modality",

--- a/api/scpca_portal/test/serializers/test_computed_file.py
+++ b/api/scpca_portal/test/serializers/test_computed_file.py
@@ -10,7 +10,13 @@ class TestComputedFileSerializer(TestCase):
         self.computed_file_data = model_to_dict(SampleComputedFileFactory())
 
     def assertContainsFields(self, serializer):
-        for field in ("format", "has_bulk_rna_seq", "has_cite_seq_data", "modality"):
+        for field in (
+            "format",
+            "has_bulk_rna_seq",
+            "has_cite_seq_data",
+            "has_multiplexed_data",
+            "modality",
+        ):
             self.assertIn(field, serializer.data)
 
     def test_serializer_with_empty_data(self):


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Adds `has_multiplexed_data` to a project or samples related computed files.
This was previously added only to the Serializer for authenticated requests.

## Types of changes

- New feature (non-breaking change which adds functionality)


## Functional tests

n/a

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A
