### PR TITLE
Update download filename to match the portal documentation.

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -198,7 +198,12 @@ class Project(CommonDataAttributes, TimestampedModel):
         if self.has_multiplexed_data and not download_config.get("excludes_multiplexed", False):
             name_segments.append("MULTIPLEXED")
 
-        return f"{'_'.join(name_segments)}.zip"
+        # Change to filename format must be accompanied by an entry in the docs.
+        # Each segment should have hyphens and no underscores
+        # Each segment should be joined by underscores
+        file_name = "_".join([segment.replace("_", "-") for segment in name_segments])
+
+        return f"{file_name}.zip"
 
     def create_computed_files(
         self,

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -253,7 +253,12 @@ class Sample(CommonDataAttributes, TimestampedModel):
         if self.has_multiplexed_data:
             name_segments.append("MULTIPLEXED")
 
-        return f"{'_'.join(name_segments)}.zip"
+        # Change to filename format must be accompanied by an entry in the docs.
+        # Each segment should have hyphens and no underscores
+        # Each segment should be joined by underscores
+        file_name = "_".join([segment.replace("_", "-") for segment in name_segments])
+
+        return f"{file_name}.zip"
 
     @staticmethod
     def create_computed_files(


### PR DESCRIPTION
## Issue Number

N/A


## Purpose/Implementation Notes


We need to ensure that the filename user's download matches what is contained in our own documentation as to not confuse users. This change should be included in the next portal release and synchronized with the next documentation release as well.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
