### PR TITLE
711 - Create library model factory method and add it to Project::load_data

### DIFF
--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -34,3 +34,16 @@ class Library(TimestampedModel):
     modality = models.TextField(choices=Modalities.CHOICES)
     scpca_id = models.TextField(unique=True)
     workflow_version = models.TextField()
+
+    @classmethod
+    def get_from_dict(cls, data, formats, is_multiplexed, modality):
+        library = cls(
+            formats=formats,
+            is_multiplexed=is_multiplexed,
+            metadata=data,
+            modality=modality,
+            scpca_id=data["library_id"],
+            workflow_version=data["workflow_version"],
+        )
+
+        return library

--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -49,7 +49,7 @@ class Library(TimestampedModel):
                 if "filtered_cell_count" in data
                 else Library.Modalities.SPATIAL
             ),
-            scpca_id=data["library_id"],
+            scpca_id=data["scpca_library_id"],
             workflow_version=data["workflow_version"],
         )
 
@@ -66,8 +66,7 @@ class Library(TimestampedModel):
                 if any(sample_dir.glob("*.h5ad")):
                     formats.append(Library.FileFormats.ANN_DATA)
             else:
-                if any(sample_dir.glob("*_spatial/*.rds")):
-                    formats.append(Library.FileFormats.SINGLE_CELL_EXPERIMENT)
+                formats.append(Library.FileFormats.SINGLE_CELL_EXPERIMENT)
 
             libraries.append(Library.get_from_dict(library_json, formats))
 

--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Dict, List
+
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
@@ -36,14 +39,37 @@ class Library(TimestampedModel):
     workflow_version = models.TextField()
 
     @classmethod
-    def get_from_dict(cls, data, formats, is_multiplexed, modality):
+    def get_from_dict(cls, data, formats):
         library = cls(
             formats=formats,
-            is_multiplexed=is_multiplexed,
+            is_multiplexed=("demux_samples" in data),
             metadata=data,
-            modality=modality,
+            modality=(
+                Library.Modalities.SINGLE_CELL
+                if "filtered_cell_count" in data
+                else Library.Modalities.SPATIAL
+            ),
             scpca_id=data["library_id"],
             workflow_version=data["workflow_version"],
         )
 
         return library
+
+    @classmethod
+    def bulk_create_from_dicts(cls, library_jsons: List[Dict], sample, sample_dir: Path) -> None:
+        libraries = []
+        for library_json in library_jsons:
+            formats = []
+            if "filtered_cell_count" in library_json:
+                if any(sample_dir.glob("*.rds")):
+                    formats.append(Library.FileFormats.SINGLE_CELL_EXPERIMENT)
+                if any(sample_dir.glob("*.h5ad")):
+                    formats.append(Library.FileFormats.ANN_DATA)
+            else:
+                if any(sample_dir.glob("*_spatial/*.rds")):
+                    formats.append(Library.FileFormats.SINGLE_CELL_EXPERIMENT)
+
+            libraries.append(Library.get_from_dict(library_json, formats))
+
+        Library.objects.bulk_create(libraries)
+        sample.libraries.add(*libraries)

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -858,7 +858,6 @@ class Project(CommonDataAttributes, TimestampedModel):
         return samples_metadata
 
     def load_libraries_metadata(self, samples_metadata: List[Dict]):
