### PR TITLE
778 - Presenting sample sample_cell_estimates per sample in output metadata file

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -63,7 +63,7 @@ METADATA_COLUMN_SORT_ORDER = [
     "total_reads",
     "mapped_reads",
     "sample_cell_count_estimate",
-    "sample_cell_estimates",  # ONLY FOR MULTIPLEXED
+    "sample_cell_estimate",  # ONLY FOR MULTIPLEXED
     "unfiltered_cells",
     "filtered_cell_count",
     "processed_cells",

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -96,7 +96,6 @@ def write_metadata_dicts(list_of_dicts: List[Dict], output_file_path: str, **kwa
         "fieldnames", utils.get_sorted_field_names(utils.get_keys_from_dicts(list_of_dicts))
     )
     kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
-    kwargs["restval"] = kwargs.get("restval", "NA")
 
     sorted_list_of_dicts = sorted(
         list_of_dicts,

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -96,6 +96,7 @@ def write_metadata_dicts(list_of_dicts: List[Dict], output_file_path: str, **kwa
         "fieldnames", utils.get_sorted_field_names(utils.get_keys_from_dicts(list_of_dicts))
     )
     kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
+    kwargs["restval"] = kwargs.get("restval", "NA")
 
     sorted_list_of_dicts = sorted(
         list_of_dicts,

--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -179,6 +179,8 @@ class Library(TimestampedModel):
         excluded_metadata_attributes = {
             "scpca_sample_id",
             "has_citeseq",
+            # for multiplexed samples, this is handled at the sample level
+            "sample_cell_estimates",
         }
 
         library_metadata.update(
@@ -202,7 +204,7 @@ class Library(TimestampedModel):
             if self.modality == Library.Modalities.SPATIAL or self.is_multiplexed:
                 del metadata["sample_cell_count_estimate"]
             if not self.is_multiplexed:
-                del metadata["sample_cell_estimates"]
+                del metadata["sample_cell_estimate"]
 
             combined_metadatas.append(metadata)
 

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -127,7 +127,7 @@ class Sample(CommonDataAttributes, TimestampedModel):
 
         sample_metadata.update({key: getattr(self, key) for key in included_sample_attributes})
         # Update name from attribute name to expected output name
-        sample_metadata["sample_cell_estimates"] = sample_metadata.pop("demux_cell_count_estimate")
+        sample_metadata["sample_cell_estimate"] = sample_metadata.pop("demux_cell_count_estimate")
 
         sample_metadata.update(
             {key: self.additional_metadata[key] for key in self.additional_metadata}

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -451,7 +451,7 @@ class TestLoadData(TransactionTestCase):
             "total_reads",
             "mapped_reads",
             "sample_cell_count_estimate",  # with non-multiplexed
-            "sample_cell_estimates",
+            "sample_cell_estimate",
             "unfiltered_cells",
             "filtered_cell_count",  # with non-multiplexed
             "processed_cells",
@@ -601,7 +601,7 @@ class TestLoadData(TransactionTestCase):
             "demux_samples",
             "total_reads",
             "mapped_reads",
-            "sample_cell_estimates",
+            "sample_cell_estimate",
             "unfiltered_cells",
             "filtered_cell_count",  # with non-multiplexed
             "processed_cells",


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/778

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

- Rename `sample_cell_estimates` attribute to `sample_cell_estimate`.
- Exclude `sample_cell_estimates` key from being passed through from `library.metadata` in `Library::get_metadata`
- Include `sample_cell_estiamate` key from Sample model, which pulls from the `Sample.demux_sample_cell_count` (which is updated in Project::update_sample_aggregate_values`
- Update `restval` in `metadata_file::write_metadata_dicts`

Note about addition of `restval`:
- The reason that the updating of the `restval` property of `metadata_file::write_metadata_dicts` is in this PR is because we have to assume that projects with multiplexed libraries will also have samples with non multiplexed libraries. As such, both `sample_cell_count_estimate` and `sample_cell_estimate` fields will be present, and depending on if the library is multiplexed or not, one of these two fields will be blank. Due to the fact that 'NA' `restvals` are present in `samples_metadata.csv`, which we end up passing through to our output metadata files, justifies making this addition here.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A