### PR TITLE
Hot fix - bug in non-recursive paths in utils::list_s3_paths

### DIFF
--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -246,3 +246,16 @@ class TestListS3Paths(TestCase):
         expected = [Path("nested-dir/file.txt"), Path("nested-dir/dir/")]
         result = utils.list_s3_paths(bucket_path=Path("input-bucket"))
         self.assertEqual(expected, result)
+
+    @patch("subprocess.run")
+    def test_list_s3_paths_non_recursive_path(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["aws", "s3", "ls", "s3://input-bucket/nested-dir"],
+            returncode=0,
+            stdout="PRE nested-dir",
+        )
+        expected = [Path("nested-dir")]
+        result = utils.list_s3_paths(
+            bucket_path=Path("input-bucket"), relative_path=Path("nested-dir"), recursive=False
+        )
+        self.assertEqual(expected, result)

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -156,4 +156,7 @@ def list_s3_paths(
 
     # bucket_path may contain nested keys, we want to omit these in returned paths
     bucket_keys = Path().joinpath(*bucket_path.parts[1:])
-    return [Path(entry.file_path).relative_to(bucket_keys) for entry in bucket_entries]
+    if recursive:
+        return [Path(entry.file_path).relative_to(bucket_keys) for entry in bucket_entries]
+    else:
+        return [Path(entry.file_path) for entry in bucket_entries]

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -156,7 +156,7 @@ def list_s3_paths(
 
     # bucket_path may contain nested keys, we want to omit these in returned paths
     bucket_keys = Path().joinpath(*bucket_path.parts[1:])
-    # recursive returns an absolutely path, as such need to remove bucket prefix
+    # recursive returns an absolute path, so we need to remove the bucket prefix before returning
     if recursive:
         return [Path(entry.file_path).relative_to(bucket_keys) for entry in bucket_entries]
     # non recursive already returns a relative path

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -116,7 +116,8 @@ def list_s3_paths(
 ):
     """
     Queries a path on an inputted s3 bucket
-    and returns bucket's existing content as a list of Path objects.
+    and returns bucket's existing content as a list of Path objects,
+    relative to (without) the bucket prefix.
 
     The `aws s3 ls <bucket>` command returns a list of two types of entries:
     - Bucket Object Entries
@@ -124,11 +125,6 @@ def list_s3_paths(
     In order to create a standard API, where `entry.file_path` could be accessed
     irrespective of the entry type, we've created two named tuples which follow the return format
     of each of the bucket entry types.
-
-    If recursive is set to True then an absolute path will be generated,
-    in which case the bucket prefix should be removed before returning.
-    When recursive is set to False then a relative path is generated
-    and no further action is needed.
     """
     root_path = Path(*bucket_path.parts, *relative_path.parts)
     command_inputs = ["aws", "s3", "ls", f"s3://{root_path}"]

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -156,7 +156,9 @@ def list_s3_paths(
 
     # bucket_path may contain nested keys, we want to omit these in returned paths
     bucket_keys = Path().joinpath(*bucket_path.parts[1:])
+    # recursive returns an absolutely path, as such need to remove bucket prefix
     if recursive:
         return [Path(entry.file_path).relative_to(bucket_keys) for entry in bucket_entries]
+    # non recursive already returns a relative path
     else:
         return [Path(entry.file_path) for entry in bucket_entries]


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

`utils::list_s3_paths` had a bug in it which prevented it from adequately handling non-recursive paths. 

I've fixed that bug while also adding a new test which tests non-recursive paths.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

`test_utils::TestListS3Paths::test_list_s3_paths_non_recursive_path`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A