-
         libraries_metadata = {
             Sample.Modalities.SINGLE_CELL: [],
             Sample.Modalities.SPATIAL: [],
@@ -880,15 +879,13 @@ class Project(CommonDataAttributes, TimestampedModel):
 
             single_cell_metadata_paths = set(Path(sample_dir).glob("*_metadata.json"))
             spatial_metadata_paths = set(Path(sample_dir).rglob("*_spatial/*_metadata.json"))
-
             library_metadata_paths = list(single_cell_metadata_paths | spatial_metadata_paths)
-            all_libraries_metadata = [
-                metadata_file.load_library_metadata(path) for path in library_metadata_paths
-            ]
+            all_libraries_metadata = []
 
-            for library_metadata, library_path in zip(
-                all_libraries_metadata, library_metadata_paths
-            ):
+            for library_path in library_metadata_paths:
+                library_metadata = metadata_file.load_library_metadata(library_path)
+                all_libraries_metadata.append(library_metadata)
+
                 if library_path in single_cell_metadata_paths:
                     sample_cell_count_estimate += library_metadata["filtered_cell_count"]
                     libraries_metadata[Sample.Modalities.SINGLE_CELL].append(library_metadata)

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -426,12 +426,7 @@ class Project(CommonDataAttributes, TimestampedModel):
         """
         multiplexed_libraries_metadata = []
         for filename_path in sorted(Path(self.input_data_path).rglob("*,*/*_metadata.json")):
-            with open(filename_path) as multiplexed_json_file:
-                multiplexed_json = json.load(multiplexed_json_file)
-
-            multiplexed_json["scpca_library_id"] = multiplexed_json.pop("library_id")
-            multiplexed_json["scpca_sample_id"] = multiplexed_json.pop("sample_id")
-
+            multiplexed_json = metadata_file.load_library_metadata(filename_path)
             multiplexed_libraries_metadata.append(multiplexed_json)
 
         return multiplexed_libraries_metadata

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -66,12 +66,6 @@ class Sample(CommonDataAttributes, TimestampedModel):
     def get_from_dict(cls, data, project):
         """Prepares ready for saving sample object."""
 
-        # If any project metadata exists in provided data dict, remove it
-        if any(key in data for key in ["scpca_project_id", "project_title", "pi_name"]):
-            data.pop("scpca_project_id", None)
-            data.pop("project_title", None)
-            data.pop("pi_name", None)
-
         sample = cls(
             age_at_diagnosis=data["age_at_diagnosis"],
             demux_cell_count_estimate=(data.get("demux_cell_count_estimate", None)),
@@ -85,14 +79,10 @@ class Sample(CommonDataAttributes, TimestampedModel):
             includes_anndata=data.get("includes_anndata", False),
             is_cell_line=utils.boolean_from_string(data.get("is_cell_line", False)),
             is_xenograft=utils.boolean_from_string(data.get("is_xenograft", False)),
-            multiplexed_with=data.get("multiplexed_with", None),
-            sample_cell_count_estimate=(
-                data.get("sample_cell_count_estimate", None)
-                if not data.get("has_multiplexed_data", False)
-                else None
-            ),
+            multiplexed_with=data.get("multiplexed_with", []),
+            sample_cell_count_estimate=(data.get("sample_cell_count_estimate", None)),
             project=project,
-            scpca_id=data.pop("scpca_sample_id"),
+            scpca_id=data.get("scpca_sample_id"),
             seq_units=data.get("seq_units", ""),
             sex=data["sex"],
             subdiagnosis=data["subdiagnosis"],
@@ -104,7 +94,13 @@ class Sample(CommonDataAttributes, TimestampedModel):
         # Additional metadata varies project by project.
         # Generally, whatever's not on the Sample model is additional.
         sample.additional_metadata = {
-            key: value for key, value in data.items() if not hasattr(sample, key)
+            key: value
+            for key, value in data.items()
+            if not hasattr(sample, key)
+            # Don't include project metadata keys (needed for writing)
+            and key not in ("scpca_project_id", "project_title", "pi_name")
+            # Deliberate model attribute and file field name mismatch
+            and key != "scpca_sample_id"
         }
 
         return sample

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -57,7 +57,7 @@ class Sample(CommonDataAttributes, TimestampedModel):
     treatment = models.TextField(blank=True, null=True)
 
     project = models.ForeignKey("Project", on_delete=models.CASCADE, related_name="samples")
-    libraries = models.ManyToManyField(Library)
+    libraries = models.ManyToManyField(Library, related_name="samples")
 
     def __str__(self):
         return f"Sample {self.scpca_id} of {self.project}"
@@ -99,7 +99,7 @@ class Sample(CommonDataAttributes, TimestampedModel):
             if not hasattr(sample, key)
             # Don't include project metadata keys (needed for writing)
             and key not in ("scpca_project_id", "project_title", "pi_name")
-            # Deliberate model attribute and file field name mismatch
+            # Exclude deliberate model attribute and file field name mismatch
             and key != "scpca_sample_id"
         }
 

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -85,9 +85,9 @@ class Sample(CommonDataAttributes, TimestampedModel):
             includes_anndata=data.get("includes_anndata", False),
             is_cell_line=utils.boolean_from_string(data.get("is_cell_line", False)),
             is_xenograft=utils.boolean_from_string(data.get("is_xenograft", False)),
-            multiplexed_with=data.get("multiplexed_with"),
+            multiplexed_with=data.get("multiplexed_with", None),
             sample_cell_count_estimate=(
-                data.get("sample_cell_count_estimate")
+                data.get("sample_cell_count_estimate", None)
                 if not data.get("has_multiplexed_data", False)
                 else None
             ),

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -430,7 +430,7 @@ class TestLoadData(TransactionTestCase):
             "disease_ontology_term_id",
             "droplet_filtering_method",
             "filtered_cell_count",  # with non-multiplexed
-            "filtered_cells",
+            # "filtered_cells",
             "has_cellhash",
             "includes_anndata",
             "is_cell_line",

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -430,7 +430,6 @@ class TestLoadData(TransactionTestCase):
             "disease_ontology_term_id",
             "droplet_filtering_method",
             "filtered_cell_count",  # with non-multiplexed
-            # "filtered_cells",
             "has_cellhash",
             "includes_anndata",
             "is_cell_line",


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/711

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR takes the creation the `Library` model forward from PR https://github.com/AlexsLemonade/scpca-portal/pull/720 and begins to implement it. 

The following three items are included in the current PR:

- `Library::get_from_dict` and `Library::bulk_create_from_dicts` methods are built, similar to those in the `Sample` model. These methods are responsible for building a collection of new `Library` objects, and saving them to the db.
- The building of `Library` objects is added to `Project::load_libraries_metadata`. In order to accommodate this, the building and creating of `Sample` objects is moved from the end of `Project::handle_samples_metadata` to `Project::load_samples_metadata`, which in any case is a more appropriate place for this activity. This change was important in order that `Sample` objects should be built before `Library` objects so that the new `Library` objects could be related to the already created `Sample` objects.
- The updating of `Project` purging logic in `Project::purge` to include the purging of related `Library` objects from the db.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

Still need to be written.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Screenshots

N/A