### PR TITLE
742 - Break up ComputedFile::process_computed_file

### DIFF
--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -235,8 +235,6 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             ),
         )
 
-        computed_file.save()
-
         return computed_file
 
     @classmethod
@@ -322,8 +320,6 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
                 library.workflow_version for library in libraries
             ),
         )
-
-        computed_file.save()
 
         return computed_file
 

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -385,8 +385,6 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
 
         logger.info(f"Uploading {self}")
         subprocess.check_call(command_parts)
-        # When computed file has been sent to S3 to be uploaded, save to db
-        self.save()
 
     def delete_s3_file(self, force=False):
         # If we're not running in the cloud then we shouldn't try to

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -409,15 +409,3 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
     def clean_up_local_computed_file(self):
         """Delete local computed file."""
         self.zip_file_path.unlink(missing_ok=True)
-
-    def process_computed_file(self, clean_up_output_data, update_s3):
-        """Processes saving, upload and cleanup of a single computed file."""
-        self.save()
-        if update_s3:
-            self.upload_s3_file()
-
-        # Don't clean up multiplexed sample zips until the project is done
-        is_multiplexed_sample = self.sample and self.sample.has_multiplexed_data
-
-        if clean_up_output_data and not is_multiplexed_sample:
-            self.zip_file_path.unlink(missing_ok=True)

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -329,6 +329,8 @@ class Project(CommonDataAttributes, TimestampedModel):
 
         def on_get_project_file(future):
             if computed_file := future.result():
+                computed_file.save()
+
                 if update_s3:
                     computed_file.upload_s3_file()
                 if clean_up_output_data:

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -329,7 +329,11 @@ class Project(CommonDataAttributes, TimestampedModel):
 
         def on_get_project_file(future):
             if computed_file := future.result():
-                computed_file.process_computed_file(clean_up_output_data, update_s3)
+                if update_s3:
+                    computed_file.upload_s3_file()
+                if clean_up_output_data:
+                    computed_file.clean_up_local_computed_file()
+
             # Close DB connection for each thread.
             connection.close()
 

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -183,6 +183,11 @@ class Sample(CommonDataAttributes, TimestampedModel):
         return sorted(multiplexed_sample_ids)
 
     @property
+    def is_last_multiplexed_sample(self):
+        """Return True if sample id is highest in list of multiplexed ids, False if not"""
+        return self.scpca_id == self.multiplexed_ids[-1]
+
+    @property
     def multiplexed_computed_file(self):
         try:
             return self.sample_computed_files.get(
@@ -257,33 +262,16 @@ class Sample(CommonDataAttributes, TimestampedModel):
     ):
         """Prepares ready for saving project computed files based on generated file mappings."""
 
-        # Prepare a threading.Lock for each sample, with the chief purpose being to protect
-        # multiplexed samples that shares a zip file.
-        locks = {}
-
         def on_get_sample_file(future):
             if computed_file := future.result():
-                # Once created, save immediately, so that it can be queried below
-                computed_file.save()
 
-                config = {
-                    "modality": computed_file.modality,
-                    "format": computed_file.format,
-                }
-                # Protect from duplicate computed file uploads with multiplexed samples
-                with locks.get(sample.get_config_identifier(config)):
-                    nonlocal update_s3
+                # Only upload and clean up the last if multiplexed
+                if computed_file.sample.is_last_multiplexed_sample:
                     if update_s3:
-                        computed_file.upload_s3
-                        update_s3 = False
-
-                all_samples_created = (
-                    len(computed_file.sample.multiplexed_ids)
-                    == ComputedFile.objects.filter(s3_key=computed_file.s3_key).count()
-                )
-                # Only clean up local file if all multiplexed samples have been created
-                if clean_up_output_data and all_samples_created:
-                    computed_file.clean_up_local_computed_file()
+                        computed_file.upload_s3_file()
+                    if clean_up_output_data:
+                        computed_file.clean_up_local_computed_file()
+                computed_file.save()
 
             # Close DB connection for each thread.
             connection.close()
@@ -294,6 +282,9 @@ class Sample(CommonDataAttributes, TimestampedModel):
             f"{max_workers} worker{pluralize(max_workers)}"
         )
 
+        # Prepare a threading.Lock for each sample, with the chief purpose being to protect
+        # multiplexed samples that shares a zip file.
+        locks = {}
         with ThreadPoolExecutor(max_workers=max_workers) as tasks:
             for sample in samples:
                 for config in common.GENERATED_SAMPLE_DOWNLOAD_CONFIGURATIONS:


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/742

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR deals with the breaking up of `ComputedFile::process_computed_file` into two methods:
- `ComputedFile::upload_s3_file`
- `ComputedFile::clean_up_local_computed_file`. 

The calling of these methods is moved outside of a wrapper (like the role that `ComputedFile::process_computed_file` played), and are called directly inside of `Project::create_computed_files::on_get_project_file` and `Sample::create_computed_files::on_get_sample_file` after computed files have been generated and `computed_file` objects have been created and returned.

As a note - a check has been included before the uploading and cleaning up of local files that makes sure that files are only uploaded and cleaned up once. This is especially a point of concern with computed files that have multiplexed samples. The check ensures that only one sample in a collection of multiplexed samples will be responsible for uploading and cleaning up files, via the new `Sample::is_last_multiplexed_sample` property method, removing duplicate and unwanted behavior.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A