### PR TITLE
693 - Extract metadata file writing from combine metadata

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1180,9 +1180,7 @@ class Project(CommonDataAttributes, TimestampedModel):
             unfiltered_samples_metadata = (
                 updated_samples_metadata
                 if modality is not Sample.Modalities.MULTIPLEXED
-                else self.get_multiplexed_samples_metadata(
-                    updated_samples_metadata, sample_metadata_keys, sample_id
-                )
+                else self.get_multiplexed_samples_metadata(updated_samples_metadata, sample_id)
             )
             samples_metadata_filtered_keys = utils.filter_dict_list_by_keys(
                 unfiltered_samples_metadata, sample_metadata_keys

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1163,10 +1163,11 @@ class Project(CommonDataAttributes, TimestampedModel):
                 modalities.add(Sample.Modalities.CITE_SEQ)
 
             sample_metadata_keys = self.get_sample_metadata_keys(
-                set(updated_samples_metadata[0].keys()), modalities=modalities
+                utils.get_key_superset_from_dicts(updated_samples_metadata), modalities=modalities
             )
             library_metadata_keys = self.get_library_metadata_keys(
-                set(libraries_metadata[modality][0].keys()), modalities=modalities
+                utils.get_key_superset_from_dicts(libraries_metadata[modality]),
+                modalities=modalities,
             )
 
             unfiltered_samples_metadata = (
@@ -1223,11 +1224,13 @@ class Project(CommonDataAttributes, TimestampedModel):
                 continue
 
             # Establish field names for tsv
-            key_set = set(combined_metadata[modality][0].keys())
+            key_set = utils.get_key_superset_from_dicts(combined_metadata[modality])
             if modality == Sample.Modalities.MULTIPLEXED:
                 # add in non-multiplexed single-cell metadata keys to samples_metadata field_names
                 key_set = key_set.union(
-                    set(combined_metadata[Sample.Modalities.SINGLE_CELL][0].keys())
+                    utils.get_key_superset_from_dicts(
+                        combined_metadata[Sample.Modalities.SINGLE_CELL]
+                    )
                 )
             field_names = self.get_metadata_field_names(key_set, modality=modality)
 

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1163,10 +1163,10 @@ class Project(CommonDataAttributes, TimestampedModel):
                 modalities.add(Sample.Modalities.CITE_SEQ)
 
             sample_metadata_keys = self.get_sample_metadata_keys(
-                utils.get_key_superset_from_dicts(updated_samples_metadata), modalities=modalities
+                utils.get_keys_from_dicts(updated_samples_metadata), modalities=modalities
             )
             library_metadata_keys = self.get_library_metadata_keys(
-                utils.get_key_superset_from_dicts(libraries_metadata[modality]),
+                utils.get_keys_from_dicts(libraries_metadata[modality]),
                 modalities=modalities,
             )
 
@@ -1224,13 +1224,11 @@ class Project(CommonDataAttributes, TimestampedModel):
                 continue
 
             # Establish field names for tsv
-            key_set = utils.get_key_superset_from_dicts(combined_metadata[modality])
+            key_set = utils.get_keys_from_dicts(combined_metadata[modality])
             if modality == Sample.Modalities.MULTIPLEXED:
                 # add in non-multiplexed single-cell metadata keys to samples_metadata field_names
                 key_set = key_set.union(
-                    utils.get_key_superset_from_dicts(
-                        combined_metadata[Sample.Modalities.SINGLE_CELL]
-                    )
+                    utils.get_keys_from_dicts(combined_metadata[Sample.Modalities.SINGLE_CELL])
                 )
             field_names = self.get_metadata_field_names(key_set, modality=modality)
 

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1266,20 +1266,19 @@ class Project(CommonDataAttributes, TimestampedModel):
                 combined_metadata[Sample.Modalities.MULTIPLEXED].extend(
                     combined_metadata[Sample.Modalities.SINGLE_CELL]
                 )
-            project_metadata_path = f"output_{modality.lower()}_metadata_file_path"
+
             # Write project metadata file
-            with open(getattr(self, project_metadata_path), "w", newline="") as project_file:
-                project_csv_writer = csv.DictWriter(
-                    project_file, fieldnames=field_names, delimiter=common.TAB
-                )
-                project_csv_writer.writeheader()
-                # Project file data has to be sorted by the library_id.
-                project_csv_writer.writerows(
-                    sorted(
-                        [cm for cm in combined_metadata[modality]],
-                        key=lambda cm: (cm["scpca_sample_id"], cm["scpca_library_id"]),
-                    )
-                )
+            # Project file data has to be sorted by the library_id.
+            combined_metadata[modality].sort(
+                key=lambda cm: (cm["scpca_sample_id"], cm["scpca_library_id"])
+            )
+            project_metadata_path = f"output_{modality.lower()}_metadata_file_path"
+            utils.write_dict_list_to_file(
+                combined_metadata[modality],
+                getattr(self, project_metadata_path),
+                field_names,
+                common.TAB,
+            )
 
         return combined_metadata
 

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1248,7 +1248,9 @@ class Project(CommonDataAttributes, TimestampedModel):
                     )
 
                 sample_metadata_path = Sample.get_output_metadata_file_path(sample_id, modality)
-                utils.write_dicts_to_tsv(sample_libraries, sample_metadata_path, field_names)
+                utils.write_dicts_to_file(
+                    sample_libraries, sample_metadata_path, fieldnames=field_names
+                )
 
             # Write project metadata to file
             if modality == Sample.Modalities.MULTIPLEXED:
@@ -1262,10 +1264,10 @@ class Project(CommonDataAttributes, TimestampedModel):
                 key=lambda cm: (cm["scpca_sample_id"], cm["scpca_library_id"]),
             )
             project_metadata_path = f"output_{modality.lower()}_metadata_file_path"
