### PR TITLE
694 - Move project property assignments from load_data command to Project model

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -19,3 +19,6 @@ OUTPUT_DATA_PATH = DATA_PATH / "output"
 TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"
 
 TAB = "\t"
+
+IGNORED_INPUT_VALUES = {"", "N/A", "TBD"}
+STRIPPED_INPUT_VALUES = "< >"

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -13,7 +13,7 @@ import boto3
 from botocore.client import Config
 
 from scpca_portal import common
-from scpca_portal.models import Project
+from scpca_portal.models import Contact, Project
 
 ALLOWED_SUBMITTERS = {
     "christensen",
@@ -208,6 +208,7 @@ class Command(BaseCommand):
             project = Project.get_from_dict(project_data)
             logger.info(f"Importing '{project}' data")
             project.save()
+            Contact.bulk_create_from_project_data(project_data, project)
 
             project.load_data(sample_id=sample_id, **kwargs)
             if samples_count := project.samples.count():

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -13,7 +13,7 @@ import boto3
 from botocore.client import Config
 
 from scpca_portal import common
-from scpca_portal.models import Contact, Project
+from scpca_portal.models import Contact, ExternalAccession, Project
 
 ALLOWED_SUBMITTERS = {
     "christensen",
@@ -209,6 +209,7 @@ class Command(BaseCommand):
             logger.info(f"Importing '{project}' data")
             project.save()
             Contact.bulk_create_from_project_data(project_data, project)
+            ExternalAccession.bulk_create_from_project_data(project_data, project)
 
             project.load_data(sample_id=sample_id, **kwargs)
             if samples_count := project.samples.count():

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -13,7 +13,7 @@ import boto3
 from botocore.client import Config
 
 from scpca_portal import common
-from scpca_portal.models import Contact, ExternalAccession, Project
+from scpca_portal.models import Contact, ExternalAccession, Project, Publication
 
 ALLOWED_SUBMITTERS = {
     "christensen",
@@ -210,6 +210,7 @@ class Command(BaseCommand):
             project.save()
             Contact.bulk_create_from_project_data(project_data, project)
             ExternalAccession.bulk_create_from_project_data(project_data, project)
+            Publication.bulk_create_from_project_data(project_data, project)
 
             project.load_data(sample_id=sample_id, **kwargs)
             if samples_count := project.samples.count():

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -205,8 +205,8 @@ class Command(BaseCommand):
                     logger.info(f"'{project}' already exists. Use --reload-existing to re-import.")
                     continue
 
-            project = Project.get_from_dict(project_data)
             logger.info(f"Importing '{project}' data")
+            project = Project.get_from_dict(project_data)
             project.save()
             Contact.bulk_create_from_project_data(project_data, project)
             ExternalAccession.bulk_create_from_project_data(project_data, project)

--- a/api/scpca_portal/models/contact.py
+++ b/api/scpca_portal/models/contact.py
@@ -50,11 +50,11 @@ class Contact(TimestampedModel):
             return
 
         for idx, email in enumerate(emails):
-            # Skip contact if already in db
-            if Contact.objects.filter(email=email):
+            if email in common.IGNORED_INPUT_VALUES:
                 continue
 
-            if email in common.IGNORED_INPUT_VALUES:
+            # Skip contact if already in db
+            if Contact.objects.filter(email=email):
                 continue
 
             contact_data = {"name": names[idx], "email": email, "pi_name": project.pi_name}

--- a/api/scpca_portal/models/contact.py
+++ b/api/scpca_portal/models/contact.py
@@ -34,7 +34,7 @@ class Contact(TimestampedModel):
 
     @staticmethod
     def bulk_create_from_project_data(project_data, project):
-        """Creates a list of contact objects and then save them."""
+        """Creates a list of contact objects and saves them."""
         emails = [
             email.lower().strip()
             for email in project_data["contact_email"].split(common.CSV_MULTI_VALUE_DELIMITER)

--- a/api/scpca_portal/models/contact.py
+++ b/api/scpca_portal/models/contact.py
@@ -1,6 +1,12 @@
+from typing import Dict
+
 from django.db import models
 
+from scpca_portal import common
+from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.models.base import TimestampedModel
+
+logger = get_and_configure_logger(__name__)
 
 
 class Contact(TimestampedModel):
@@ -15,3 +21,44 @@ class Contact(TimestampedModel):
 
     def __str__(self) -> str:
         return f"{self.name} <{self.email}>"
+
+    @classmethod
+    def get_from_dict(cls, data: Dict):
+        contact = cls(
+            name=data.get("name"),
+            email=data.get("email"),
+            pi_name=data.get("pi_name"),
+        )
+
+        return contact
+
+    @staticmethod
+    def bulk_create_from_project_data(project_data, project):
+        """Creates a list of contact objects and then save them."""
+        emails = [
+            email.lower().strip()
+            for email in project_data["contact_email"].split(common.CSV_MULTI_VALUE_DELIMITER)
+        ]
+        names = [
+            name.strip()
+            for name in project_data["contact_name"].split(common.CSV_MULTI_VALUE_DELIMITER)
+        ]
+        contacts = []
+
+        if len(emails) != len(names):
+            logger.error("Unable to add ambiguous contacts.")
+            return
+
+        for idx, email in enumerate(emails):
+            # Skip contact if already in db
+            if Contact.objects.filter(email=email):
+                continue
+
+            if email in common.IGNORED_INPUT_VALUES:
+                continue
+
+            contact_data = {"name": names[idx], "email": email, "pi_name": project.pi_name}
+            contacts.append(Contact.get_from_dict(contact_data))
+
+        Contact.objects.bulk_create(contacts)
+        project.contacts.add(*contacts)

--- a/api/scpca_portal/models/external_accession.py
+++ b/api/scpca_portal/models/external_accession.py
@@ -34,7 +34,7 @@ class ExternalAccession(TimestampedModel):
 
     @staticmethod
     def bulk_create_from_project_data(project_data, project):
-        """Creates a list of contact objects and then save them."""
+        """Creates a list of external accession objects and saves them."""
         accessions = [
             a.strip()
             for a in project_data["external_accession"].split(common.CSV_MULTI_VALUE_DELIMITER)

--- a/api/scpca_portal/models/external_accession.py
+++ b/api/scpca_portal/models/external_accession.py
@@ -1,6 +1,12 @@
+from typing import Dict
+
 from django.db import models
 
+from scpca_portal import common, utils
+from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.models.base import TimestampedModel
+
+logger = get_and_configure_logger(__name__)
 
 
 class ExternalAccession(TimestampedModel):
@@ -15,3 +21,53 @@ class ExternalAccession(TimestampedModel):
 
     def __str__(self) -> str:
         return self.accession
+
+    @classmethod
+    def get_from_dict(cls, data: Dict):
+        external_accession = cls(
+            accession=data.get("accession"),
+            has_raw=data.get("has_raw"),
+            url=data.get("url"),
+        )
+
+        return external_accession
+
+    @staticmethod
+    def bulk_create_from_project_data(project_data, project):
+        """Creates a list of contact objects and then save them."""
+        accessions = [
+            a.strip()
+            for a in project_data["external_accession"].split(common.CSV_MULTI_VALUE_DELIMITER)
+        ]
+        urls = [
+            u.strip(common.STRIPPED_INPUT_VALUES)
+            for u in project_data["external_accession_url"].split(common.CSV_MULTI_VALUE_DELIMITER)
+        ]
+        accessions_raw = [
+            utils.boolean_from_string(ar.strip())
+            for ar in project_data["external_accession_raw"].split(common.CSV_MULTI_VALUE_DELIMITER)
+        ]
+        external_accessions = []
+
+        if len(set((len(accessions), len(urls), len(accessions_raw)))) != 1:
+            logger.error("Unable to add ambiguous external accessions.")
+            return
+
+        for idx, accession in enumerate(accessions):
+            if accession in common.IGNORED_INPUT_VALUES:
+                continue
+
+            # Skip if already in db
+            if ExternalAccession.objects.filter(accession=accession):
+                continue
+
+            external_accession_data = {
+                "accession": accession,
+                "has_raw": accessions_raw[idx],
+                "url": urls[idx],
+            }
+
+            external_accessions.append(ExternalAccession.get_from_dict(external_accession_data))
+
+        ExternalAccession.objects.bulk_create(external_accessions)
+        project.external_accessions.add(*external_accessions)

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -227,31 +227,6 @@ class Project(CommonDataAttributes, TimestampedModel):
         # Close DB connection for each thread.
         connection.close()
 
-    def add_external_accessions(
-        self, external_accession, external_accession_url, external_accession_raw
-    ):
-        """Creates and adds project external accessions."""
-        accessions = external_accession.split(common.CSV_MULTI_VALUE_DELIMITER)
-        urls = external_accession_url.split(common.CSV_MULTI_VALUE_DELIMITER)
-        accessions_raw = external_accession_raw.split(common.CSV_MULTI_VALUE_DELIMITER)
-
-        if len(set((len(accessions), len(urls), len(accessions_raw)))) != 1:
-            logger.error("Unable to add ambiguous external accessions.")
-            return
-
-        for idx, accession in enumerate(accessions):
-            if accession in IGNORED_INPUT_VALUES:
-                continue
-
-            external_accession, _ = ExternalAccession.objects.get_or_create(
-                accession=accession.strip()
-            )
-            external_accession.url = urls[idx].strip(STRIPPED_INPUT_VALUES)
-            external_accession.has_raw = utils.boolean_from_string(accessions_raw[idx].strip())
-            external_accession.save()
-
-            self.external_accessions.add(external_accession)
-
     def add_publications(self, citation, citation_doi):
         """Creates and adds project publications."""
         citations = citation.split(common.CSV_MULTI_VALUE_DELIMITER)
@@ -447,11 +422,6 @@ class Project(CommonDataAttributes, TimestampedModel):
         # Project needs to be saved and given an id before many-to-manys can be established.
         project.save()
 
-        project.add_external_accessions(
-            data.get("external_accession"),
-            data.get("external_accession_url"),
-            data.get("external_accession_raw"),
-        )
         project.add_publications(data.get("citation"), data.get("citation_doi"))
 
         return project

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1180,9 +1180,7 @@ class Project(CommonDataAttributes, TimestampedModel):
             unfiltered_samples_metadata = (
                 updated_samples_metadata
                 if modality is not Sample.Modalities.MULTIPLEXED
-                else self.get_multiplexed_samples_metadata(
-                    updated_samples_metadata, sample_metadata_keys, sample_id
-                )
+                else self.get_multiplexed_samples_metadata(updated_samples_metadata, sample_id)
             )
             samples_metadata_filtered_keys = utils.filter_dict_list_by_keys(
                 unfiltered_samples_metadata, sample_metadata_keys

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1163,10 +1163,11 @@ class Project(CommonDataAttributes, TimestampedModel):
                 modalities.add(Sample.Modalities.CITE_SEQ)
 
             sample_metadata_keys = self.get_sample_metadata_keys(
-                set(updated_samples_metadata[0].keys()), modalities=modalities
+                utils.get_key_superset_from_dicts(updated_samples_metadata), modalities=modalities
             )
             library_metadata_keys = self.get_library_metadata_keys(
-                set(libraries_metadata[modality][0].keys()), modalities=modalities
+                utils.get_key_superset_from_dicts(libraries_metadata[modality]),
+                modalities=modalities,
             )
 
             unfiltered_samples_metadata = (
@@ -1223,11 +1224,13 @@ class Project(CommonDataAttributes, TimestampedModel):
                 continue
 
             # Establish field names for tsv
-            key_set = set(combined_metadata[modality][0].keys())
+            key_set = utils.get_key_superset_from_dicts(combined_metadata[modality])
             if modality == Sample.Modalities.MULTIPLEXED:
                 # add in non-multiplexed single-cell metadata keys to samples_metadata field_names
                 key_set = key_set.union(
-                    set(combined_metadata[Sample.Modalities.SINGLE_CELL][0].keys())
+                    utils.get_key_superset_from_dicts(
+                        combined_metadata[Sample.Modalities.SINGLE_CELL]
+                    )
                 )
             field_names = self.get_metadata_field_names(key_set, modality=modality)
 

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -227,26 +227,6 @@ class Project(CommonDataAttributes, TimestampedModel):
         # Close DB connection for each thread.
         connection.close()
 
-    def add_contacts(self, contact_email, contact_name):
-        """Creates and adds project contacts."""
-        emails = contact_email.split(common.CSV_MULTI_VALUE_DELIMITER)
-        names = contact_name.split(common.CSV_MULTI_VALUE_DELIMITER)
-
-        if len(emails) != len(names):
-            logger.error("Unable to add ambiguous contacts.")
-            return
-
-        for idx, email in enumerate(emails):
-            if email in IGNORED_INPUT_VALUES:
-                continue
-
-            contact, _ = Contact.objects.get_or_create(email=email.lower().strip())
-            contact.name = names[idx].strip()
-            contact.submitter_id = self.pi_name
-            contact.save()
-
-            self.contacts.add(contact)
-
     def add_external_accessions(
         self, external_accession, external_accession_url, external_accession_raw
     ):
@@ -467,7 +447,6 @@ class Project(CommonDataAttributes, TimestampedModel):
         # Project needs to be saved and given an id before many-to-manys can be established.
         project.save()
 
-        project.add_contacts(data.get("contact_email"), data.get("contact_name"))
         project.add_external_accessions(
             data.get("external_accession"),
             data.get("external_accession_url"),

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1266,20 +1266,19 @@ class Project(CommonDataAttributes, TimestampedModel):
                 combined_metadata[Sample.Modalities.MULTIPLEXED].extend(
                     combined_metadata[Sample.Modalities.SINGLE_CELL]
                 )
-            project_metadata_path = f"output_{modality.lower()}_metadata_file_path"
+
             # Write project metadata file
-            with open(getattr(self, project_metadata_path), "w", newline="") as project_file:
-                project_csv_writer = csv.DictWriter(
-                    project_file, fieldnames=field_names, delimiter=common.TAB
-                )
-                project_csv_writer.writeheader()
-                # Project file data has to be sorted by the library_id.
-                project_csv_writer.writerows(
-                    sorted(
-                        [cm for cm in combined_metadata[modality]],
-                        key=lambda cm: (cm["scpca_sample_id"], cm["scpca_library_id"]),
-                    )
-                )
+            # Project file data has to be sorted by the library_id.
+            combined_metadata[modality].sort(
+                key=lambda cm: (cm["scpca_sample_id"], cm["scpca_library_id"])
+            )
+            project_metadata_path = f"output_{modality.lower()}_metadata_file_path"
+            utils.write_dict_list_to_file(
+                combined_metadata[modality],
+                getattr(self, project_metadata_path),
+                field_names,
+                common.TAB,
+            )
 
         return combined_metadata
 

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -441,6 +441,42 @@ class Project(CommonDataAttributes, TimestampedModel):
                         file_format,
                     ).add_done_callback(create_computed_file)
 
+    @classmethod
+    def get_from_dict(cls, data: Dict):
+        project = cls(
+            scpca_id=data.pop("scpca_project_id"),
+        )
+
+        # Massage keys
+        data["has_bulk_rna_seq"] = data.pop("has_bulk", False)
+        data["has_cite_seq_data"] = data.pop("has_CITE", False)
+        data["has_multiplexed_data"] = data.pop("has_multiplex", False)
+        data["has_spatial_data"] = data.pop("has_spatial", False)
+        data["human_readable_pi_name"] = data.pop("PI", None)
+        data["pi_name"] = data.pop("submitter", None)
+        data["title"] = data.pop("project_title", None)
+
+        # Assign values to remaining properties
+        for key in data.keys():
+            if hasattr(project, key):
+                if key.startswith("includes_") or key.startswith("has_"):
+                    setattr(project, key, utils.boolean_from_string(data.get(key, False)))
+                else:
+                    setattr(project, key, data.get(key))
+
+        # Project needs to be saved and given an id before many-to-manys can be established.
+        project.save()
+
+        project.add_contacts(data.get("contact_email"), data.get("contact_name"))
+        project.add_external_accessions(
+            data.get("external_accession"),
+            data.get("external_accession_url"),
+            data.get("external_accession_raw"),
+        )
+        project.add_publications(data.get("citation"), data.get("citation_doi"))
+
+        return project
+
     def get_bulk_rna_seq_sample_ids(self):
         """Returns set of bulk RNA sequencing sample IDs."""
         bulk_rna_seq_sample_ids = set()
@@ -831,60 +867,13 @@ class Project(CommonDataAttributes, TimestampedModel):
         """Returns an input data directory based on a sample ID."""
         return self.input_data_path / sample_scpca_id
 
-    def assign_project_properties(self, project_properties: Dict) -> None:
-        """
-        Assigns project level properties (parsed from the project's entry in the top level
-        `project_metadata.csv` file) to the current project object, and thene saves the object.
-        """
-        self.abstract = project_properties["abstract"]
-        self.additional_restrictions = project_properties["additional_restrictions"]
-        self.has_bulk_rna_seq = utils.boolean_from_string(project_properties.get("has_bulk", False))
-        self.has_cite_seq_data = utils.boolean_from_string(
-            project_properties.get("has_CITE", False)
-        )
-        self.has_multiplexed_data = utils.boolean_from_string(
-            project_properties.get("has_multiplex", False)
-        )
-        self.has_spatial_data = utils.boolean_from_string(
-            project_properties.get("has_spatial", False)
-        )
-        self.human_readable_pi_name = project_properties["PI"]
-        self.includes_anndata = utils.boolean_from_string(
-            project_properties.get("includes_anndata", False)
-        )
-        self.includes_cell_lines = utils.boolean_from_string(
-            project_properties.get("includes_cell_lines", False)
-        )
-        self.includes_merged_anndata = utils.boolean_from_string(
-            project_properties.get("includes_merged_anndata", False)
-        )
-        self.includes_merged_sce = utils.boolean_from_string(
-            project_properties.get("includes_merged_sce", False)
-        )
-        self.includes_xenografts = utils.boolean_from_string(
-            project_properties.get("includes_xenografts", False)
-        )
-        self.pi_name = project_properties["submitter"]
-        self.title = project_properties["project_title"]
-        self.save()
-
-        self.add_contacts(project_properties["contact_email"], project_properties["contact_name"])
-        self.add_external_accessions(
-            project_properties["external_accession"],
-            project_properties["external_accession_url"],
-            project_properties["external_accession_raw"],
-        )
-        self.add_publications(project_properties["citation"], project_properties["citation_doi"])
-
-    def load_data(self, project_properties: Dict, sample_id: str = None, **kwargs) -> None:
+    def load_data(self, sample_id: str = None, **kwargs) -> None:
         """
         Goes through a project directory's contents, parses multiple level metadata
         files, writes combined metadata into resulting files.
 
         Returns a list of project's computed files.
         """
-        self.assign_project_properties(project_properties)
-
         self.create_anndata_readme_file()
         self.create_anndata_merged_readme_file()
         self.create_multiplexed_readme_file()

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -1248,7 +1248,9 @@ class Project(CommonDataAttributes, TimestampedModel):
                     )
 
                 sample_metadata_path = Sample.get_output_metadata_file_path(sample_id, modality)
-                utils.write_dicts_to_tsv(sample_libraries, sample_metadata_path, field_names)
+                utils.write_dicts_to_file(
+                    sample_libraries, sample_metadata_path, fieldnames=field_names
+                )
 
             # Write project metadata to file
             if modality == Sample.Modalities.MULTIPLEXED:
@@ -1262,10 +1264,10 @@ class Project(CommonDataAttributes, TimestampedModel):
                 key=lambda cm: (cm["scpca_sample_id"], cm["scpca_library_id"]),
             )
             project_metadata_path = f"output_{modality.lower()}_metadata_file_path"
-            utils.write_dicts_to_tsv(
+            utils.write_dicts_to_file(
                 sorted_combined_metadata_by_modality,
                 getattr(self, project_metadata_path),
-                field_names,
+                fieldnames=field_names,
             )
 
     def purge(self, delete_from_s3=False):

--- a/api/scpca_portal/models/publication.py
+++ b/api/scpca_portal/models/publication.py
@@ -1,6 +1,12 @@
+from typing import Dict
+
 from django.db import models
 
+from scpca_portal import common
+from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.models.base import TimestampedModel
+
+logger = get_and_configure_logger(__name__)
 
 
 class Publication(TimestampedModel):
@@ -20,3 +26,43 @@ class Publication(TimestampedModel):
     def doi_url(self):
         """Returns DOI URL."""
         return f"https://doi.org/{self.doi}"
+
+    @classmethod
+    def get_from_dict(cls, data: Dict):
+        publication = cls(
+            doi=data.get("doi"),
+            citation=data.get("citation"),
+            pi_name=data.get("pi_name"),
+        )
+
+        return publication
+
+    @staticmethod
+    def bulk_create_from_project_data(project_data, project):
+        """Creates a list of publication objects and saves them."""
+        citations = [
+            c.strip(common.STRIPPED_INPUT_VALUES)
+            for c in project_data["citation"].split(common.CSV_MULTI_VALUE_DELIMITER)
+        ]
+        dois = [
+            d.strip() for d in project_data["citation_doi"].split(common.CSV_MULTI_VALUE_DELIMITER)
+        ]
+        publications = []
+
+        if len(citations) != len(dois):
+            logger.error("Unable to add ambiguous publications.")
+            return
+
+        for idx, doi in enumerate(dois):
+            if doi in common.IGNORED_INPUT_VALUES:
+                continue
+
+            # Skip if already in db
+            if Publication.objects.filter(doi=doi):
+                continue
+
+            publication_data = {"doi": doi, "citation": citations[idx], "pi_name": project.pi_name}
+            publications.append(Publication.get_from_dict(publication_data))
+
+        Publication.objects.bulk_create(publications)
+        project.publications.add(*publications)

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -100,6 +100,18 @@ class TestFilterDictListByKeys(TestCase):
         self.assertEqual(actual_result, expected_result)
 
 
+class TestGetKeySupersetFromDicts(TestCase):
+    def test_get_key_superset_from_dicts_same_keys(self):
+        list_of_dicts = [{"a": 1, "b": 2, "c": 3}, {"c": 4, "b": 5, "a": 6}]
+        expected_superset = {"a", "b", "c"}
+        self.assertEqual(utils.get_key_superset_from_dicts(list_of_dicts), expected_superset)
+
+    def test_get_key_superset_from_dicts_different_keys(self):
+        list_of_dicts = [{"a": 1, "b": 2, "c": 3}, {"c": 4, "d": 5, "e": 6}]
+        expected_superset = {"a", "b", "c", "d", "e"}
+        self.assertEqual(utils.get_key_superset_from_dicts(list_of_dicts), expected_superset)
+
+
 class TestWriteDictsToFile(TestCase):
     def setUp(self):
         self.dummy_list_of_dicts = [

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -141,7 +141,8 @@ class TestWriteDictsToFile(TestCase):
             )
 
     def test_write_dicts_to_file_not_inputted_field_names(self):
-        pass
+        utils.write_dicts_to_file(self.dummy_list_of_dicts, self.dummy_output_path)
+        self.assertTrue(os.path.exists(self.dummy_output_path))
 
     def test_write_dicts_to_file_invalid_output_file(self):
         invalid_output_file = os.path.join(self.dummy_dir, "invalid", "path", "output.csv")

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from scpca_portal import utils
+from scpca_portal import common, utils
 
 
 class TestBooleanFromString(TestCase):
@@ -100,7 +100,7 @@ class TestFilterDictListByKeys(TestCase):
         self.assertEqual(actual_result, expected_result)
 
 
-class TestWriteDictListToFile(TestCase):
+class TestWriteDictsToTsv(TestCase):
     def setUp(self):
         self.dummy_list_of_dicts = [
             {"country": "USA", "language": "English", "capital": "Washington DC"},
@@ -110,43 +110,37 @@ class TestWriteDictListToFile(TestCase):
         ]
         self.dummy_field_names = {"country", "language", "capital"}
         self.dummy_dir = Path(tempfile.mkdtemp())
-        self.test_output_file = Path(self.dummy_dir, "test_output.tsv")
+        self.dummy_output_file = Path(self.dummy_dir, "dummy_output.tsv")
 
     def tearDown(self):
-        if Path.exists(self.test_output_file):
-            Path.unlink(self.test_output_file)
+        if Path.exists(self.dummy_output_file):
+            Path.unlink(self.dummy_output_file)
         if Path.exists(self.dummy_dir):
             Path.rmdir(self.dummy_dir)
 
-    def test_write_dict_list_to_file_successful_write(self):
-        delimiter = ","
-        utils.write_dict_list_to_file(
-            self.dummy_list_of_dicts, self.test_output_file, self.dummy_field_names, delimiter
+    def test_write_dicts_to_tsv_successful_write(self):
+        utils.write_dicts_to_tsv(
+            self.dummy_list_of_dicts, self.dummy_output_file, self.dummy_field_names
         )
-        self.assertTrue(os.path.exists(self.test_output_file))
+        self.assertTrue(os.path.exists(self.dummy_output_file))
 
-    def test_write_dict_list_to_file_read_write_values_match(self):
-        delimiter = ","
-        utils.write_dict_list_to_file(
-            self.dummy_list_of_dicts, self.test_output_file, self.dummy_field_names, delimiter
+    def test_write_dicts_to_tsv_read_write_values_match(self):
+        utils.write_dicts_to_tsv(
+            self.dummy_list_of_dicts, self.dummy_output_file, self.dummy_field_names
         )
 
-        with open(self.test_output_file) as output_file:
-            output_list_of_dicts = list(csv.DictReader(output_file))
+        with open(self.dummy_output_file) as output_file:
+            output_list_of_dicts = list(csv.DictReader(output_file, delimiter=common.TAB))
             self.assertEqual(self.dummy_list_of_dicts, output_list_of_dicts)
 
-    def test_write_dict_list_to_file_missing_field_names(self):
+    def test_write_dicts_to_tsv_missing_field_names(self):
         field_names = {"country", "language"}
-        delimiter = ","
         with self.assertRaises(ValueError):
-            utils.write_dict_list_to_file(
-                self.dummy_list_of_dicts, self.test_output_file, field_names, delimiter
-            )
+            utils.write_dicts_to_tsv(self.dummy_list_of_dicts, self.dummy_output_file, field_names)
 
-    def test_write_dict_list_to_file_invalid_output_file(self):
+    def test_write_dicts_to_tsv_invalid_output_file(self):
         invalid_output_file = os.path.join(self.dummy_dir, "invalid", "path", "output.csv")
-        delimiter = ","
         with self.assertRaises(FileNotFoundError):
-            utils.write_dict_list_to_file(
-                self.dummy_list_of_dicts, invalid_output_file, self.dummy_field_names, delimiter
+            utils.write_dicts_to_tsv(
+                self.dummy_list_of_dicts, invalid_output_file, self.dummy_field_names
             )

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -162,3 +162,45 @@ class TestWriteDictsToFile(TestCase):
             utils.write_dicts_to_file(
                 self.dummy_list_of_dicts, invalid_output_file, fieldnames=self.dummy_field_names
             )
+
+
+class TestGetCsvZippedValues(TestCase):
+    def test_get_csv_zipped_values_same_length_values(self):
+        data = {
+            "country": "USA;Spain;France;Japan",
+            "language": "English;Spanish;French;Japanese",
+            "capital": "Washington DC;Madrid;Paris;Tokyo",
+        }
+        args = ["country", "language", "capital"]
+
+        expected_result = [
+            ("USA", "English", "Washington DC"),
+            ("Spain", "Spanish", "Madrid"),
+            ("France", "French", "Paris"),
+            ("Japan", "Japanese", "Tokyo"),
+        ]
+        actual_result = utils.get_csv_zipped_values(data, *args)
+
+        self.assertEqual(expected_result, actual_result)
+
+    def test_get_csv_zipped_value_different_length_values(self):
+        data = {
+            "country": "USA;Spain;France;Japan",
+            "language": "English;Spanish;French;Japanese",
+            "capital": "Washington DC;Madrid",
+        }
+        args = ["country", "language", "capital"]
+
+        with self.assertRaises(ValueError):
+            utils.get_csv_zipped_values(data, *args)
+
+    def test_get_csv_zipped_values_keys_not_present(self):
+        data = {
+            "country": "USA;Spain;France;Japan",
+            "language": "English;Spanish;French;Japanese",
+            "capital": "Washington DC;Madrid;Paris;Tokyo",
+        }
+        args = ["country", "language", "population", "currency"]
+
+        with self.assertRaises(AttributeError):
+            utils.get_csv_zipped_values(data, *args)

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -100,7 +100,7 @@ class TestFilterDictListByKeys(TestCase):
         self.assertEqual(actual_result, expected_result)
 
 
-class TestWriteDictsToTsv(TestCase):
+class TestWriteDictsToFile(TestCase):
     def setUp(self):
         self.dummy_list_of_dicts = [
             {"country": "USA", "language": "English", "capital": "Washington DC"},
@@ -110,37 +110,42 @@ class TestWriteDictsToTsv(TestCase):
         ]
         self.dummy_field_names = {"country", "language", "capital"}
         self.dummy_dir = Path(tempfile.mkdtemp())
-        self.dummy_output_file = Path(self.dummy_dir, "dummy_output.tsv")
+        self.dummy_output_path = Path(self.dummy_dir, "dummy_output.tsv")
 
     def tearDown(self):
-        if Path.exists(self.dummy_output_file):
-            Path.unlink(self.dummy_output_file)
+        if Path.exists(self.dummy_output_path):
+            Path.unlink(self.dummy_output_path)
         if Path.exists(self.dummy_dir):
             Path.rmdir(self.dummy_dir)
 
-    def test_write_dicts_to_tsv_successful_write(self):
-        utils.write_dicts_to_tsv(
-            self.dummy_list_of_dicts, self.dummy_output_file, self.dummy_field_names
+    def test_write_dicts_to_file_successful_write(self):
+        utils.write_dicts_to_file(
+            self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=self.dummy_field_names
         )
-        self.assertTrue(os.path.exists(self.dummy_output_file))
+        self.assertTrue(os.path.exists(self.dummy_output_path))
 
-    def test_write_dicts_to_tsv_read_write_values_match(self):
-        utils.write_dicts_to_tsv(
-            self.dummy_list_of_dicts, self.dummy_output_file, self.dummy_field_names
+    def test_write_dicts_to_file_read_write_values_match(self):
+        utils.write_dicts_to_file(
+            self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=self.dummy_field_names
         )
 
-        with open(self.dummy_output_file) as output_file:
+        with open(self.dummy_output_path) as output_file:
             output_list_of_dicts = list(csv.DictReader(output_file, delimiter=common.TAB))
             self.assertEqual(self.dummy_list_of_dicts, output_list_of_dicts)
 
-    def test_write_dicts_to_tsv_missing_field_names(self):
+    def test_write_dicts_to_file_incomplete_field_names(self):
         field_names = {"country", "language"}
         with self.assertRaises(ValueError):
-            utils.write_dicts_to_tsv(self.dummy_list_of_dicts, self.dummy_output_file, field_names)
+            utils.write_dicts_to_file(
+                self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=field_names
+            )
 
-    def test_write_dicts_to_tsv_invalid_output_file(self):
+    def test_write_dicts_to_file_not_inputted_field_names(self):
+        pass
+
+    def test_write_dicts_to_file_invalid_output_file(self):
         invalid_output_file = os.path.join(self.dummy_dir, "invalid", "path", "output.csv")
         with self.assertRaises(FileNotFoundError):
-            utils.write_dicts_to_tsv(
-                self.dummy_list_of_dicts, invalid_output_file, self.dummy_field_names
+            utils.write_dicts_to_file(
+                self.dummy_list_of_dicts, invalid_output_file, fieldnames=self.dummy_field_names
             )

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -58,13 +58,15 @@ def filter_dict_list_by_keys(
     return new_list_of_dicts
 
 
-def write_dicts_to_tsv(
-    list_of_dicts: List[Dict],
-    output_file_name: str,
-    field_names: Set,
-) -> None:
-    """Writes a list of dictionaries to a csv-like file (exact delimiter provided)."""
-    with open(output_file_name, "w", newline="") as raw_file:
-        csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=common.TAB)
+def write_dicts_to_file(list_of_dicts: List[Dict], output_file_path: str, **kwargs) -> None:
+    """
+    Writes a list of dictionaries to a csv-like file.
+    Optional modifiers to the csv.DictWriter can be passed to function as kwargs.
+    """
+    kwargs["fieldnames"] = kwargs.get("fieldnames")
+    kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
+
+    with open(output_file_path, "w", newline="") as raw_file:
+        csv_writer = csv.DictWriter(raw_file, **kwargs)
         csv_writer.writeheader()
         csv_writer.writerows(list_of_dicts)

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -1,9 +1,12 @@
 """Misc utils."""
 import csv
 from datetime import datetime
-from typing import Dict, List, Set
+from typing import Dict, Iterable, List, Set
 
 from scpca_portal import common
+from scpca_portal.config.logging import get_and_configure_logger
+
+logger = get_and_configure_logger(__name__)
 
 
 def boolean_from_string(value: str) -> bool:
@@ -79,3 +82,29 @@ def write_dicts_to_file(list_of_dicts: List[Dict], output_file_path: str, **kwar
         csv_writer = csv.DictWriter(raw_file, **kwargs)
         csv_writer.writeheader()
         csv_writer.writerows(list_of_dicts)
+
+
+def get_csv_zipped_values(
+    data: Dict,
+    *args: str,
+    delimiter: str = common.CSV_MULTI_VALUE_DELIMITER,
+    model_name: str = None,
+) -> Iterable:
+    """
+    Splits a collection of concatenated strings into new iterables,
+    zips together the values within the new iterables which share the same index,
+    and returns the zipped values.
+    """
+    zipped_values = []
+
+    try:
+        zipped_values = zip(*(data.get(key).split(delimiter) for key in args), strict=True)
+    except ValueError:
+        if model_name:
+            logger.error(
+                f"Zip Error: iterables of non-equal lengths, unable to add {model_name} objects."
+            )
+        else:
+            logger.error(ValueError)
+
+    return zipped_values

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -1,4 +1,5 @@
 """Misc utils."""
+import csv
 from datetime import datetime
 from typing import Dict, List, Set
 
@@ -53,3 +54,15 @@ def filter_dict_list_by_keys(
         new_list_of_dicts.append(dictionary_copy)
 
     return new_list_of_dicts
+
+
+def write_dict_list_to_file(
+    list_of_dicts: List[Dict],
+    output_file_name: str,
+    field_names: Set,
+    delimiter: str,
+) -> None:
+    with open(output_file_name, "w", newline="") as raw_file:
+        csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=delimiter)
+        csv_writer.writeheader()
+        csv_writer.writerows(list_of_dicts)

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -58,12 +58,21 @@ def filter_dict_list_by_keys(
     return new_list_of_dicts
 
 
+def get_key_superset_from_dicts(list_of_dicts: List[Dict]) -> Set:
+    """Extracts each provided dictionary's key set and returns the superset of all key sets."""
+    key_superset = set()
+    for dictionary in list_of_dicts:
+        key_superset.update(set(dictionary.keys()))
+
+    return key_superset
+
+
 def write_dicts_to_file(list_of_dicts: List[Dict], output_file_path: str, **kwargs) -> None:
     """
     Writes a list of dictionaries to a csv-like file.
     Optional modifiers to the csv.DictWriter can be passed to function as kwargs.
     """
-    kwargs["fieldnames"] = kwargs.get("fieldnames")
+    kwargs["fieldnames"] = kwargs.get("fieldnames", get_key_superset_from_dicts(list_of_dicts))
     kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
 
     with open(output_file_path, "w", newline="") as raw_file:

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -1,7 +1,7 @@
 """Misc utils."""
 import csv
 from datetime import datetime
-from typing import Dict, Iterable, List, Set
+from typing import Dict, List, Set
 
 from scpca_portal import common
 from scpca_portal.config.logging import get_and_configure_logger
@@ -88,23 +88,10 @@ def get_csv_zipped_values(
     data: Dict,
     *args: str,
     delimiter: str = common.CSV_MULTI_VALUE_DELIMITER,
-    model_name: str = None,
-) -> Iterable:
+) -> List:
     """
     Splits a collection of concatenated strings into new iterables,
     zips together the values within the new iterables which share the same index,
-    and returns the zipped values.
+    and returns the zipped values as a list.
     """
-    zipped_values = []
-
-    try:
-        zipped_values = zip(*(data.get(key).split(delimiter) for key in args), strict=True)
-    except ValueError:
-        if model_name:
-            logger.error(
-                f"Zip Error: iterables of non-equal lengths, unable to add {model_name} objects."
-            )
-        else:
-            logger.error(ValueError)
-
-    return zipped_values
+    return list(zip(*(data.get(key).split(delimiter) for key in args), strict=True))

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -62,6 +62,7 @@ def write_dict_list_to_file(
     field_names: Set,
     delimiter: str,
 ) -> None:
+    """Writes a list of dictionaries to a csv-like file (exact delimiter provided)."""
     with open(output_file_name, "w", newline="") as raw_file:
         csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=delimiter)
         csv_writer.writeheader()

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -1,8 +1,9 @@
 """Misc utils."""
 from datetime import datetime
+from typing import Dict, List, Set
 
 
-def boolean_from_string(value):
+def boolean_from_string(value: str) -> bool:
     """
     Returns True if string value represents truthy value. Otherwise returns False.
     Raises ValueError if value cannot be casted to boolean.
@@ -19,18 +20,20 @@ def boolean_from_string(value):
     return value.lower() in ("t", "true")
 
 
-def join_workflow_versions(workflow_versions):
+def join_workflow_versions(workflow_versions: Set) -> str:
     """Returns list of sorted unique workflow versions."""
 
     return ", ".join(sorted(set(workflow_versions)))
 
 
-def get_today_string(format: str = "%Y-%m-%d"):
+def get_today_string(format: str = "%Y-%m-%d") -> str:
     """Returns today's date formatted. Defaults to ISO 8601."""
     return datetime.today().strftime(format)
 
 
-def filter_dict_list_by_keys(list_of_dicts, included_keys, *, ignore_value_error=True):
+def filter_dict_list_by_keys(
+    list_of_dicts: List[Dict], included_keys: Set, *, ignore_value_error: bool = True
+) -> List[Dict]:
     """
     Returns a list of dictionaries with keys filtered according to provided include_keys.
     If included-keys are not a subset of dictionary keys, returns a ValueError.

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -86,7 +86,7 @@ def write_dicts_to_file(list_of_dicts: List[Dict], output_file_path: str, **kwar
 
 def get_csv_zipped_values(
     data: Dict,
-    *args: str,
+    *args: List[str],
     delimiter: str = common.CSV_MULTI_VALUE_DELIMITER,
 ) -> List:
     """

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -3,6 +3,8 @@ import csv
 from datetime import datetime
 from typing import Dict, List, Set
 
+from scpca_portal import common
+
 
 def boolean_from_string(value: str) -> bool:
     """
@@ -56,14 +58,13 @@ def filter_dict_list_by_keys(
     return new_list_of_dicts
 
 
-def write_dict_list_to_file(
+def write_dicts_to_tsv(
     list_of_dicts: List[Dict],
     output_file_name: str,
     field_names: Set,
-    delimiter: str,
 ) -> None:
     """Writes a list of dictionaries to a csv-like file (exact delimiter provided)."""
     with open(output_file_name, "w", newline="") as raw_file:
-        csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=delimiter)
+        csv_writer = csv.DictWriter(raw_file, fieldnames=field_names, delimiter=common.TAB)
         csv_writer.writeheader()
         csv_writer.writerows(list_of_dicts)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/694

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR addresses a design improvement of moving the assignment of project-level properties (to the active project object) from the `load_data` command to `Project::load_data`. 

From an implementation perspective, the necessary changes include moving the `load_data::process_project_data` function to the `Project` model, and sending in, as an additional argument to `Project::load_data`, the project-level properties dictionary (which is parsed from the top-level `project_metadata.csv` file that `load_data::load_data` uses to create the `Project` objects to begin with).


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A