### PR TITLE
Hotfix: add check for seq-units

### DIFF
--- a/client/src/components/ProjectHeader.js
+++ b/client/src/components/ProjectHeader.js
@@ -62,9 +62,7 @@ export const ProjectHeader = ({ project, linked = false }) => {
             badge="Samples"
             label={`${project.downloadable_sample_count} Downloadable Samples`}
           />
-          {project.seq_units && (
-            <Badge badge="SeqUnit" label={capitalize(project.seq_units)} />
-          )}
+          <Badge badge="SeqUnit" label={capitalize(project.seq_units || '')} />
           <Badge badge="Kit" label={project.technologies} />
           {project.modalities.length > 0 && (
             <Badge badge="Modality" label={project.modalities.join(', ')} />

--- a/client/src/components/ProjectHeader.js
+++ b/client/src/components/ProjectHeader.js
@@ -62,7 +62,9 @@ export const ProjectHeader = ({ project, linked = false }) => {
             badge="Samples"
             label={`${project.downloadable_sample_count} Downloadable Samples`}
           />
-          <Badge badge="SeqUnit" label={capitalize(project.seq_units)} />
+          {project.seq_units && (
+            <Badge badge="SeqUnit" label={capitalize(project.seq_units)} />
+          )}
           <Badge badge="Kit" label={project.technologies} />
           {project.modalities.length > 0 && (
             <Badge badge="Modality" label={project.modalities.join(', ')} />


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

As a general policy we should prevent the client from breaking entirely on the browse page when data is malformed.

When loading a specific project (or currently if a project is partially processed) it is possible for `seq_units` to be `null` though we shouldn't really expect this to be the case. This PR adds a fallback to a value that is parsed on the client.

Specifically here, If one project has `seq_units` null then the client crashes making it impossible to download any projects.

I think a future and more robust fix would be having a type of state attribute on the project model that allows us to filter out processing or malformed projects via the API endpoint so only "good" projects are returned. This fix would safely be removable at that point. 


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A tested locally

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
