### PR TITLE
add django extensions to installed apps

### DIFF
--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -20,6 +20,7 @@ class Common(Configuration):
         # Third party apps
         "rest_framework",  # utilities for rest apis
         "django_filters",  # for filtering rest endpoints
+        "django_extensions",  # additional managment commands
         "drf_yasg",
         "corsheaders",
         # Your apps


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I was debugging the staging database when I needed some commands that are present in django_extensions. We already include this module in our base requirements so this is just a matter of telling django to include it on start.

## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
