### PR TITLE
Combine non-multiplexed and multiplexed metadata for project `samples_metadata.tsv`

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -325,15 +325,19 @@ class Project(CommonDataAttributes, TimestampedModel):
                             combined_metadata_added_pair_ids.add(pair_id)
                             combined_metadata.append(library_metadata_copy)
 
+        # Add non-multiplexed samples metadata to project metadata file.
+        combined_metadata.extend(combined_single_cell_metadata)
         with open(self.output_multiplexed_metadata_file_path, "w", newline="") as project_file:
             project_csv_writer = csv.DictWriter(
                 project_file, fieldnames=field_names, delimiter=common.TAB
             )
             project_csv_writer.writeheader()
             # Project file data has to be sorted by the library_id.
-            all_metadata = combined_single_cell_metadata + combined_metadata
             project_csv_writer.writerows(
-                sorted([cm for cm in all_metadata], key=lambda cm: cm["scpca_library_id"])
+                sorted(
+                    [cm for cm in combined_metadata],
+                    key=lambda cm: (cm["scpca_sample_id"], cm["scpca_library_id"]),
+                )
             )
 
         return combined_metadata, multiplexed_sample_mapping

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -233,7 +233,7 @@ class Project(CommonDataAttributes, TimestampedModel):
             set(samples_metadata[0].keys()), modalities={modality}
         )
 
-        # add in non-multiplexed metadata to multiplexed download
+        # add in non-multiplexed single-cell metadata keys to samples_metadata field_names
         combined_single_cell_metadata_keys = set(combined_single_cell_metadata[0].keys())
         all_single_cell_keys = library_metadata_keys.union(
             sample_metadata_keys, combined_single_cell_metadata_keys

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -429,6 +429,7 @@ class TestLoadData(TransactionTestCase):
             "development_stage_ontology_term_id",
             "disease_ontology_term_id",
             "droplet_filtering_method",
+            "filtered_cell_count",  # with non-multiplexed
             "filtered_cells",
             "has_cellhash",
             "includes_anndata",
@@ -442,6 +443,7 @@ class TestLoadData(TransactionTestCase):
             "prob_compromised_cutoff",
             "processed_cells",
             "salmon_version",
+            "sample_cell_count_estimate",  # with non-multiplexed
             "sample_cell_estimates",
             "self_reported_ethnicity_ontology_term_id",
             "sex_ontology_term_id",
@@ -463,8 +465,7 @@ class TestLoadData(TransactionTestCase):
                 "This dataset is designated as research or academic purposes only.",
                 project_zip,
             )
-
-        self.assertEqual(len(sample_metadata_lines), 3)  # 2 items + header.
+        self.assertEqual(len(sample_metadata_lines), 4)  # 3 items + header.
 
         sample_metadata_keys = sample_metadata_lines[0].split(common.TAB)
         self.assertEqual(sample_metadata_keys, expected_keys)


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We recently added new options for available downloads for projects that contain multiplexed samples.

- Single-cell as Single-cell Experiment/Single-cell as AnnData
  - Only non-multiplexed samples
  - `samples_metadata.tsv` will only contain non-multiplexed sample libraries
- Single-cell as Single-cell Experiment w/ Multiplexed samples
  - Will contain non-multiplexed samples and multiplexed samples alike
  - `samples_metadata.tsv` will only contain all single-cell samples libraries metadata

This PR essentially takes the previously generated Single-cell non-multiplexed samples metadata and concatenates it with the multiplexed metadata libraries before writing to disk. During write the rows are sorted by `scpca_sample_id` first and `scpca_library_id` second.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A ran locally and updated tests

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

n/a
