### PR TITLE
Consolidate readme file creation inside of Project::load_data

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -203,6 +203,17 @@ class Project(CommonDataAttributes, TimestampedModel):
         sample_metadata["project_title"] = self.title
         sample_metadata["scpca_project_id"] = self.scpca_id
 
+    def create_readmes(self) -> None:
+        """
+        Creates all possible readmes to be included later when archiving the desired computed file.
+        """
+        self.create_anndata_readme_file()
+        self.create_anndata_merged_readme_file()
+        self.create_multiplexed_readme_file()
+        self.create_single_cell_readme_file()
+        self.create_single_cell_merged_readme_file()
+        self.create_spatial_readme_file()
+
     def create_anndata_readme_file(self):
         """Creates an annotation metadata README file."""
         with open(ComputedFile.README_ANNDATA_FILE_PATH, "w") as readme_file:
@@ -782,12 +793,7 @@ class Project(CommonDataAttributes, TimestampedModel):
 
         Returns a list of project's computed files.
         """
-        self.create_anndata_readme_file()
-        self.create_anndata_merged_readme_file()
-        self.create_multiplexed_readme_file()
-        self.create_single_cell_readme_file()
-        self.create_single_cell_merged_readme_file()
-        self.create_spatial_readme_file()
+        self.create_readmes()
 
         combined_metadata = self.handle_samples_metadata(sample_id)
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Simple addition to thin out `Project::load_data` by a few lines. 

Consolidates all `self.create_<type>_readme_file` methods into a single method called `create_readmes`.

## Types of changes

What types of changes does your code introduce?


<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes

## Screenshots

N/A
