### PR TITLE
Allow downloading of multiple configuration options

### DIFF
--- a/client/src/hooks/useDownloadModal.js
+++ b/client/src/hooks/useDownloadModal.js
@@ -22,7 +22,7 @@ export const useDownloadModal = (
   const hasMultipleFiles = hasMultiple(resource.computed_files)
 
   // states that dictate what the modal can show
-  const isDownloadReady = download && token && publicComputedFile
+  const isDownloadReady = download && token
   const isTokenReady = !token && publicComputedFile
   const isOptionsReady = !publicComputedFile && hasMultipleFiles
 
@@ -78,9 +78,15 @@ export const useDownloadModal = (
         // try to open download
         const { type, project, sample } = publicComputedFile
         trackDownload(type, project, sample)
-        surveyListForm.submit({ email, scpca_last_download_date: getDateISO() })
+        surveyListForm.submit({
+          email,
+          scpca_last_download_date: getDateISO()
+        })
         window.open(downloadRequest.response.download_url)
         setDownload(downloadRequest.response)
+        // Clear out the selected file if it was not explicitly set.
+        // This allows to select a different configuration.
+        if (!initialPublicComputedFile) setPublicComputedFile(null)
       } else if (downloadRequest.status === 403) {
         await createToken()
       } else {


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

When selecting `Download Now` again (without refreshing) the previously configured download would automatically trigger. This was not the expected behavior. We now clear out the public computed file after downloading so that users can select new download options without refreshing.

- Conditionally set `publicComputedFile` to null when not specified on modal open
- Loosen constraint that `publicComputedFile` be defined to show `DownloadStarted` state.
  - This should be fine because `download` must be true which implies `publicComputedFile` was correctly defined at some point in the hooks's lifecycle

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
