### PR TITLE
649 - Fix the ALSF logo flash on page load/refresh

### DIFF
--- a/client/src/components/Logo.js
+++ b/client/src/components/Logo.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Box, Text } from 'grommet'
 import { useResponsive } from 'hooks/useResponsive'
 import styled from 'styled-components'
-import ASLFLogo from '../images/alsf-logo.svg'
+import ALSFLogo from '../images/alsf-logo.svg'
 import ALSFLogoBlue from '../images/alsf-logo-blue.svg'
 
 const ALSFLogoBlueStyled = styled(ALSFLogoBlue)``
@@ -53,9 +53,10 @@ const Logo = () => {
             />
           </Box>
         ) : (
-          <ASLFLogo
+          <ALSFLogo
             role="img"
             aria-label="Alex's Lemonade Stand Foundation Logo"
+            width="91px"
           />
         )}
       </Box>


### PR DESCRIPTION
## Issue Number

Closing #649

## Purpose/Implementation Notes
I've set the `width: 91px` to the ALSF logo to prevent it from flashing on page load/refresh.

Please see the latest UI [here](https://scpca-portal-jsdsi75v1-ccdl.vercel.app/).


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

