### PR TITLE
740 - Project and Sample Create Computed Files Driver Methods

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -364,8 +364,7 @@ class Project(CommonDataAttributes, TimestampedModel):
         """Prepares ready for saving project computed files based on generated file mappings."""
 
         def on_get_project_file(future):
-            computed_file = future.result()
-            if computed_file:
+            if computed_file := future.result():
                 computed_file.process_computed_file(clean_up_output_data, update_s3)
 
         with ThreadPoolExecutor(max_workers=max_workers) as tasks:

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -107,6 +107,34 @@ class Project(CommonDataAttributes, TimestampedModel):
             pass
 
     @property
+    def output_all_metadata_computed_file_name(self):
+        return f"{self.scpca_id}_all_metadata.zip"
+
+    @property
+    def output_merged_computed_file_name(self):
+        return f"{self.scpca_id}_merged.zip"
+
+    @property
+    def output_merged_anndata_computed_file_name(self):
+        return f"{self.scpca_id}_merged_anndata.zip"
+
+    @property
+    def output_multiplexed_computed_file_name(self):
+        return f"{self.scpca_id}_multiplexed.zip"
+
+    @property
+    def output_single_cell_computed_file_name(self):
+        return f"{self.scpca_id}.zip"
+
+    @property
+    def output_single_cell_anndata_computed_file_name(self):
+        return f"{self.scpca_id}_anndata.zip"
+
+    @property
+    def output_spatial_computed_file_name(self):
+        return f"{self.scpca_id}_spatial.zip"
+
+    @property
     def output_all_metadata_file_path(self):
         return common.OUTPUT_DATA_PATH / f"{self.scpca_id}_all_metadata.tsv"
 

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -147,10 +147,13 @@ class Sample(CommonDataAttributes, TimestampedModel):
 
         return sample_metadata
 
-    def get_lock_name(self, download_config: Dict) -> str:
-        """Returns a unique lock name based on multiplexed status and download config"""
-        lock_prefix = self.scpca_id if not self.is_multiplexed else "_".join(self.multiplexed_ids)
-        return f'{lock_prefix}-{download_config["modality"]}-{download_config["format"]}'
+    def get_config_identifier(self, download_config: Dict) -> str:
+        """
+        Returns a unique identifier for the sample and download config combination.
+        Multiplexed samples are not considered unique as they share the same output.
+        """
+        ids = [self.scpca_id] if not self.has_multiplexed_data else self.multiplexed_ids
+        return "_".join(ids + sorted(download_config.values()))
 
     @staticmethod
     def get_output_metadata_file_path(scpca_sample_id, modality):
@@ -306,7 +309,7 @@ class Sample(CommonDataAttributes, TimestampedModel):
         with ThreadPoolExecutor(max_workers=max_workers) as tasks:
             for sample in samples:
                 for config in common.GENERATED_SAMPLE_DOWNLOAD_CONFIGURATIONS:
-                    sample_lock = locks.setdefault(sample.get_lock_name(config), Lock())
+                    sample_lock = locks.setdefault(sample.get_config_identifier(config), Lock())
                     tasks.submit(
                         ComputedFile.get_sample_file,
                         self,

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -291,8 +291,7 @@ class Sample(CommonDataAttributes, TimestampedModel):
         """Prepares ready for saving project computed files based on generated file mappings."""
 
         def on_get_sample_file(future):
-            computed_file = future.result()
-            if computed_file:
+            if computed_file := future.result():
                 computed_file.process_computed_file(clean_up_output_data, update_s3)
 
         samples = Sample.objects.filter(project__scpca_id=project.scpca_id)

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -192,6 +192,22 @@ class Sample(CommonDataAttributes, TimestampedModel):
         return sorted(multiplexed_sample_ids)
 
     @property
+    def output_multiplexed_computed_file_name(self):
+        return f"{'_'.join(self.multiplexed_ids)}_multiplexed.zip"
+
+    @property
+    def output_single_cell_computed_file_name(self):
+        return f"{self.scpca_id}.zip"
+
+    @property
+    def output_single_cell_anndata_computed_file_name(self):
+        return f"{self.scpca_id}_anndata.zip"
+
+    @property
+    def output_spatial_computed_file_name(self):
+        return f"{self.scpca_id}_spatial.zip"
+
+    @property
     def output_multiplexed_metadata_file_path(self):
         return Sample.get_output_metadata_file_path(self.scpca_id, Sample.Modalities.MULTIPLEXED)
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/740

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

- Added `Project::create_computed_files` and `Sample::create_computed_files` methods, which utilize iteration over prebaked download configuration to kick of a ThreadPoolExecutor which creates computed files in parallel.
- Added `Project|Sample::get_download_config_file_output_name` method for dynamic naming of zip files.
- Added `Sample::get_lock_name` utility method to abstract lock naming logic.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A