-            utils.write_dicts_to_tsv(
+            utils.write_dicts_to_file(
                 sorted_combined_metadata_by_modality,
                 getattr(self, project_metadata_path),
-                field_names,
+                fieldnames=field_names,
             )
 
     def purge(self, delete_from_s3=False):

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -100,6 +100,18 @@ class TestFilterDictListByKeys(TestCase):
         self.assertEqual(actual_result, expected_result)
 
 
+class TestGetKeySupersetFromDicts(TestCase):
+    def test_get_key_superset_from_dicts_same_keys(self):
+        list_of_dicts = [{"a": 1, "b": 2, "c": 3}, {"c": 4, "b": 5, "a": 6}]
+        expected_superset = {"a", "b", "c"}
+        self.assertEqual(utils.get_key_superset_from_dicts(list_of_dicts), expected_superset)
+
+    def test_get_key_superset_from_dicts_different_keys(self):
+        list_of_dicts = [{"a": 1, "b": 2, "c": 3}, {"c": 4, "d": 5, "e": 6}]
+        expected_superset = {"a", "b", "c", "d", "e"}
+        self.assertEqual(utils.get_key_superset_from_dicts(list_of_dicts), expected_superset)
+
+
 class TestWriteDictsToFile(TestCase):
     def setUp(self):
         self.dummy_list_of_dicts = [

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -141,7 +141,8 @@ class TestWriteDictsToFile(TestCase):
             )
 
     def test_write_dicts_to_file_not_inputted_field_names(self):
-        pass
+        utils.write_dicts_to_file(self.dummy_list_of_dicts, self.dummy_output_path)
+        self.assertTrue(os.path.exists(self.dummy_output_path))
 
     def test_write_dicts_to_file_invalid_output_file(self):
         invalid_output_file = os.path.join(self.dummy_dir, "invalid", "path", "output.csv")

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from scpca_portal import utils
+from scpca_portal import common, utils
 
 
 class TestBooleanFromString(TestCase):
@@ -100,7 +100,7 @@ class TestFilterDictListByKeys(TestCase):
         self.assertEqual(actual_result, expected_result)
 
 
-class TestWriteDictListToFile(TestCase):
+class TestWriteDictsToTsv(TestCase):
     def setUp(self):
         self.dummy_list_of_dicts = [
             {"country": "USA", "language": "English", "capital": "Washington DC"},
@@ -110,43 +110,37 @@ class TestWriteDictListToFile(TestCase):
         ]
         self.dummy_field_names = {"country", "language", "capital"}
         self.dummy_dir = Path(tempfile.mkdtemp())
-        self.test_output_file = Path(self.dummy_dir, "test_output.tsv")
+        self.dummy_output_file = Path(self.dummy_dir, "dummy_output.tsv")
 
     def tearDown(self):
-        if Path.exists(self.test_output_file):
-            Path.unlink(self.test_output_file)
+        if Path.exists(self.dummy_output_file):
+            Path.unlink(self.dummy_output_file)
         if Path.exists(self.dummy_dir):
             Path.rmdir(self.dummy_dir)
 
-    def test_write_dict_list_to_file_successful_write(self):
-        delimiter = ","
-        utils.write_dict_list_to_file(
-            self.dummy_list_of_dicts, self.test_output_file, self.dummy_field_names, delimiter
+    def test_write_dicts_to_tsv_successful_write(self):
+        utils.write_dicts_to_tsv(
+            self.dummy_list_of_dicts, self.dummy_output_file, self.dummy_field_names
         )
-        self.assertTrue(os.path.exists(self.test_output_file))
+        self.assertTrue(os.path.exists(self.dummy_output_file))
 
-    def test_write_dict_list_to_file_read_write_values_match(self):
-        delimiter = ","
-        utils.write_dict_list_to_file(
-            self.dummy_list_of_dicts, self.test_output_file, self.dummy_field_names, delimiter
+    def test_write_dicts_to_tsv_read_write_values_match(self):
+        utils.write_dicts_to_tsv(
+            self.dummy_list_of_dicts, self.dummy_output_file, self.dummy_field_names
         )
 
-        with open(self.test_output_file) as output_file:
-            output_list_of_dicts = list(csv.DictReader(output_file))
+        with open(self.dummy_output_file) as output_file:
+            output_list_of_dicts = list(csv.DictReader(output_file, delimiter=common.TAB))
             self.assertEqual(self.dummy_list_of_dicts, output_list_of_dicts)
 
-    def test_write_dict_list_to_file_missing_field_names(self):
+    def test_write_dicts_to_tsv_missing_field_names(self):
         field_names = {"country", "language"}
-        delimiter = ","
         with self.assertRaises(ValueError):
-            utils.write_dict_list_to_file(
-                self.dummy_list_of_dicts, self.test_output_file, field_names, delimiter
-            )
+            utils.write_dicts_to_tsv(self.dummy_list_of_dicts, self.dummy_output_file, field_names)
 
-    def test_write_dict_list_to_file_invalid_output_file(self):
+    def test_write_dicts_to_tsv_invalid_output_file(self):
         invalid_output_file = os.path.join(self.dummy_dir, "invalid", "path", "output.csv")
-        delimiter = ","
         with self.assertRaises(FileNotFoundError):
-            utils.write_dict_list_to_file(
-                self.dummy_list_of_dicts, invalid_output_file, self.dummy_field_names, delimiter
+            utils.write_dicts_to_tsv(
+                self.dummy_list_of_dicts, invalid_output_file, self.dummy_field_names
             )

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -100,7 +100,7 @@ class TestFilterDictListByKeys(TestCase):
         self.assertEqual(actual_result, expected_result)
 
 
-class TestWriteDictsToTsv(TestCase):
+class TestWriteDictsToFile(TestCase):
     def setUp(self):
         self.dummy_list_of_dicts = [
             {"country": "USA", "language": "English", "capital": "Washington DC"},
@@ -110,37 +110,42 @@ class TestWriteDictsToTsv(TestCase):
         ]
         self.dummy_field_names = {"country", "language", "capital"}
         self.dummy_dir = Path(tempfile.mkdtemp())
-        self.dummy_output_file = Path(self.dummy_dir, "dummy_output.tsv")
+        self.dummy_output_path = Path(self.dummy_dir, "dummy_output.tsv")
 
     def tearDown(self):
-        if Path.exists(self.dummy_output_file):
-            Path.unlink(self.dummy_output_file)
+        if Path.exists(self.dummy_output_path):
+            Path.unlink(self.dummy_output_path)
         if Path.exists(self.dummy_dir):
             Path.rmdir(self.dummy_dir)
 
-    def test_write_dicts_to_tsv_successful_write(self):
-        utils.write_dicts_to_tsv(
-            self.dummy_list_of_dicts, self.dummy_output_file, self.dummy_field_names
+    def test_write_dicts_to_file_successful_write(self):
+        utils.write_dicts_to_file(
+            self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=self.dummy_field_names
         )
-        self.assertTrue(os.path.exists(self.dummy_output_file))
+        self.assertTrue(os.path.exists(self.dummy_output_path))
 
-    def test_write_dicts_to_tsv_read_write_values_match(self):
-        utils.write_dicts_to_tsv(
-            self.dummy_list_of_dicts, self.dummy_output_file, self.dummy_field_names
+    def test_write_dicts_to_file_read_write_values_match(self):
+        utils.write_dicts_to_file(
+            self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=self.dummy_field_names
         )
 
-        with open(self.dummy_output_file) as output_file:
+        with open(self.dummy_output_path) as output_file:
             output_list_of_dicts = list(csv.DictReader(output_file, delimiter=common.TAB))
             self.assertEqual(self.dummy_list_of_dicts, output_list_of_dicts)
 
-    def test_write_dicts_to_tsv_missing_field_names(self):
+    def test_write_dicts_to_file_incomplete_field_names(self):
         field_names = {"country", "language"}
         with self.assertRaises(ValueError):
-            utils.write_dicts_to_tsv(self.dummy_list_of_dicts, self.dummy_output_file, field_names)
+            utils.write_dicts_to_file(
+                self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=field_names
+            )
 
-    def test_write_dicts_to_tsv_invalid_output_file(self):
+    def test_write_dicts_to_file_not_inputted_field_names(self):
+        pass
+
+    def test_write_dicts_to_file_invalid_output_file(self):
         invalid_output_file = os.path.join(self.dummy_dir, "invalid", "path", "output.csv")
         with self.assertRaises(FileNotFoundError):
-            utils.write_dicts_to_tsv(
-                self.dummy_list_of_dicts, invalid_output_file, self.dummy_field_names
+            utils.write_dicts_to_file(
+                self.dummy_list_of_dicts, invalid_output_file, fieldnames=self.dummy_field_names
             )

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -100,16 +100,16 @@ class TestFilterDictListByKeys(TestCase):
         self.assertEqual(actual_result, expected_result)
 
 
-class TestGetKeySupersetFromDicts(TestCase):
-    def test_get_key_superset_from_dicts_same_keys(self):
+class TestGetKeysFromDicts(TestCase):
+    def test_get_keys_from_dicts_same_keys(self):
         list_of_dicts = [{"a": 1, "b": 2, "c": 3}, {"c": 4, "b": 5, "a": 6}]
         expected_superset = {"a", "b", "c"}
-        self.assertEqual(utils.get_key_superset_from_dicts(list_of_dicts), expected_superset)
+        self.assertEqual(utils.get_keys_from_dicts(list_of_dicts), expected_superset)
 
-    def test_get_key_superset_from_dicts_different_keys(self):
+    def test_get_key_s_from_dicts_different_keys(self):
         list_of_dicts = [{"a": 1, "b": 2, "c": 3}, {"c": 4, "d": 5, "e": 6}]
         expected_superset = {"a", "b", "c", "d", "e"}
-        self.assertEqual(utils.get_key_superset_from_dicts(list_of_dicts), expected_superset)
+        self.assertEqual(utils.get_keys_from_dicts(list_of_dicts), expected_superset)
 
 
 class TestWriteDictsToFile(TestCase):

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -58,13 +58,15 @@ def filter_dict_list_by_keys(
     return new_list_of_dicts
 
 
-def write_dicts_to_tsv(
-    list_of_dicts: List[Dict],
-    output_file_name: str,
-    field_names: Set,
-) -> None:
-    """Writes a list of dictionaries to a csv-like file (exact delimiter provided)."""
-    with open(output_file_name, "w", newline="") as raw_file:
-        csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=common.TAB)
+def write_dicts_to_file(list_of_dicts: List[Dict], output_file_path: str, **kwargs) -> None:
+    """
+    Writes a list of dictionaries to a csv-like file.
+    Optional modifiers to the csv.DictWriter can be passed to function as kwargs.
+    """
+    kwargs["fieldnames"] = kwargs.get("fieldnames")
+    kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
+
+    with open(output_file_path, "w", newline="") as raw_file:
+        csv_writer = csv.DictWriter(raw_file, **kwargs)
         csv_writer.writeheader()
         csv_writer.writerows(list_of_dicts)

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -1,4 +1,5 @@
 """Misc utils."""
+import csv
 from datetime import datetime
 from typing import Dict, List, Set
 
@@ -53,3 +54,15 @@ def filter_dict_list_by_keys(
         new_list_of_dicts.append(dictionary_copy)
 
     return new_list_of_dicts
+
+
+def write_dict_list_to_file(
+    list_of_dicts: List[Dict],
+    output_file_name: str,
+    field_names: Set,
+    delimiter: str,
+) -> None:
+    with open(output_file_name, "w", newline="") as raw_file:
+        csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=delimiter)
+        csv_writer.writeheader()
+        csv_writer.writerows(list_of_dicts)

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -58,12 +58,21 @@ def filter_dict_list_by_keys(
     return new_list_of_dicts
 
 
+def get_key_superset_from_dicts(list_of_dicts: List[Dict]) -> Set:
+    """Extracts each provided dictionary's key set and returns the superset of all key sets."""
+    key_superset = set()
+    for dictionary in list_of_dicts:
+        key_superset.update(set(dictionary.keys()))
+
+    return key_superset
+
+
 def write_dicts_to_file(list_of_dicts: List[Dict], output_file_path: str, **kwargs) -> None:
     """
     Writes a list of dictionaries to a csv-like file.
     Optional modifiers to the csv.DictWriter can be passed to function as kwargs.
     """
-    kwargs["fieldnames"] = kwargs.get("fieldnames")
+    kwargs["fieldnames"] = kwargs.get("fieldnames", get_key_superset_from_dicts(list_of_dicts))
     kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
 
     with open(output_file_path, "w", newline="") as raw_file:

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -62,6 +62,7 @@ def write_dict_list_to_file(
     field_names: Set,
     delimiter: str,
 ) -> None:
+    """Writes a list of dictionaries to a csv-like file (exact delimiter provided)."""
     with open(output_file_name, "w", newline="") as raw_file:
         csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=delimiter)
         csv_writer.writeheader()

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -1,8 +1,9 @@
 """Misc utils."""
 from datetime import datetime
+from typing import Dict, List, Set
 
 
-def boolean_from_string(value):
+def boolean_from_string(value: str) -> bool:
     """
     Returns True if string value represents truthy value. Otherwise returns False.
     Raises ValueError if value cannot be casted to boolean.
@@ -19,18 +20,20 @@ def boolean_from_string(value):
     return value.lower() in ("t", "true")
 
 
-def join_workflow_versions(workflow_versions):
+def join_workflow_versions(workflow_versions: Set) -> str:
     """Returns list of sorted unique workflow versions."""
 
     return ", ".join(sorted(set(workflow_versions)))
 
 
-def get_today_string(format: str = "%Y-%m-%d"):
+def get_today_string(format: str = "%Y-%m-%d") -> str:
     """Returns today's date formatted. Defaults to ISO 8601."""
     return datetime.today().strftime(format)
 
 
-def filter_dict_list_by_keys(list_of_dicts, included_keys, *, ignore_value_error=True):
+def filter_dict_list_by_keys(
+    list_of_dicts: List[Dict], included_keys: Set, *, ignore_value_error: bool = True
+) -> List[Dict]:
     """
     Returns a list of dictionaries with keys filtered according to provided include_keys.
     If included-keys are not a subset of dictionary keys, returns a ValueError.

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -58,13 +58,9 @@ def filter_dict_list_by_keys(
     return new_list_of_dicts
 
 
-def get_key_superset_from_dicts(list_of_dicts: List[Dict]) -> Set:
-    """Extracts each provided dictionary's key set and returns the superset of all key sets."""
-    key_superset = set()
-    for dictionary in list_of_dicts:
-        key_superset.update(set(dictionary.keys()))
-
-    return key_superset
+def get_keys_from_dicts(dicts: List[Dict]) -> Set:
+    """Takes a list of dictionaries and returns a set equal to the union of their keys."""
+    return set(k for d in dicts for k in d.keys())
 
 
 def write_dicts_to_file(list_of_dicts: List[Dict], output_file_path: str, **kwargs) -> None:
@@ -72,7 +68,7 @@ def write_dicts_to_file(list_of_dicts: List[Dict], output_file_path: str, **kwar
     Writes a list of dictionaries to a csv-like file.
     Optional modifiers to the csv.DictWriter can be passed to function as kwargs.
     """
-    kwargs["fieldnames"] = kwargs.get("fieldnames", get_key_superset_from_dicts(list_of_dicts))
+    kwargs["fieldnames"] = kwargs.get("fieldnames", get_keys_from_dicts(list_of_dicts))
     kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
 
     with open(output_file_path, "w", newline="") as raw_file:

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -3,6 +3,8 @@ import csv
 from datetime import datetime
 from typing import Dict, List, Set
 
+from scpca_portal import common
+
 
 def boolean_from_string(value: str) -> bool:
     """
@@ -56,14 +58,13 @@ def filter_dict_list_by_keys(
     return new_list_of_dicts
 
 
-def write_dict_list_to_file(
+def write_dicts_to_tsv(
     list_of_dicts: List[Dict],
     output_file_name: str,
     field_names: Set,
-    delimiter: str,
 ) -> None:
     """Writes a list of dictionaries to a csv-like file (exact delimiter provided)."""
     with open(output_file_name, "w", newline="") as raw_file:
-        csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=delimiter)
+        csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=common.TAB)
         csv_writer.writeheader()
         csv_writer.writerows(list_of_dicts)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/693

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Prior to this PR, 
- the combining of sample and library metadata dictionaries, and 
- the writing of those combined libraries to sample and project metadata tsv files 

lived together inside `Project::combine_metadata`. 

In order to decouple these two actions, all file writing logic within `Project::combine_metadata` was removed and placed into a new method called `Project::write_combined_metadata_libraries`. 

The new execution of `Project::load_data` looks as follows 
- Readmes are generated
- `Project::handle_samples_metadata` is called, which parses and combines sample and library metadata, and returns the `combine_metadata` libraries
- Directly afterwards, `Project::write_combined_metadata_libraries` is called, taking the `combined_metadata` libraries and writing them to disk
- Files archives are generated

In addition, with the goal of being more generic, a utils function was created, called `utils::write_dict_list_to_file`, which takes in a list of dictionaries, the output file name/path, the field names, and the type of delimiter, and carries out the file writing to disk. In `Project::write_combined_metadata_libraries`, `utils::write_dict_list_to_file` is used for the actual writing of both the sample and project metadata files to disk.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

Tests for `write_dicts_to_file`
- `test_write_dicts_to_file_successful_write`
- `test_write_dicts_to_file_read_write_values_match`
- `test_write_dicts_to_file_incomplete_field_names`
- `test_write_dicts_to_file_not_inputted_field_names`
- `test_write_dicts_to_file_invalid_output_file`

Tests for `get_key_superset_from_dicts`
- `test_get_key_superset_from_dicts_same_keys`
- `test_get_key_superset_from_dicts_different_keys`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A

