### PR TITLE
797 - Scaffolding the porta-wide metadata management command and test files

### DIFF
--- a/api/scpca_portal/management/commands/create_portal_metadata.py
+++ b/api/scpca_portal/management/commands/create_portal_metadata.py
@@ -1,0 +1,36 @@
+import logging
+from argparse import BooleanOptionalAction
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
+
+
+class Command(BaseCommand):
+    help = """Creates a computed file and zip for portal-wide metadata,
+     saves the instance to the databse, and
+     uploads the zip file to S3 bucket.
+    """
+
+    @staticmethod
+    def clean_up_output_data():
+        """Cleans up the output data files after processing the computed file"""
+        logger.info("Cleaning up output data")
+        # This static method may not be required using buffers
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--clean-up-output-data", action=BooleanOptionalAction, default=settings.PRODUCTION
+        )
+
+    def handle(self, *args, **kwargs):
+        self.create_portal_metadata(**kwargs)
+
+    def create_portal_metadata(self, **kwargs):
+        logger.info("Creating the portal-wide metadata computed file")
+
+        if kwargs["clean_up_output_data"]:
+            self.clean_up_output_data()

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -4,7 +4,7 @@ from django.test import TransactionTestCase
 
 from scpca_portal import common
 from scpca_portal.management.commands import create_portal_metadata, load_data
-from scpca_portal.models import Library
+from scpca_portal.models import Library, Project, Sample
 
 # NOTE: Test data bucket is defined in `scpca_porta/common.py`.
 # When common.INPUT_BUCKET_NAME is changed, please delete the contents of
@@ -24,6 +24,11 @@ class TestCreatePortalMetadata(TransactionTestCase):
         shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
 
     def load_test_data(self):
+        # Set up the database
+        PROJECT_COUNT = 3
+        SAMPLES_COUNT = 9
+        LIBRARIES_COUNT = 7
+
         self.loader.load_data(
             allowed_submitters=list(ALLOWED_SUBMITTERS),
             clean_up_input_data=False,
@@ -34,28 +39,12 @@ class TestCreatePortalMetadata(TransactionTestCase):
             update_s3=False,
         )
 
+        self.assertEqual(Project.objects.all().count(), PROJECT_COUNT)
+        self.assertEqual(Sample.objects.all().count(), SAMPLES_COUNT)
+        self.assertEqual(Library.objects.all().count(), LIBRARIES_COUNT)
+
     def test_create_portal_metadata(self):
-        # Set up the database
-        PROJECT_COUNT = 3
-        SAMPLES_COUNT = 8
-        LIBRARIES_COUNT = 7
-
         self.load_test_data()
-
-        libraries = Library.objects.all()
-        libraries_metadata = [
-            lib for library in libraries for lib in library.get_combined_library_metadata()
-        ]
-
-        self.assertEqual(
-            len(set(lib["scpca_project_id"] for lib in libraries_metadata)), PROJECT_COUNT
-        )
-        self.assertEqual(
-            len(set(lib["scpca_sample_id"] for lib in libraries_metadata)), SAMPLES_COUNT
-        )
-        self.assertEqual(libraries.count(), LIBRARIES_COUNT)
-
         # Once the database is set up correctly, run the create_portal_metadata management command
         self.processor.create_portal_metadata(clean_up_output_data=False)
-
         # Test the content of the generated zip file here

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -1,0 +1,50 @@
+import shutil
+
+from django.test import TransactionTestCase
+
+from scpca_portal import common
+from scpca_portal.management.commands import create_portal_metadata, load_data
+from scpca_portal.models import Project
+
+# NOTE: Test data bucket is defined in `scpca_porta/common.py`.
+# When common.INPUT_BUCKET_NAME is changed, please delete the contents of
+# api/test_data/input before testing to ensure test files are updated correctly.
+
+ALLOWED_SUBMITTERS = {"scpca"}
+
+
+class TestCreatePortalMetadata(TransactionTestCase):
+    def setUp(self):
+        self.processor = create_portal_metadata.Command()
+        self.loader = load_data.Command()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
+
+    def setup_database(self, project_ids):
+        for project_id in project_ids:
+            self.loader.load_data(
+                allowed_submitters=list(ALLOWED_SUBMITTERS),
+                clean_up_input_data=False,
+                clean_up_output_data=False,
+                max_workers=4,
+                reload_all=False,
+                reload_existing=False,
+                scpca_project_id=project_id,
+                update_s3=False,
+            )
+
+    def test_create_portal_metadata(self):
+        # Set up the database
+        project_ids = ["SCPCP999990", "SCPCP999991", "SCPCP999992"]
+        self.setup_database(project_ids)
+
+        # Make sure that the number of projects created matches the length of project_ids
+        self.assertEqual(Project.objects.count(), len(project_ids))
+
+        # Once the database is set up correctly, run the create_portal_metadata management command
+        self.processor.create_portal_metadata(clean_up_output_data=False)
+
+        # Test the content of the generated zip file here

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -4,7 +4,7 @@ from django.test import TransactionTestCase
 
 from scpca_portal import common
 from scpca_portal.management.commands import create_portal_metadata, load_data
