### PR TITLE
Update postgres minor version 12.14 -> 12.19

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "postgres_db" {
   allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
-  engine_version = "12.14"
+  engine_version = "12.19"
   auto_minor_version_upgrade = false
   instance_class = var.database_instance_type
   name = "scpca_portal"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Does what it says on the tin. Our postgres install has upgraded minor versions in a maintenance window so terraform is trying to roll it back to 12.14. This PR prevents that by updating our specified version.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
