### PR TITLE
Client multiplexed computed file changes

### DIFF
--- a/client/src/components/CheckBoxExcludeMultiplexed.js
+++ b/client/src/components/CheckBoxExcludeMultiplexed.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Box, CheckBox } from 'grommet'
+import { useDownloadOptionsContext } from 'hooks/useDownloadOptionsContext'
+import { config } from 'config'
+import { WarningText } from 'components/WarningText'
+
+export const CheckBoxExcludeMultiplexed = () => {
+  const {
+    excludeMultiplexed,
+    setExcludeMultiplexed,
+    isExcludeMultiplexedAvailable
+  } = useDownloadOptionsContext()
+  const handleChange = () => setExcludeMultiplexed(!excludeMultiplexed)
+
+  return (
+    <>
+      <Box direction="row">
+        <CheckBox
+          checked={excludeMultiplexed}
+          disabled={!isExcludeMultiplexedAvailable}
+          label="Exclude multiplexed samples"
+          onChange={handleChange}
+        />
+      </Box>
+      {!isExcludeMultiplexedAvailable && (
+        <WarningText
+          iconMargin={{ right: 'none' }}
+          text="Multiplexed samples are not available as AnnData (Python)."
+          link={config.links.which_samples_can_download_as_anndata}
+        />
+      )}
+    </>
+  )
+}
+
+export default CheckBoxExcludeMultiplexed

--- a/client/src/components/CheckBoxMergedObjects.js
+++ b/client/src/components/CheckBoxMergedObjects.js
@@ -1,31 +1,39 @@
 import React, { useEffect } from 'react'
-import { Box, CheckBox } from 'grommet'
+import { Box, CheckBox, Text } from 'grommet'
 import { config } from 'config'
 import { useDownloadOptionsContext } from 'hooks/useDownloadOptionsContext'
 import { HelpLink } from 'components/HelpLink'
+import { InfoText } from 'components/InfoText'
+import { Link } from 'components/Link'
 
