### PR TITLE
Ensure sample exists before creating library

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -332,8 +332,11 @@ class Project(CommonDataAttributes, TimestampedModel):
             # Multiplexed samples are represented in scpca_sample_id as comma separated lists
             # This ensures that all samples with be related to the correct library
             for sample_id in library_metadata["scpca_sample_id"].split(","):
-                sample = self.samples.get(scpca_id=sample_id)
-                Library.bulk_create_from_dicts([library_metadata], sample)
+                # We create samples based on what is in samples_metadata.csv
+                # If the sample folder is in the input bucket, but not listed
+                # we should skip creating that library as the sample won't exist.
+                if sample := self.samples.filter(scpca_id=sample_id).first():
+                    Library.bulk_create_from_dicts([library_metadata], sample)
 
     def purge(self, delete_from_s3=False):
         """Purges project and its related data."""


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This is a fix for a specific type of situation that we do not expect to encounter regularly. It seems prudent to include at this time because it is difficult to surface when an error occurs when reloading the portal as the output is pretty verbose and takes a long time. I don't expect myself or anyone else to sit there and watch the terminal for the duration of loading data.

The problem occurs when there is a PROJECT_ID/SAMPLE_ID/LIBRARY_ID_metadata.json file present when `SAMPLE_ID` is not present in `PROJECT_ID/samples_metadata.csv`. The error occurs when we try and fetch a Sample based on the ID present in the library metadata and it does not exist.

This fix conditionally creates the library only if the sample id present in the library metadata exists in the database.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
