### PR TITLE
Nozomione/751 replace empty field value with na in metadata

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -23,6 +23,7 @@ TAB = "\t"
 IGNORED_INPUT_VALUES = {"", "N/A", "TBD"}
 STRIPPED_INPUT_VALUES = "< >"
 
+NA = "NA"  # A substitute for an empty field value in metadata
 # Global sort order for Metadata TSVs
 # Columns
 METADATA_COLUMN_SORT_ORDER = [

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -95,10 +95,18 @@ def write_metadata_dicts(list_of_dicts: List[Dict], output_file_path: str, **kwa
     kwargs["fieldnames"] = kwargs.get(
         "fieldnames", utils.get_sorted_field_names(utils.get_keys_from_dicts(list_of_dicts))
     )
+
+    updated_list_of_dicts = list_of_dicts.copy()
+    # Replace any empty values with "NA"
+    for d in updated_list_of_dicts:
+        for k, v in d.items():
+            if v == "":
+                d[k] = common.NA
+
     kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
 
     sorted_list_of_dicts = sorted(
-        list_of_dicts,
+        updated_list_of_dicts,
         key=lambda k: (
             k[common.PROJECT_ID_KEY],
             k[common.SAMPLE_ID_KEY],

--- a/api/scpca_portal/test/test_metadata_file.py
+++ b/api/scpca_portal/test/test_metadata_file.py
@@ -39,9 +39,9 @@ class TestWriteMetadataDicts(TestCase):
                 "scpca_project_id": "SCPCP999993",
                 "scpca_sample_id": "SCPCS999993",
                 "scpca_library_id": "SCPCL999993",
-                "country": "Japan",
-                "language": "Japanese",
-                "capital": "Tokyo",
+                "country": "Antarctica",
+                "language": "Antarctic English",
+                "capital": "",
             },
         ]
         self.dummy_field_names = {
@@ -75,6 +75,17 @@ class TestWriteMetadataDicts(TestCase):
         with open(self.dummy_output_path) as output_file:
             output_list_of_dicts = list(csv.DictReader(output_file, delimiter=common.TAB))
             self.assertEqual(self.dummy_list_of_dicts, output_list_of_dicts)
+
+    def test_write_metadata_dicts_read_write_no_empty_values(self):
+        field_name = "capital"
+        item = 3
+        metadata_file.write_metadata_dicts(
+            self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=self.dummy_field_names
+        )
+
+        with open(self.dummy_output_path) as output_file:
+            output_list_of_dicts = list(csv.DictReader(output_file, delimiter=common.TAB))
+            self.assertEqual(common.NA, output_list_of_dicts[item][field_name])
 
     def test_write_metadata_dicts_incomplete_field_names(self):
         field_names = {"country", "language"}


### PR DESCRIPTION
## Issue Numbe
Closing #751 

## Purpose/Implementation Notes
Some fields in the download metadata file may not have values, and for consistency, these empty values should be replaced with "NA". This PR achieves this.

The following changes are made:
- Added `common.NA`
- Iterate over the given list of dictionaries and replace empty field values (`""`) with `common.NA` in `metadata_file.write_metadata_dicts`

## Types of changes
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests
N/A

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
N/A