### PR TITLE
update cert name: latest -> cert

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -1,7 +1,7 @@
 # This terraform file hosts the resources directly related to the
 # postgres RDS instance.
 
-data "aws_rds_certificate" "latest" {
+data "aws_rds_certificate" "cert" {
   latest_valid_till = true
 }
 
@@ -53,7 +53,7 @@ resource "aws_db_instance" "postgres_db" {
   multi_az = true
   publicly_accessible = true
 
-  ca_cert_identifier  = data.aws_rds_certificate.latest.id
+  ca_cert_identifier  = data.aws_rds_certificate.cert.id
 
   backup_retention_period  = var.stage == "prod" ? "7" : "0"
 


### PR DESCRIPTION
## Issue Number

#848 

## Purpose/Implementation Notes

Known error occurring in terraform where the `latest_valid_till` argument is returning multiple certs and the aws provider does not know what to do. There is an open issue here: 

I'd like to test if a rename works, If this does not work, I will open a PR for setting a specific version.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
