### PR TITLE
729 - Add new ontology columns to METADATA_COLUMN_SORT_ORDER list

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -27,7 +27,7 @@ STRIPPED_INPUT_VALUES = "< >"
 # Columns
 METADATA_COLUMN_SORT_ORDER = [
     "scpca_project_id",
-    # sample metadata
+    # Sample metadata
     "scpca_sample_id",
     "scpca_library_id",
     "diagnosis",
@@ -40,6 +40,12 @@ METADATA_COLUMN_SORT_ORDER = [
     "submitter",
     "submitter_id",
     "organism",
+    "development_stage_ontology_term_id",
+    "sex_ontology_term_id",
+    "organism_ontology_id",
+    "self_reported_ethnicity_ontology_term_id",
+    "disease_ontology_term_id",
+    "tissue_ontology_term_id",
     "*",  # Addtional metadata
     # Library metadata
     "seq_unit",

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -411,14 +411,14 @@ class TestLoadData(TransactionTestCase):
             "submitter",
             "submitter_id",
             "organism",
-            "demux_samples",
             "development_stage_ontology_term_id",
-            "disease_ontology_term_id",
-            "filtered_cells",
+            "sex_ontology_term_id",
             "organism_ontology_id",
             "self_reported_ethnicity_ontology_term_id",
-            "sex_ontology_term_id",
+            "disease_ontology_term_id",
             "tissue_ontology_term_id",
+            "demux_samples",
+            "filtered_cells",
             "WHO_grade",
             "seq_unit",
             "technology",
@@ -556,14 +556,14 @@ class TestLoadData(TransactionTestCase):
             "submitter",
             "submitter_id",
             "organism",
-            "demux_samples",
             "development_stage_ontology_term_id",
-            "disease_ontology_term_id",
-            "filtered_cells",
+            "sex_ontology_term_id",
             "organism_ontology_id",
             "self_reported_ethnicity_ontology_term_id",
-            "sex_ontology_term_id",
+            "disease_ontology_term_id",
             "tissue_ontology_term_id",
+            "demux_samples",
+            "filtered_cells",
             "WHO_grade",
             "seq_unit",
             "technology",
@@ -595,7 +595,6 @@ class TestLoadData(TransactionTestCase):
             "workflow_version",
             "workflow_commit",
         ]
-
         sample_zip_path = common.OUTPUT_DATA_PATH / sample.output_multiplexed_computed_file_name
         with ZipFile(sample_zip_path) as sample_zip:
             with sample_zip.open(
@@ -688,10 +687,10 @@ class TestLoadData(TransactionTestCase):
             "submitter_id",
             "organism",
             "development_stage_ontology_term_id",
-            "disease_ontology_term_id",
+            "sex_ontology_term_id",
             "organism_ontology_id",
             "self_reported_ethnicity_ontology_term_id",
-            "sex_ontology_term_id",
+            "disease_ontology_term_id",
             "tissue_ontology_term_id",
             "WHO_grade",
             "seq_unit",
@@ -916,10 +915,10 @@ class TestLoadData(TransactionTestCase):
             "submitter_id",
             "organism",
             "development_stage_ontology_term_id",
-            "disease_ontology_term_id",
+            "sex_ontology_term_id",
             "organism_ontology_id",
             "self_reported_ethnicity_ontology_term_id",
-            "sex_ontology_term_id",
+            "disease_ontology_term_id",
             "tissue_ontology_term_id",
             "WHO_grade",
             "seq_unit",
@@ -939,7 +938,6 @@ class TestLoadData(TransactionTestCase):
             "workflow_version",
             "workflow_commit",
         ]
-
         project_zip_path = common.OUTPUT_DATA_PATH / project.output_spatial_computed_file_name
         with ZipFile(project_zip_path) as project_zip:
             spatial_metadata_file = project_zip.read(

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -135,9 +135,9 @@ class TestGetSortedFieldNames(TestCase):
             "subdiagnosis",
             "submitter_id",
             "organism",
-            "location_class",
             "organism_ontology_id",
             "tissue_ontology_term_id",
+            "location_class",
             "WHO_grade",
             "technology",
         ]


### PR DESCRIPTION
## Issue Number
Closing #729 

## Purpose/Implementation Notes
I've added the new ontology columns to `METADATA_COLUMN_SORT_ORDER` and adjusted the tests. 

**Question:** should we remove those newly added ontology columns from the expected additional metadata keys in `TestLoadData`? Thank you, David!


## Types of changes
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

