### PR TITLE
784 - In memory metadata file generation

### DIFF
--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -132,31 +132,3 @@ def format_metadata_dict(metadata_dict: Dict) -> Dict:
     Returns a copy of metadata dict that is formatted and ready to be written to file.
     """
     return {k: utils.string_from_list(v) for k, v in metadata_dict.items()}
-
-
-def write_metadata_dicts(list_of_dicts: List[Dict], output_file_path: str, **kwargs) -> None:
-    """
-    Writes a list of dictionaries to a csv-like file.
-    Optional modifiers to the csv.DictWriter can be passed to function as kwargs.
-    """
-    kwargs["fieldnames"] = kwargs.get(
-        "fieldnames", utils.get_sorted_field_names(utils.get_keys_from_dicts(list_of_dicts))
-    )
-    kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
-    # By default fill missing values with "NA"
-    kwargs["restval"] = kwargs.get("restval", common.NA)
-
-    sorted_list_of_dicts = sorted(
-        list_of_dicts,
-        key=lambda k: (
-            k[common.PROJECT_ID_KEY],
-            k[common.SAMPLE_ID_KEY],
-            k[common.LIBRARY_ID_KEY],
-        ),
-    )
-
-    with open(output_file_path, "w", newline="") as raw_file:
-        csv_writer = csv.DictWriter(raw_file, **kwargs)
-        csv_writer.writeheader()
-        for metadata_dict in sorted_list_of_dicts:
-            csv_writer.writerow(format_metadata_dict(metadata_dict))

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -102,15 +102,11 @@ def get_file_name(download_config: Dict) -> str:
     return getattr(MetadataFilenames, f'{download_config["modality"]}_METADATA_FILE_NAME')
 
 
-def get_file_contents(libraries, **kwargs) -> str:
+def get_file_contents(libraries_metadata: List[Dict], **kwargs) -> str:
     """Return newly genereated metadata file as a string for immediate writing to a zip archive."""
-    libraries_metadata = [
-        format_metadata_dict(library_metadata)
-        for library in libraries
-        for library_metadata in library.get_combined_library_metadata()
-    ]
+    formatted_libraries_metadata = [format_metadata_dict(lib_md) for lib_md in libraries_metadata]
     sorted_libraries_metadata = sorted(
-        libraries_metadata,
+        formatted_libraries_metadata,
         key=lambda k: (k[common.PROJECT_ID_KEY], k[common.SAMPLE_ID_KEY], k[common.LIBRARY_ID_KEY]),
     )
 

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -1,4 +1,5 @@
 import csv
+import io
 import json
 from collections import namedtuple
 from pathlib import Path
@@ -104,7 +105,9 @@ def get_metadata_file_name(download_config: Dict) -> str:
     return getattr(MetadataFilenames, output_file_constant)
 
 
-def write_metadata_dicts(list_of_dicts: List[Dict], output_file_path: str, **kwargs) -> None:
+def write_metadata_dicts(
+    list_of_dicts: List[Dict], output_file_path: str = None, *, buffer: io.StringIO = None, **kwargs
+) -> None:
     """
     Writes a list of dictionaries to a csv-like file.
     Optional modifiers to the csv.DictWriter can be passed to function as kwargs.
@@ -125,7 +128,11 @@ def write_metadata_dicts(list_of_dicts: List[Dict], output_file_path: str, **kwa
         ),
     )
 
-    with open(output_file_path, "w", newline="") as raw_file:
-        csv_writer = csv.DictWriter(raw_file, **kwargs)
-        csv_writer.writeheader()
-        csv_writer.writerows(sorted_list_of_dicts)
+    output_stream = open(output_file_path, "w", newline="") if output_file_path else buffer
+
+    csv_writer = csv.DictWriter(output_stream, **kwargs)
+    csv_writer.writeheader()
+    csv_writer.writerows(sorted_list_of_dicts)
+
+    if output_file_path:
+        output_stream.close()

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -96,13 +96,10 @@ class MetadataFilenames:
 
 def get_file_name(download_config: Dict) -> str:
     """Return metadata file name according to passed download_config."""
