### PR TITLE
816 - Refactor Tests for metadata_file::get_file_contents

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Set perms
         run: chmod -R a+rw api
       - name: Build the stack
-        run: docker-compose --env-file ./docker-compose.env build
+        run: docker compose --env-file ./docker-compose.env build
       - name: Test
         run: ./bin/sportal test-api

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -115,7 +115,7 @@ def get_file_contents(libraries_metadata: List[Dict], **kwargs) -> str:
         utils.get_sorted_field_names(utils.get_keys_from_dicts(sorted_libraries_metadata)),
     )
     kwargs["delimiter"] = kwargs.get("delimiter", common.TAB)
-    # By default fill missing values with "NA"
+    # By default fill dicts with missing fieldnames with "NA" values
     kwargs["restval"] = kwargs.get("restval", common.NA)
 
     with io.StringIO() as metadata_buffer:
@@ -131,4 +131,6 @@ def format_metadata_dict(metadata_dict: Dict) -> Dict:
     """
     Returns a copy of metadata dict that is formatted and ready to be written to file.
     """
+    # Replace empty blank or None values with "NA"
+    metadata_dict.update({k: common.NA for k, v in metadata_dict.items() if v in ["", None]})
     return {k: utils.string_from_list(v) for k, v in metadata_dict.items()}

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -131,6 +131,4 @@ def format_metadata_dict(metadata_dict: Dict) -> Dict:
     """
     Returns a copy of metadata dict that is formatted and ready to be written to file.
     """
-    # Replace empty blank or None values with "NA"
-    metadata_dict.update({k: common.NA for k, v in metadata_dict.items() if v in ["", None]})
     return {k: utils.string_from_list(v) for k, v in metadata_dict.items()}

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -106,15 +106,19 @@ class LibraryFactory(factory.django.DjangoModelFactory):
     project = factory.SubFactory(LeafProjectFactory)
     scpca_id = factory.Sequence(lambda n: "SCPCL0000%d" % n)
     workflow_version = "development"
-    metadata = {
-        "technology": "10Xv3.1",
-        "seq_unit": "nucleus",
-        "is_multiplexed": True,
-        "has_citeseq": False,
-        "has_cellhash": True,
-        "workflow": "https://github.com/AlexsLemonade/scpca-nf",
-        "workflow_version": "development",
-    }
+    # With factory_body, factory instances share attributes by default
+    # Use LazyFunction to populate metadata dict so that changes don't propogate to all instances
+    metadata = factory.LazyFunction(
+        lambda: {
+            "technology": "10Xv3.1",
+            "seq_unit": "nucleus",
+            "is_multiplexed": True,
+            "has_citeseq": False,
+            "has_cellhash": True,
+            "workflow": "https://github.com/AlexsLemonade/scpca-nf",
+            "workflow_version": "development",
+        }
+    )
 
 
 class ProjectFactory(LeafProjectFactory):

--- a/api/scpca_portal/test/test_metadata_file.py
+++ b/api/scpca_portal/test/test_metadata_file.py
@@ -14,12 +14,14 @@ class TestGetFileContents(TestCase):
         for library in self.libraries:
             library.samples.add(SampleFactory(project=library.project))
 
-        # Allow easy access to one library for easy modification
+        # Allow quick access to one library for easy modification
         self.first_library = self.libraries[0]
 
+        # Pre-compute value for easy reference (not all tests use this value)
         self.libraries_metadata = self.get_libraries_metadata(self.libraries)
 
     def get_libraries_metadata(self, libraries: List) -> List[Dict]:
+        """Lazy compute libraries_metadata value if libraries are mutated."""
         return [
             lib_md for library in libraries for lib_md in library.get_combined_library_metadata()
         ]
@@ -34,12 +36,9 @@ class TestGetFileContents(TestCase):
         with io.StringIO(output_file_contents) as output_buffer:
             output_list_of_dicts = list(csv.DictReader(output_buffer, delimiter=common.TAB))
             for output_dict in output_list_of_dicts:
-                input_dict = next(
-                    library_metadata
-                    for library_metadata in self.libraries_metadata
-                    if library_metadata["scpca_library_id"] == output_dict["scpca_library_id"]
-                )
-                # Cast all values in input_dict to string to match types in string buffer
+                id = "scpca_library_id"
+                input_dict = next(lm for lm in self.libraries_metadata if lm[id] == output_dict[id])
+                # Cast all values in input_dict to str to match str types of string buffer
                 formatted_input_dict = {k: str(v) for k, v in input_dict.items()}
                 self.assertEqual(output_dict, formatted_input_dict)
 

--- a/api/scpca_portal/test/test_metadata_file.py
+++ b/api/scpca_portal/test/test_metadata_file.py
@@ -1,49 +1,27 @@
 import csv
 import io
+from typing import Dict, List
 
 from django.test import TestCase
 
 from scpca_portal import common, metadata_file
+from scpca_portal.test.factories import LibraryFactory, SampleFactory
 
 
 class TestGetFileContents(TestCase):
     def setUp(self):
