### PR TITLE
fix setting name AWS_S3_BUCKET_NAME

### DIFF
--- a/api/scpca_portal/s3.py
+++ b/api/scpca_portal/s3.py
@@ -128,7 +128,7 @@ def delete_output_file(key: str) -> bool:
         return True
 
     try:
-        aws_s3.delete_object(Bucket=settings.AWS_S3_BUCKET, Key=key)
+        aws_s3.delete_object(Bucket=settings.AWS_S3_BUCKET_NAME, Key=key)
     except Exception:
         logger.exception(
             "Failed to delete S3 object for Computed File.",


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- Fixes error with default bucket name's incomplete name

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