-    output_file_constant = (
-        f'{download_config["modality"]}_METADATA_FILE_NAME'
-        if not download_config.get("metadata_only", False)
-        else "METADATA_ONLY_FILE_NAME"
-    )
+    if download_config.get("metadata_only", False):
+        return MetadataFilenames.METADATA_ONLY_FILE_NAME
 
-    return getattr(MetadataFilenames, output_file_constant)
+    return getattr(MetadataFilenames, f'{download_config["modality"]}_METADATA_FILE_NAME')
 
 
 def get_file_contents(libraries, **kwargs) -> str:

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -87,6 +87,23 @@ def transform_keys(data_dict: Dict, key_transforms: List[Tuple]):
     return data_dict
 
 
+class MetadataFilenames:
+    SINGLE_CELL_METADATA_FILE_NAME = "single_cell_metadata.tsv"
+    SPATIAL_METADATA_FILE_NAME = "spatial_metadata.tsv"
+    METADATA_ONLY_FILE_NAME = "metadata.tsv"
+
+
+def get_metadata_file_name(download_config: Dict) -> str:
+    """Return metadata file name according to passed download_config."""
+    output_file_constant = (
+        f'{download_config["modality"]}_METADATA_FILE_NAME'
+        if not download_config.get("metadata_only", False)
+        else "METADATA_ONLY_FILE_NAME"
+    )
+
+    return getattr(MetadataFilenames, output_file_constant)
+
+
 def write_metadata_dicts(list_of_dicts: List[Dict], output_file_path: str, **kwargs) -> None:
     """
     Writes a list of dictionaries to a csv-like file.

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -101,6 +101,9 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         if not libraries.exists():
             return
 
+        libraries_metadata = [
+            lib_md for library in libraries for lib_md in library.get_combined_library_metadata()
+        ]
         library_data_file_paths = [
             fp for lib in libraries for fp in lib.get_download_config_file_paths(download_config)
         ]
@@ -117,7 +120,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             # Metadata file
             zip_file.writestr(
                 metadata_file.get_file_name(download_config),
-                metadata_file.get_file_contents(libraries),
+                metadata_file.get_file_contents(libraries_metadata),
             )
 
             if not download_config.get("metadata_only", False):
@@ -186,6 +189,9 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         if not libraries.exists():
             return
 
+        libraries_metadata = [
+            lib_md for library in libraries for lib_md in library.get_combined_library_metadata()
+        ]
         library_data_file_paths = [
             fp for lib in libraries for fp in lib.get_download_config_file_paths(download_config)
         ]
@@ -204,7 +210,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
                     # Metadata file
                     zip_file.writestr(
                         metadata_file.get_file_name(download_config),
-                        metadata_file.get_file_contents(libraries),
+                        metadata_file.get_file_contents(libraries_metadata),
                     )
 
                     for file_path in library_data_file_paths:

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -26,11 +26,6 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         get_latest_by = "updated_at"
         ordering = ["updated_at", "id"]
 
-    class MetadataFilenames:
-        SINGLE_CELL_METADATA_FILE_NAME = "single_cell_metadata.tsv"
-        SPATIAL_METADATA_FILE_NAME = "spatial_metadata.tsv"
-        METADATA_ONLY_FILE_NAME = "metadata.tsv"
-
     class OutputFileModalities:
         SINGLE_CELL = "SINGLE_CELL"
         SPATIAL = "SPATIAL"
@@ -109,7 +104,9 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         libraries_metadata = [
             lib for library in libraries for lib in library.get_combined_library_metadata()
         ]
+
         local_metadata_path = ComputedFile.get_local_project_metadata_path(project, download_config)
+        output_metadata_file_name = metadata_file.get_metadata_file_name(download_config)
         metadata_file.write_metadata_dicts(libraries_metadata, local_metadata_path)
 
         library_data_file_paths = [
@@ -126,14 +123,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             )
 
             # Metadata file
-            output_file_constant = (
-                f'{download_config["modality"]}_METADATA_FILE_NAME'
-                if not download_config["metadata_only"]
-                else "METADATA_ONLY_FILE_NAME"
-            )
-            zip_file.write(
-                local_metadata_path, getattr(ComputedFile.MetadataFilenames, output_file_constant)
-            )
+            zip_file.write(local_metadata_path, output_metadata_file_name)
 
             if not download_config.get("metadata_only", False):
                 for file_path in library_data_file_paths:
@@ -204,7 +194,9 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         libraries_metadata = [
             lib for library in libraries for lib in library.get_combined_library_metadata()
         ]
+
         local_metadata_path = ComputedFile.get_local_sample_metadata_path(sample, download_config)
+        output_metadata_file_name = metadata_file.get_metadata_file_name(download_config)
         metadata_file.write_metadata_dicts(libraries_metadata, local_metadata_path)
 
         library_data_file_paths = [
@@ -221,13 +213,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
                         readme_creation.get_file_contents(download_config, sample.project),
                     )
                     # Metadata file
-                    zip_file.write(
-                        local_metadata_path,
-                        getattr(
-                            ComputedFile.MetadataFilenames,
-                            f'{download_config["modality"]}_METADATA_FILE_NAME',
-                        ),
-                    )
+                    zip_file.write(local_metadata_path, output_metadata_file_name)
 
                     for file_path in library_data_file_paths:
                         zip_file.write(

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -1,4 +1,3 @@
-import io
 import subprocess
 from pathlib import Path
 from threading import Lock
@@ -116,15 +115,10 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             )
 
             # Metadata file
-            with io.StringIO() as metadata_buffer:
-                libraries_metadata = [
-                    lib for library in libraries for lib in library.get_combined_library_metadata()
-                ]
-                # Write libraries metadata to buffer
-                metadata_file.write_metadata_dicts(libraries_metadata, buffer=metadata_buffer)
-                output_metadata_file_name = metadata_file.get_metadata_file_name(download_config)
-                # Write buffer directly to zip archive
-                zip_file.writestr(output_metadata_file_name, metadata_buffer.getvalue())
+            zip_file.writestr(
+                metadata_file.get_file_name(download_config),
+                metadata_file.get_file_contents(libraries),
+            )
 
             if not download_config.get("metadata_only", False):
                 for file_path in library_data_file_paths:
@@ -206,22 +200,12 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
                         readme_file.OUTPUT_NAME,
                         readme_file.get_file_contents(download_config, sample.project),
                     )
+
                     # Metadata file
-                    with io.StringIO() as metadata_buffer:
-                        libraries_metadata = [
-                            lib
-                            for library in libraries
-                            for lib in library.get_combined_library_metadata()
-                        ]
-                        # Write libraries metadata to buffer
-                        metadata_file.write_metadata_dicts(
-                            libraries_metadata, buffer=metadata_buffer
-                        )
-                        output_metadata_file_name = metadata_file.get_metadata_file_name(
-                            download_config
-                        )
-                        # Write buffer directly to zip archive
-                        zip_file.writestr(output_metadata_file_name, metadata_buffer.getvalue())
+                    zip_file.writestr(
+                        metadata_file.get_file_name(download_config),
+                        metadata_file.get_file_contents(libraries),
+                    )
 
                     for file_path in library_data_file_paths:
                         zip_file.write(

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 
 from django.test import TransactionTestCase
 
-from scpca_portal import common
+from scpca_portal import common, metadata_file
 from scpca_portal.management.commands.load_data import Command
 from scpca_portal.models import ComputedFile, Project, ProjectSummary, Sample
 
@@ -491,7 +491,7 @@ class TestLoadData(TransactionTestCase):
         )
         with ZipFile(project_zip_path) as project_zip:
             sample_metadata = project_zip.read(
-                ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME
+                metadata_file.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME
             )
             sample_metadata_lines = [
                 sm for sm in sample_metadata.decode("utf-8").split("\r\n") if sm
@@ -638,7 +638,7 @@ class TestLoadData(TransactionTestCase):
         )
         with ZipFile(sample_zip_path) as sample_zip:
             with sample_zip.open(
-                ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME, "r"
+                metadata_file.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME, "r"
             ) as sample_csv:
                 csv_reader = csv.DictReader(
                     TextIOWrapper(sample_csv, "utf-8"), delimiter=common.TAB
@@ -775,7 +775,7 @@ class TestLoadData(TransactionTestCase):
         )
         with ZipFile(project_zip_path) as project_zip:
             sample_metadata = project_zip.read(
-                ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME
+                metadata_file.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME
             )
             sample_metadata_lines = [
                 sm for sm in sample_metadata.decode("utf-8").split("\r\n") if sm
@@ -863,7 +863,7 @@ class TestLoadData(TransactionTestCase):
         )
         with ZipFile(sample_zip_path) as sample_zip:
             with sample_zip.open(
-                ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME, "r"
+                metadata_file.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME, "r"
             ) as sample_csv:
                 csv_reader = csv.DictReader(
                     TextIOWrapper(sample_csv, "utf-8"), delimiter=common.TAB
@@ -894,7 +894,7 @@ class TestLoadData(TransactionTestCase):
         )
         with ZipFile(sample_zip_path) as sample_zip:
             with sample_zip.open(
-                ComputedFile.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME, "r"
+                metadata_file.MetadataFilenames.SINGLE_CELL_METADATA_FILE_NAME, "r"
             ) as sample_csv:
                 csv_reader = csv.DictReader(
                     TextIOWrapper(sample_csv, "utf-8"), delimiter=common.TAB
@@ -1009,7 +1009,7 @@ class TestLoadData(TransactionTestCase):
         )
         with ZipFile(project_zip_path) as project_zip:
             spatial_metadata_file = project_zip.read(
-                ComputedFile.MetadataFilenames.SPATIAL_METADATA_FILE_NAME
+                metadata_file.MetadataFilenames.SPATIAL_METADATA_FILE_NAME
             )
             spatial_metadata = [
                 sm for sm in spatial_metadata_file.decode("utf-8").split("\r\n") if sm
@@ -1105,7 +1105,7 @@ class TestLoadData(TransactionTestCase):
         )
         with ZipFile(sample_zip_path) as sample_zip:
             with sample_zip.open(
-                ComputedFile.MetadataFilenames.SPATIAL_METADATA_FILE_NAME, "r"
+                metadata_file.MetadataFilenames.SPATIAL_METADATA_FILE_NAME, "r"
             ) as sample_csv:
                 csv_reader = csv.DictReader(
                     TextIOWrapper(sample_csv, "utf-8"), delimiter=common.TAB

--- a/api/scpca_portal/test/test_metadata_file.py
+++ b/api/scpca_portal/test/test_metadata_file.py
@@ -1,14 +1,12 @@
 import csv
-import os
-import tempfile
-from pathlib import Path
+import io
 
 from django.test import TestCase
 
 from scpca_portal import common, metadata_file
 
 
-class TestWriteMetadataDicts(TestCase):
+class TestGetFileContents(TestCase):
     def setUp(self):
         self.dummy_list_of_dicts = [
             # This list is intentionally out of order to test the sorting.
@@ -56,22 +54,15 @@ class TestWriteMetadataDicts(TestCase):
             "capital",
             "holidays",
         }
-        self.dummy_dir = Path(tempfile.mkdtemp())
-        self.dummy_output_path = Path(self.dummy_dir, "dummy_output.tsv")
 
-    def tearDown(self):
-        if Path.exists(self.dummy_output_path):
-            Path.unlink(self.dummy_output_path)
-        if Path.exists(self.dummy_dir):
-            Path.rmdir(self.dummy_dir)
-
-    def test_write_metadata_dicts_successful_write(self):
-        metadata_file.write_metadata_dicts(
-            self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=self.dummy_field_names
+    def test_get_file_contents_successful_write(self):
+        output_file_contents = metadata_file.get_file_contents(
+            self.dummy_list_of_dicts, fieldnames=self.dummy_field_names
         )
-        self.assertTrue(os.path.exists(self.dummy_output_path))
+        self.assertIsNotNone(output_file_contents)
+        self.assertIsInstance(output_file_contents, str)
 
-    def test_write_metadata_dicts_read_write_values_match(self):
+    def test_get_file_contents_read_write_values_match(self):
         expected_output = [
             {
                 "scpca_project_id": "SCPCP999990",
@@ -102,37 +93,28 @@ class TestWriteMetadataDicts(TestCase):
             },
         ]
 
-        metadata_file.write_metadata_dicts(
-            self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=self.dummy_field_names
+        output_file_contents = metadata_file.get_file_contents(
+            self.dummy_list_of_dicts, fieldnames=self.dummy_field_names
         )
-
-        with open(self.dummy_output_path) as output_file:
-            output_list_of_dicts = list(csv.DictReader(output_file, delimiter=common.TAB))
+        with io.StringIO(output_file_contents) as output_buffer:
+            output_list_of_dicts = list(csv.DictReader(output_buffer, delimiter=common.TAB))
             self.assertEqual(expected_output, output_list_of_dicts)
 
-    def test_write_metadata_dicts_read_write_add_missing_field_names(self):
-        metadata_file.write_metadata_dicts(
-            self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=self.dummy_field_names
+    def test_get_file_contents_read_write_add_missing_field_names(self):
+        output_file_contents = metadata_file.get_file_contents(
+            self.dummy_list_of_dicts, fieldnames=self.dummy_field_names
         )
 
-        with open(self.dummy_output_path) as output_file:
-            output_list_of_dicts = list(csv.DictReader(output_file, delimiter=common.TAB))
+        with io.StringIO(output_file_contents) as output_buffer:
+            output_list_of_dicts = list(csv.DictReader(output_buffer, delimiter=common.TAB))
             self.assertIn(common.NA, [d["capital"] for d in output_list_of_dicts])
 
-    def test_write_metadata_dicts_incomplete_field_names(self):
+    def test_get_file_contents_incomplete_field_names(self):
         field_names = {"country", "language"}
         with self.assertRaises(ValueError):
-            metadata_file.write_metadata_dicts(
-                self.dummy_list_of_dicts, self.dummy_output_path, fieldnames=field_names
-            )
+            metadata_file.get_file_contents(self.dummy_list_of_dicts, fieldnames=field_names)
 
-    def test_write_metadata_dicts_not_inputted_field_names(self):
-        metadata_file.write_metadata_dicts(self.dummy_list_of_dicts, self.dummy_output_path)
-        self.assertTrue(os.path.exists(self.dummy_output_path))
-
-    def test_write_metadata_dicts_invalid_output_file(self):
-        invalid_output_file = os.path.join(self.dummy_dir, "invalid", "path", "output.csv")
-        with self.assertRaises(FileNotFoundError):
-            metadata_file.write_metadata_dicts(
-                self.dummy_list_of_dicts, invalid_output_file, fieldnames=self.dummy_field_names
-            )
+    def test_get_file_contents_not_inputted_field_names(self):
+        output_file_contents = metadata_file.get_file_contents(self.dummy_list_of_dicts)
+        self.assertIsNotNone(output_file_contents)
+        self.assertIsInstance(output_file_contents, str)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/784

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

- Replace eager writing of `output_metadata_file` to a local file (before zip archival) with writing it to an in memory buffer (during zip archival)
  - The file is written to the buffer and thereafter immediately written to the zip archive
- Move metadata output file naming logic out of zip archival process in `ComputedFile::get_project|sample_file` and into own method inside of `metadata_file` module called `metadata_file::get_metadata_file_name`
- Move MetadataFilenames constants from `ComputedFile` model to `metadata_file` module
- Update `metadata_file::write_metadata_dicts` to handle writing to a buffer

## Types of changes


<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A