-        self.dummy_list_of_dicts = [
-            # This list is intentionally out of order to test the sorting.
-            {
-                "scpca_project_id": "SCPCP999991",
-                "scpca_sample_id": "SCPCS999991",
-                "scpca_library_id": "SCPCL999991",
-                "country": "Spain",
-                "language": "Spanish",
-                "capital": "Madrid",
-                "holidays": [
-                    "New Year’s Day",
-                    "Epiphany",
-                    "Christmas Day",
-                ],
-            },
-            {
-                "scpca_project_id": "SCPCP999992",
-                "scpca_sample_id": "SCPCS999992",
-                "scpca_library_id": "SCPCL999992",
-                "country": "Antarctica",
-                "language": "Antarctic English",
-                "holidays": "NA",
-            },
-            {
-                "scpca_project_id": "SCPCP999990",
-                "scpca_sample_id": "SCPCS999990",
-                "scpca_library_id": "SCPCL999990",
-                "country": "USA",
-                "language": "English",
-                "capital": "Washington DC",
-                "holidays": [
-                    "New Year's Day",
-                    "Thanksgiving Day",
-                    "Christmas Day",
-                ],
-            },
+        self.libraries = [LibraryFactory() for _ in range(3)]
+        for library in self.libraries:
+            library.samples.add(SampleFactory(project=library.project))
+
+        # Allow easy access to one library for easy modification
+        self.first_library = self.libraries[0]
+
+        self.libraries_metadata = self.get_libraries_metadata(self.libraries)
+
+    def get_libraries_metadata(self, libraries: List) -> List[Dict]:
+        return [
+            lib_md for library in libraries for lib_md in library.get_combined_library_metadata()
         ]
         self.dummy_field_names = {
             "scpca_project_id",

--- a/api/scpca_portal/test/test_metadata_file.py
+++ b/api/scpca_portal/test/test_metadata_file.py
@@ -51,15 +51,6 @@ class TestGetFileContents(TestCase):
             first_output_dict = next(csv.DictReader(output_buffer, delimiter=common.TAB))
             self.assertEqual(first_output_dict["technology"], "first;second;third")
 
-    def test_get_file_contents_missing_value(self):
-        self.first_library.metadata["seq_units"] = ""
-        libraries_metadata = self.get_libraries_metadata(self.libraries)
-        output_file_contents = metadata_file.get_file_contents(libraries_metadata)
-
-        with io.StringIO(output_file_contents) as output_buffer:
-            first_output_dict = next(csv.DictReader(output_buffer, delimiter=common.TAB))
-            self.assertEqual(first_output_dict["seq_units"], "NA")
-
     def test_get_file_contents_missing_field_name(self):
         self.first_library.metadata.pop("workflow_version")
         libraries_metadata = self.get_libraries_metadata(self.libraries)

--- a/bin/sportal
+++ b/bin/sportal
@@ -14,14 +14,14 @@ run_api = (
     # Docker compose uses the current directory in the network name. We
     # need to pass the network name into containers, so we have to know what it is.
     f"API_NETWORK={Path.cwd().name}_default "
-    f"docker-compose --env-file ./docker-compose.env run --rm api {{}}"
+    f"docker compose --env-file ./docker-compose.env run --rm api {{}}"
 )
 
 # List of available commands.
 commands = {
-    "up": "docker-compose --env-file ./docker-compose.env up",
-    "down": "docker-compose --env-file ./docker-compose.env down",
-    "build": "docker-compose --env-file ./docker-compose.env build",
+    "up": "docker compose --env-file ./docker-compose.env up",
+    "down": "docker compose --env-file ./docker-compose.env down",
+    "build": "docker compose --env-file ./docker-compose.env build",
     "shell": run_api.format('bash -c "./manage.py shell"'),
     "recreate-schema": "./recreate_schema.sh",
     "test-api": run_api.format('bash -c "./run_tests.sh {}"'),

--- a/recreate_schema.sh
+++ b/recreate_schema.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
-docker-compose --env-file ./docker-compose.env run --rm postgres psql -h postgres -U postgres -a -c "DROP SCHEMA public CASCADE;CREATE SCHEMA public;"
+docker compose --env-file ./docker-compose.env run --rm postgres psql -h postgres -U postgres -a -c "DROP SCHEMA public CASCADE;CREATE SCHEMA public;"
 ./bin/sportal migrate

--- a/run_psql_client.sh
+++ b/run_psql_client.sh
@@ -1,2 +1,2 @@
 #! /bin/sh
-docker-compose --env-file ./docker-compose.env run --rm postgres psql -h postgres -U postgres -d postgres
+docker compose --env-file ./docker-compose.env run --rm postgres psql -h postgres -U postgres -d postgres


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/816

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Refactor the following tests in `test_metadata_file::TestGetFileContents`:
- `setUp`
- `test_get_file_contents_successful_write`
- `test_get_file_contents_read_write_values_match`

Add additional tests in `test_metadata_file::TestGetFileContents`:
- `test_get_file_contents_multi_value_field`
- `test_get_file_contents_missing_value`
- `test_get_file_contents_missing_field_name`
- `test_get_file_contents_sort_order`

Additional changes introduced include:
- Populating metadata attribute in `factories::LibraryFactory` lazily to overcome sharing of attribute among all library factory instances.
- Handling transformation of `None` or empty string `""` values to `NA` when prepping metadata for writing in `metadata_file::format_metadata_dict`.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)


## Functional tests

Changes made to tests described in `Purpose/Implementation` section.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A