### PR TITLE
Explicitly set RDS CA: rds-ca-rsa2048-g1

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -2,7 +2,9 @@
 # postgres RDS instance.
 
 data "aws_rds_certificate" "cert" {
-  latest_valid_till = true
+  id = "rds-ca-rsa2048-g1"
+  # This returns multiple certs and the aws provider throws an error.
+  # latest_valid_till = true
 }
 
 resource "aws_db_parameter_group" "postgres12_parameters" {


### PR DESCRIPTION
## Issue Number

#848

## Purpose/Implementation Notes

Unable to get the `latest_version_till` to resolve a single certificate in a reasonable amount of time. This may be looked into in the future but this certificate will expire in the 2060's which seems sufficient.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