-from scpca_portal.models import Project
+from scpca_portal.models import Library
 
 # NOTE: Test data bucket is defined in `scpca_porta/common.py`.
 # When common.INPUT_BUCKET_NAME is changed, please delete the contents of
@@ -23,26 +23,37 @@ class TestCreatePortalMetadata(TransactionTestCase):
         super().tearDownClass()
         shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
 
-    def setup_database(self, project_ids):
-        for project_id in project_ids:
-            self.loader.load_data(
-                allowed_submitters=list(ALLOWED_SUBMITTERS),
-                clean_up_input_data=False,
-                clean_up_output_data=False,
-                max_workers=4,
-                reload_all=False,
-                reload_existing=False,
-                scpca_project_id=project_id,
-                update_s3=False,
-            )
+    def load_test_data(self):
+        self.loader.load_data(
+            allowed_submitters=list(ALLOWED_SUBMITTERS),
+            clean_up_input_data=False,
+            clean_up_output_data=False,
+            max_workers=4,
+            reload_all=False,
+            reload_existing=False,
+            update_s3=False,
+        )
 
     def test_create_portal_metadata(self):
         # Set up the database
-        project_ids = ["SCPCP999990", "SCPCP999991", "SCPCP999992"]
-        self.setup_database(project_ids)
+        PROJECT_COUNT = 3
+        SAMPLES_COUNT = 8
+        LIBRARIES_COUNT = 7
 
-        # Make sure that the number of projects created matches the length of project_ids
-        self.assertEqual(Project.objects.count(), len(project_ids))
+        self.load_test_data()
+
+        libraries = Library.objects.all()
+        libraries_metadata = [
+            lib for library in libraries for lib in library.get_combined_library_metadata()
+        ]
+
+        self.assertEqual(
+            len(set(lib["scpca_project_id"] for lib in libraries_metadata)), PROJECT_COUNT
+        )
+        self.assertEqual(
+            len(set(lib["scpca_sample_id"] for lib in libraries_metadata)), SAMPLES_COUNT
+        )
+        self.assertEqual(libraries.count(), LIBRARIES_COUNT)
 
         # Once the database is set up correctly, run the create_portal_metadata management command
         self.processor.create_portal_metadata(clean_up_output_data=False)

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -24,8 +24,8 @@ class TestCreatePortalMetadata(TransactionTestCase):
         shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
 
     def load_test_data(self):
-        # Set up the database
-        PROJECT_COUNT = 3
+        # Expected object counts
+        PROJECTS_COUNT = 3
         SAMPLES_COUNT = 9
         LIBRARIES_COUNT = 7
 
@@ -39,12 +39,10 @@ class TestCreatePortalMetadata(TransactionTestCase):
             update_s3=False,
         )
 
-        self.assertEqual(Project.objects.all().count(), PROJECT_COUNT)
+        self.assertEqual(Project.objects.all().count(), PROJECTS_COUNT)
         self.assertEqual(Sample.objects.all().count(), SAMPLES_COUNT)
         self.assertEqual(Library.objects.all().count(), LIBRARIES_COUNT)
 
     def test_create_portal_metadata(self):
         self.load_test_data()
-        # Once the database is set up correctly, run the create_portal_metadata management command
         self.processor.create_portal_metadata(clean_up_output_data=False)
-        # Test the content of the generated zip file here

--- a/bin/sportal
+++ b/bin/sportal
@@ -32,6 +32,7 @@ commands = {
     "graph-models": run_api.format("./manage.py graph_models scpca_portal > models.dot"),
     "run-api": run_api,
     "manage-api": run_api.format("./manage.py {}"),
+    "create-portal-metadata": run_api.format("./manage.py create_portal_metadata {}"),
     "load-data": run_api.format("./manage.py load_data {}"),
     "mock-data": run_api.format("./manage.py load_mock_data {}"),
     "run-black": run_api.format("black --line-length=100 --exclude=volumes_postgres ."),


### PR DESCRIPTION
## Issue Number
#797 

## Purpose/Implementation Notes
This is the 1st item in the stacked PR list for the linked issue.

The following changes are included:

- Added the `create-portal-metadata.py` file
- Added the `create-portal-metadata.py` file  which setup the database by calling `load_data`
- Added the `create-portal-metadata` command to `sportal`

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests
N/A

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
N/A
