### PR TITLE
Remove left over reference to self.project in load_data::clean_up_input_data

### DIFF
--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -139,8 +139,8 @@ class Command(BaseCommand):
             "--update-s3", action=BooleanOptionalAction, default=settings.UPDATE_S3_DATA
         )
 
-    def clean_up_input_data(self):
-        shutil.rmtree(common.INPUT_DATA_PATH / self.project.scpca_id, ignore_errors=True)
+    def clean_up_input_data(self, project):
+        shutil.rmtree(common.INPUT_DATA_PATH / project.scpca_id, ignore_errors=True)
 
     def handle(self, *args, **kwargs):
         self.configure_aws_cli(**kwargs)
@@ -220,7 +220,7 @@ class Command(BaseCommand):
 
             if kwargs["clean_up_input_data"]:
                 logger.info(f"Cleaning up '{project}' input data")
-                self.clean_up_input_data()
+                self.clean_up_input_data(project)
 
             if kwargs["clean_up_output_data"]:
                 logger.info("Cleaning up output directory")


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

During the recent refactor of `Project::load_data`, project property assignments, which were previously carried out inside of `load_data::load_data`, were converted into a factory method and moved to the project model. During this refactor, all references to `self.project` were removed. It came up that one reference was left by accident, inside of `load_data::clean_up_input_data`, and that is what was cleaned up in this PR.


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes

## Screenshots

N/A