### PR TITLE
Make Library.project nullable during migration

### DIFF
--- a/api/scpca_portal/migrations/0047_library_project.py
+++ b/api/scpca_portal/migrations/0047_library_project.py
@@ -13,6 +13,10 @@ def apply_project(apps, schema_editor):
             library.save()
 
 
+def reverse_project(apps, schema_editor):
+    pass
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -24,10 +28,20 @@ class Migration(migrations.Migration):
             model_name="library",
             name="project",
             field=models.ForeignKey(
+                null=True,
                 on_delete=django.db.models.deletion.CASCADE,
                 related_name="libraries",
                 to="scpca_portal.Project",
             ),
         ),
-        migrations.RunPython(apply_project),
+        migrations.RunPython(apply_project, reverse_project),
+        migrations.AlterField(
+            model_name="library",
+            name="project",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="libraries",
+                to="scpca_portal.Project",
+            ),
+        ),
     ]


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Mainly what it says on the tin. Migration `0047_library_project` wasn't able to be run against a populated database because the new column's value was undefined at creation. This PR essentially makes the column nullable at creation, iterates over any libraries to populate that value, then restricts the column to make it non nullable again.

Additionally, I added support to roll back the custom migration to allow for testing.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Populated the db with test data from the previous deployment. Then ran the migration to recreate the error.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
