### PR TITLE
make computed file str method safe for no modality

### DIFF
--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -99,8 +99,8 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
     def __str__(self):
         return (
             f"'{self.project or self.sample}' "
-            f"{dict(self.OutputFileModalities.CHOICES)[self.modality]} "
-            f"{dict(self.OutputFileFormats.CHOICES)[self.format]} "
+            f"{dict(self.OutputFileModalities.CHOICES).get(self.modality, 'No Modality')} "
+            f"{dict(self.OutputFileFormats.CHOICES).get(self.format, 'No Format')} "
             f"computed file ({self.size_in_bytes}B)"
         )
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Hotfix to address the possibility that a computed file may not have a modality when the str dunder method is called. This was preventing uploads of metadata only downloads.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
