### PR TITLE
Project Metadata Download Feedback

### DIFF
--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -26,6 +26,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
     class MetadataFilenames:
         SINGLE_CELL_METADATA_FILE_NAME = "single_cell_metadata.tsv"
         SPATIAL_METADATA_FILE_NAME = "spatial_metadata.tsv"
+        METADATA_ONLY_FILE_NAME = "metadata.tsv"
 
     class OutputFileModalities:
         SINGLE_CELL = "SINGLE_CELL"
@@ -544,6 +545,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             return ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME
         if self.is_project_spatial_zip:
             return ComputedFile.MetadataFilenames.SPATIAL_METADATA_FILE_NAME
+        return ComputedFile.MetadataFilenames.METADATA_ONLY_FILE_NAME
 
     @property
     def zip_file_path(self):

--- a/api/scpca_portal/templates/readme/metadata_only.md
+++ b/api/scpca_portal/templates/readme/metadata_only.md
@@ -9,7 +9,9 @@ The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a d
 {% if included_projects|length > 1 %}
 This download includes associated metadata for samples from all projects currently available at time of download in the ScPCA portal.
 {% else %}
+{% for project_accession, project_url in included_projects %}
 This download includes associated metadata for samples from project [{{ project_accession }}]({{ project_url }}) in the ScPCA portal.
+{% endfor %}
 {% endif %}
 
 The metadata included in this download contains sample, library, and project-related metadata (e.g., age, sex, diagnosis, sequencing unit, etc.) along with any relevant processing metadata (e.g., software versions, filtering methods used, etc.).


### PR DESCRIPTION
## Issue Number

#738 

## Purpose/Implementation Notes

- The readme template for metadata only downloads didn't handle the list of projects correctly when a single project was being created, this fixes that by putting it in a loop (that iterates one time).
- `computed_file.metadata_file_name` was returning `None` when the modality wasn't set. This was addressed by having a default of `metadata.tsv` so we don't end up copying the entire source path into the zip file.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