-export const CheckBoxMergedObjects = ({ downloadable = false }) => {
-  const { includesMerged, setIncludesMerged } = useDownloadOptionsContext()
-  const link = downloadable
-    ? config.links.when_downloading_merged_objects
-    : config.links.which_projects_are_merged_objects
+export const CheckBoxMergedObjects = () => {
+  const { includesMerged, setIncludesMerged, isMergedObjectsAvailable } =
+    useDownloadOptionsContext()
   const handleChange = () => setIncludesMerged(!includesMerged)
 
-  // Uncheck the checkbox when no merged objects available
-  useEffect(() => {
-    if (!downloadable) setIncludesMerged(false)
-  }, [downloadable])
-
   return (
-    <Box direction="row">
-      <CheckBox
-        checked={includesMerged}
-        disabled={!downloadable}
-        label="Merge samples into 1 object"
-        onChange={handleChange}
-      />
-      <HelpLink link={link} />
-    </Box>
+    <>
+      <Box direction="row">
+        <CheckBox
+          checked={includesMerged}
+          disabled={!isMergedObjectsAvailable}
+          label="Merge samples into 1 object"
+          onChange={handleChange}
+        />
+        <HelpLink link={config.links.when_downloading_merged_objects} />
+      </Box>
+      {!isMergedObjectsAvailable && (
+        <InfoText>
+          <Text>
+            Merged objects are not available for every project.{' '}
+            <Link
+              href={config.links.which_projects_are_merged_objects}
+              label="Learn more"
+            />
+          </Text>
+        </InfoText>
+      )}
+    </>
   )
 }
 

--- a/client/src/components/DownloadOption.js
+++ b/client/src/components/DownloadOption.js
@@ -5,9 +5,11 @@ import { useDownloadOptionsContext } from 'hooks/useDownloadOptionsContext'
 import { formatBytes } from 'helpers/formatBytes'
 import { getDownloadOptionDetails } from 'helpers/getDownloadOptionDetails'
 import { WarningMergedObjects } from 'components/WarningMergedObjects'
+import { WarningMultiplexedSamples } from 'components/WarningMultiplexedSamples'
 
 export const DownloadOption = ({ computedFile, handleSelectFile }) => {
-  const { type, items, resourceId } = getDownloadOptionDetails(computedFile)
+  const { type, items, resourceId, warningFlags } =
+    getDownloadOptionDetails(computedFile)
   const { saveUserPreferences } = useDownloadOptionsContext()
   const downloadLabel = `Download ${type}`
 
@@ -41,11 +43,8 @@ export const DownloadOption = ({ computedFile, handleSelectFile }) => {
         </Box>
       </Box>
       <Box gridArea="body" margin={{ bottom: 'small' }}>
-        {computedFile.includes_merged && (
-          <Box>
-            <WarningMergedObjects />
-          </Box>
-        )}
+        {warningFlags.merged && <WarningMergedObjects />}
+        {warningFlags.multiplexed && <WarningMultiplexedSamples />}
         <Box pad="small">
           <Text margin={{ bottom: 'small' }}>
             The download consists of the following items:

--- a/client/src/components/DownloadOptions.js
+++ b/client/src/components/DownloadOptions.js
@@ -5,6 +5,7 @@ import { useDownloadOptionsContext } from 'hooks/useDownloadOptionsContext'
 import { useResponsive } from 'hooks/useResponsive'
 import getReadableOptions from 'helpers/getReadableOptions'
 import { CheckBoxMergedObjects } from 'components/CheckBoxMergedObjects'
+import { CheckBoxExcludeMultiplexed } from 'components/CheckBoxExcludeMultiplexed'
 import { DownloadOption } from 'components/DownloadOption'
 import { HelpLink } from 'components/HelpLink'
 
@@ -31,9 +32,10 @@ export const DownloadOptions = ({ handleSelectFile }) => {
     setFormat,
     formatOptions,
     computedFile,
-    resource,
-    isMergedObjectsAvailable
+    resource
   } = useDownloadOptionsContext()
+
+  const { has_multiplexed_data: hasMultiplexed } = resource
   const { responsive } = useResponsive()
 
   return (
@@ -79,7 +81,10 @@ export const DownloadOptions = ({ handleSelectFile }) => {
             />
           </FormField>
         </Box>
-        <CheckBoxMergedObjects downloadable={isMergedObjectsAvailable} />
+        <Box gap="medium">
+          <CheckBoxMergedObjects />
+          {hasMultiplexed && <CheckBoxExcludeMultiplexed />}
+        </Box>
       </Box>
       <Box>
         {computedFile && (

--- a/client/src/components/DownloadStarted.js
+++ b/client/src/components/DownloadStarted.js
@@ -33,12 +33,16 @@ export const DownloadStarted = ({
       const { isOk, response } = await api.projects.get(resource.project)
       if (isOk) {
         setRecommendedResource(response)
-        const defaultFile = getDefaultComputedFile(response, computedFile)
+        const defaultFile = getDefaultComputedFile(
+          response,
+          computedFile,
+          info.recommendedOptions
+        )
         setRecommendedFile(defaultFile)
       }
     }
 
-    if (info.fetchRecommended && !recommendedResource) fetchRecommended()
+    if (info.recommendedOptions && !recommendedResource) fetchRecommended()
   }, [])
 
   const { size: responsiveSize } = useResponsive()

--- a/client/src/components/ProjectSamplesTable.js
+++ b/client/src/components/ProjectSamplesTable.js
@@ -86,7 +86,7 @@ export const ProjectSamplesTable = ({
           )
         }
 
-        const computedFile = getFoundFile(row.original.computed_files)
+        const computedFile = getFoundFile(row.original.computed_files, true)
 
         if (computedFile) {
           return (

--- a/client/src/components/WarningMultiplexedSamples.js
+++ b/client/src/components/WarningMultiplexedSamples.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { config } from 'config'
+import { WarningText } from 'components/WarningText'
+
+export const WarningMultiplexedSamples = () => (
+  <WarningText
+    iconMargin="none"
+    iconSize="24px"
+    lineBreak={false}
+    link={config.links.what_downloading_multiplexed}
+    linkLabel="Learn more"
+    text="This project contains multiplexed samples"
+  />
+)
+
+export default WarningMultiplexedSamples

--- a/client/src/config/downloadOptions.js
+++ b/client/src/config/downloadOptions.js
@@ -4,8 +4,7 @@ export const optionsSortOrder = [
   'SINGLE_CELL',
   'SINGLE_CELL_EXPERIMENT',
   'ANN_DATA',
-  'SPATIAL',
-  'MULTIPLEXED'
+  'SPATIAL'
 ]
 
 export const combinedFiles = [
@@ -28,7 +27,12 @@ export const combinedFiles = [
 export const dynamicKeys = ['modality']
 
 // This is a list of keys to check for true.
-export const dataKeys = ['has_bulk_rna_seq', 'has_cite_seq_data']
+// Order determines how they are rendered.
+export const dataKeys = [
+  'has_multiplexed_data',
+  'has_bulk_rna_seq',
+  'has_cite_seq_data'
+]
 
 // This prevents appending "as Single-Cell Experiment" etc.
 export const nonFormatKeys = ['has_bulk_rna_seq']
@@ -45,12 +49,39 @@ export const modalityResourceInfo = {
       url: config.links.what_downloading_project
     }
   },
+  SINGLE_CELL_PROJECT_MULTIPLEXED: {
+    texts: {},
+    warning_text: {
+      link: {
+        label: 'Learn more',
+        url: config.links.what_downloading_multiplexed
+      },
+      text: 'This project contains multiplexed samples.'
+    }
+  },
   SINGLE_CELL_SAMPLE: {
     texts: {},
     learn_more: {
       label: 'here',
       text: 'Learn more about what you can expect in your download file',
       url: config.links.what_downloading_sample
+    }
+  },
+  SINGLE_CELL_SAMPLE_MULTIPLEXED: {
+    recommendedOptions: { has_multiplexed_data: true },
+    texts: {
+      text_only: 'This is a multiplexed sample.',
+      multiplexed_with: {
+        text: 'It has been multiplexed with the following samples.'
+      }
+    },
+    learn_more: {
+      label: 'here',
+      text: 'Learn more about multiplexed samples ',
+      url: config.links.what_downloading_multiplexed
+    },
+    warning_text: {
+      text: 'If you are planning to work with more than one multiplexed sample, we recommend downloading the entire project.'
     }
   },
   SPATIAL_PROJECT: {
@@ -67,33 +98,6 @@ export const modalityResourceInfo = {
       label: 'here',
       text: 'Learn more about what you can expect in your download file',
       url: config.links.what_downloading_spatial
-    }
-  },
-  MULTIPLEXED_PROJECT: {
-    texts: {},
-    warning_text: {
-      link: {
-        label: 'Learn more',
-        url: config.links.what_downloading_mulitplexed
-      },
-      text: 'This project contains multiplexed samples.'
-    }
-  },
-  MULTIPLEXED_SAMPLE: {
-    fetchRecommended: true,
-    texts: {
-      text_only: 'This is a multiplexed sample.',
-      multiplexed_with: {
-        text: 'It has been multiplexed with the following samples.'
-      }
-    },
-    learn_more: {
-      label: 'here',
-      text: 'Learn more about multiplexed samples ',
-      url: config.links.what_downloading_mulitplexed
-    },
-    warning_text: {
-      text: 'If you are planning to work with more than one multiplexed sample, we recommend downloading the entire project.'
     }
   }
 }

--- a/client/src/config/index.js
+++ b/client/src/config/index.js
@@ -12,7 +12,7 @@ export const config = {
       'https://scpca.readthedocs.io/en/stable/download_files.html#download-folder-structure-for-individual-sample-downloads',
     what_downloading_spatial:
       'https://scpca.readthedocs.io/en/stable/download_files.html#spatial-transcriptomics-libraries',
-    what_downloading_mulitplexed:
+    what_downloading_multiplexed:
       'https://scpca.readthedocs.io/en/stable/download_files.html#multiplexed-sample-libraries',
     what_est_demux_cell:
       'https://scpca.readthedocs.io/en/stable/faq.html#what-are-estimated-demux-cell-counts',
@@ -20,6 +20,8 @@ export const config = {
       'https://scpca.readthedocs.io/en/stable/faq.html#when-should-i-download-a-project-as-a-merged-object',
     which_projects_are_merged_objects:
       'https://scpca.readthedocs.io/en/stable/faq.html#which-projects-can-i-download-as-merged-objects',
+    which_samples_can_download_as_anndata:
+      'https://scpca.readthedocs.io/en/stable/faq.html#which-samples-can-i-download-as-anndata-objects',
     how_processed:
       'https://scpca.readthedocs.io/en/stable/processing_information.html',
     how_processed_multiplexed:

--- a/client/src/contexts/DownloadOptionsContext.js
+++ b/client/src/contexts/DownloadOptionsContext.js
@@ -17,6 +17,7 @@ export const DownloadOptionsContextProvider = ({
   const [modality, setModality] = useState(null)
   const [format, setFormat] = useState(null)
   const [includesMerged, setIncludesMerged] = useState(false)
+  const [excludeMultiplexed, setExcludeMultiplexed] = useState(false)
 
   // Potential Values for Download Options
   const [modalityOptions, setModalityOptions] = useState([])
@@ -58,6 +59,8 @@ export const DownloadOptionsContextProvider = ({
         resourceAttribute,
         includesMerged,
         setIncludesMerged,
+        excludeMultiplexed,
+        setExcludeMultiplexed,
         userModality,
         setUserModality,
         userFormat,

--- a/client/src/helpers/getDefaultComputedFile.js
+++ b/client/src/helpers/getDefaultComputedFile.js
@@ -1,17 +1,25 @@
+import objectContains from 'helpers/objectContains'
+
 /*
 @name getDefaultComputedFile
 @description returns the first element of the computed_files array fetched from the API
 @param {Object} resource - a resource object that contains a computed_files array
 @param {String} modality - a resource object that contains a computed_files array
 */
-export const getDefaultComputedFile = (resource, computedFile) => {
+export const getDefaultComputedFile = (
+  resource,
+  computedFile,
+  constraints = {}
+) => {
   const { computed_files: computedFiles } = resource
   if (!computedFile) return computedFiles[0]
 
-  const { modality: fileModality, format: fileFormat } = computedFile
-  const defaultFile = computedFiles.find(
-    ({ modality, format }) => modality === fileModality && format === fileFormat
-  )
+  const { modality, format } = computedFile
+
+  const filter = { modality, format, ...constraints }
+
+  const defaultFile = computedFiles.find((file) => objectContains(file, filter))
+
   return defaultFile || computedFiles[0]
 }
 

--- a/client/src/helpers/getDownloadOptionDetails.js
+++ b/client/src/helpers/getDownloadOptionDetails.js
@@ -34,9 +34,16 @@ export const getDownloadOptionDetails = (computedFile) => {
   const isSample = type === 'Sample'
   const resourceId = project || sample
 
+  // determine if there should be warnings
+  const warningFlags = {
+    merged: computedFile.includes_merged,
+    multiplexed: computedFile.has_multiplexed_data
+  }
+
   // Determine additional information to show.
   const modalityResourceKey = `${modality}_${type.toUpperCase()}`
-  const info = modalityResourceInfo[modalityResourceKey]
+  const suffix = computedFile.has_multiplexed_data ? '_MULTIPLEXED' : ''
+  const info = modalityResourceInfo[modalityResourceKey + suffix]
 
   // Sort out what is in the file.
   const items = []
@@ -67,5 +74,5 @@ export const getDownloadOptionDetails = (computedFile) => {
 
   items.push(metadata)
 
-  return { type, items, info, resourceId, isProject, isSample }
+  return { type, items, info, resourceId, isProject, isSample, warningFlags }
 }

--- a/client/src/helpers/getReadable.js
+++ b/client/src/helpers/getReadable.js
@@ -34,7 +34,8 @@ const readableFiles = {
   has_cite_seq_data: 'CITE-seq data',
   has_spatial_data: 'Spatial',
   has_single_cell: 'Single-cell',
-  has_bulk_rna_seq: 'Bulk RNA-Seq data'
+  has_bulk_rna_seq: 'Bulk RNA-Seq data',
+  has_multiplexed_data: 'Multiplexed single-cell data'
 }
 
 export const getReadable = (key) => readableNames[key] || key

--- a/client/src/helpers/uniqueValuesForKey.js
+++ b/client/src/helpers/uniqueValuesForKey.js
@@ -1,0 +1,3 @@
+export default (items = [], key) => {
+  return [...new Set(items.map((i) => i[key]))]
+}

--- a/client/src/hooks/useDownloadOptionsContext.js
+++ b/client/src/hooks/useDownloadOptionsContext.js
@@ -126,7 +126,17 @@ export const useDownloadOptionsContext = () => {
       const newComputedFile = getFoundFile()
       if (newComputedFile) setComputedFile(newComputedFile)
     }
-  }, [modality, format, includesMerged])
+  }, [modality, format, includesMerged, excludeMultiplexed])
+
+  // Update excludeMultiplexed depending on availability.
+  useEffect(() => {
+    setExcludeMultiplexed(!isExcludeMultiplexedAvailable)
+  }, [isExcludeMultiplexedAvailable])
+
+  // Update includesMerged depending on availability.
+  useEffect(() => {
+    if (!isMergedObjectsAvailable) setIncludesMerged(false)
+  }, [isMergedObjectsAvailable])
 
   return {
     modality,


### PR DESCRIPTION
## Issue Number

#676 

## Purpose/Implementation Notes

- removes references of multiplexed as a modality in download options logic
- adds new checkbox and warning for multiplexed samples
- breaks up merged objects help link
- updates default computed file to support a filter (for suggesting project with multiplexed data)
- some house cleaning

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
