### PR TITLE
Sort samples download size

### DIFF
--- a/client/src/components/ProjectSamplesTable.js
+++ b/client/src/components/ProjectSamplesTable.js
@@ -21,8 +21,7 @@ export const ProjectSamplesTable = ({
 }) => {
   // We only want to show the applied donwload options.
   // Also need some helpers for presentation.
-  const { modality, format, getFoundFile, resourceSort } =
-    useDownloadOptionsContext()
+  const { modality, format, getFoundFile } = useDownloadOptionsContext()
   const [loaded, setLoaded] = useState(false)
   const [samples, setSamples] = useState(defaultSamples)
   const [showDownloadOptions, setShowDownloadOptions] = useState(false)
@@ -37,12 +36,9 @@ export const ProjectSamplesTable = ({
     setLoaded(false)
   }
 
-  // Update soring after save
+  // Update after save
   useEffect(() => {
-    if (samples) {
-      samples.sort(resourceSort)
-      setLoaded(false)
-    }
+    if (samples) setLoaded(false)
   }, [samples, modality, format])
 
   useEffect(() => {
@@ -70,7 +66,12 @@ export const ProjectSamplesTable = ({
   const columns = [
     {
       Header: 'Download',
-      accessor: () => 'computed_files',
+      id: 'download',
+      accessor: ({ computed_files: computedFiles }) => {
+        if (computedFiles.length === 0) return -1
+        const computedFile = getFoundFile(computedFiles)
+        return computedFile ? computedFile.size_in_bytes : 0
+      },
       Cell: ({ row }) => {
         // there is nothing available to download
         if (row.original.computed_files.length === 0) {

--- a/client/src/components/ProjectSamplesTable.js
+++ b/client/src/components/ProjectSamplesTable.js
@@ -204,6 +204,7 @@ export const ProjectSamplesTable = ({
       pageSize={5}
       pageSizeOptions={[5, 10, 20, 50]}
       infoText={infoText}
+      defaultSort={[{ id: 'download', desc: true }]}
     >
       <Box direction="row" gap="xlarge" pad={{ bottom: 'medium' }}>
         <Box direction="row">

--- a/client/src/components/Table.js
+++ b/client/src/components/Table.js
@@ -201,6 +201,7 @@ export const Table = ({
   Head = THead,
   Body = TBody,
   filter = false,
+  defaultSort = [],
   pageSize: initialPageSize = 0,
   pageSizeOptions = [],
   infoText,
@@ -225,13 +226,15 @@ export const Table = ({
     hooks.push(usePagination)
   }
 
+  const sortRules = useMemo(() => defaultSort, [userData])
+
   const instance = useTable(
     {
       columns,
       data,
       globalFilter,
       filterTypes,
-      initialState: { pageSize }
+      initialState: { pageSize, sortBy: sortRules }
     },
     ...hooks
   )


### PR DESCRIPTION
## Issue Number

#557 

## Purpose/Implementation Notes

This PR addresses the functionality of sorting the samples table by the size of the download when clicking the arrows on the column header.

- Makes the arrows functional on the download column and sorts in order of:
  -  download size
  - if the sample is available in a different format
  - if the sample is not downloadable last

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A sorted locally

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

<img width="495" alt="Screenshot 2024-04-25 at 6 02 56 PM" src="https://github.com/AlexsLemonade/scpca-portal/assets/1075609/64d1602e-9b0d-41bb-b86e-663a1e2baa75">
<img width="465" alt="Screenshot 2024-04-25 at 6 02 17 PM" src="https://github.com/AlexsLemonade/scpca-portal/assets/1075609/75485233-0470-4b80-bce7-30de94548359">

