### PR TITLE
842 - Add placeholder generate_computed_files command

### DIFF
--- a/api/scpca_portal/management/commands/generate_computed_files.py
+++ b/api/scpca_portal/management/commands/generate_computed_files.py
@@ -71,10 +71,6 @@ class Command(BaseCommand):
     def clean_up_input_data() -> None:
         shutil.rmtree(common.INPUT_DATA_PATH, ignore_errors=True)
 
-    @staticmethod
-    def clean_up_output_data() -> None:
-        shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
-
     def create_computed_file(self, future, *, update_s3: bool, clean_up_output_data: bool) -> None:
         """
         Saves computed file returned from future to the db.
@@ -148,7 +144,3 @@ class Command(BaseCommand):
         if clean_up_input_data:
             logger.info("Cleaning up input data")
             self.clean_up_input_data()
-
-        if clean_up_output_data:
-            logger.info("Cleaning up output directory")
-            self.clean_up_output_data()

--- a/api/scpca_portal/management/commands/generate_computed_files.py
+++ b/api/scpca_portal/management/commands/generate_computed_files.py
@@ -1,0 +1,146 @@
+import logging
+import shutil
+from argparse import BooleanOptionalAction
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from threading import Lock
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+from scpca_portal import common, s3, utils
+from scpca_portal.models import Project
+from scpca_portal.models.computed_file import ComputedFile
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
+
+
+class Command(BaseCommand):
+    help = """
+    Data files should be contained in an S3 bucket called scpca-portal-inputs.
+
+    The directory structure for this bucket should follow this pattern:
+        /project_metadata.csv
+        /SCPCP000001/libraries_metadata.csv
+        /SCPCP000001/samples_metadata.csv
+        /SCPCP000001/SCPCS000109/SCPCL000126_filtered.rds
+        /SCPCP000001/SCPCS000109/SCPCL000126_metadata.json
+        /SCPCP000001/SCPCS000109/SCPCL000126_processed.rds
+        /SCPCP000001/SCPCS000109/SCPCL000126_qc.html
+        /SCPCP000001/SCPCS000109/SCPCL000126_unfiltered.rds
+        /SCPCP000001/SCPCS000109/SCPCL000127_filtered.rds
+        /SCPCP000001/SCPCS000109/SCPCL000127_metadata.json
+        /SCPCP000001/SCPCS000109/SCPCL000127_processed.rds
+        /SCPCP000001/SCPCS000109/SCPCL000127_qc.html
+        /SCPCP000001/SCPCS000109/SCPCL000127_unfiltered.rds
+
+    The files will be zipped up and stats will be calculated for them.
+
+    If run locally the zipped ComputedFiles will be copied to the
+    "scpca-local-data" bucket.
+
+    If run in the cloud the zipped ComputedFiles files will be copied
+    to a stack-specific S3 bucket."""
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--clean-up-input-data",
+            action=BooleanOptionalAction,
+            type=bool,
+            default=settings.PRODUCTION,
+        )
+        parser.add_argument(
+            "--clean-up-output-data",
+            action=BooleanOptionalAction,
+            type=bool,
+            default=settings.PRODUCTION,
+        )
+        parser.add_argument("--max-workers", type=int, default=10)
+        parser.add_argument("--scpca-project-id", type=str)
+        parser.add_argument(
+            "--update-s3", action=BooleanOptionalAction, type=bool, default=settings.UPDATE_S3_DATA
+        )
+
+    def handle(self, *args, **kwargs):
+        self.generate_computed_files(**kwargs)
+
+    @staticmethod
+    def clean_up_input_data() -> None:
+        shutil.rmtree(common.INPUT_DATA_PATH, ignore_errors=True)
+
+    @staticmethod
+    def clean_up_output_data() -> None:
+        shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
+
+    def create_computed_file(self, future, *, update_s3: bool, clean_up_output_data: bool) -> None:
+        """
+        Saves computed file returned from future to the db.
+        Uploads file to s3 and cleans up output data depending on passed options.
+        """
+        if computed_file := future.result():
+
+            # Only upload and clean up projects and the last sample if multiplexed
+            if computed_file.project or computed_file.sample.is_last_multiplexed_sample:
+                if update_s3:
+                    s3.upload_output_file(computed_file.s3_key, computed_file.s3_bucket)
+                if clean_up_output_data:
+                    computed_file.clean_up_local_computed_file()
+            computed_file.save()
+
+        # Close DB connection for each thread.
+        connection.close()
+
+    def generate_computed_files(self, **kwargs) -> None:
+        """Generates a project's computed files according predetermined download configurations"""
+        project = Project.objects.get(scpca_id=kwargs["scpca_project_id"])
+
+        # Prepare data input directory.
+        common.INPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
+
+        # Prepare data output directory.
+        shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
+        common.OUTPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
+
+        # Prep callback function
+        create_computed_file_kwargs = utils.filter_dict_by_keys(
+            kwargs, {"update_s3", "clean_up_output_data"}
+        )
+        on_get_file = partial(self.create_computed_file, **create_computed_file_kwargs)
+
+        # Prepare a threading.Lock for each sample, with the chief purpose being to protect
+        # multiplexed samples that share a zip file.
+        locks = {}
+        with ThreadPoolExecutor(max_workers=kwargs["max_workers"]) as tasks:
+            # Generated project computed files
+            for config in common.GENERATED_PROJECT_DOWNLOAD_CONFIGURATIONS:
+                tasks.submit(
+                    ComputedFile.get_project_file,
+                    project,
+                    config,
+                    project.get_download_config_file_output_name(config),
+                ).add_done_callback(on_get_file)
+
+            # Generated sample computed files
+            for sample in project.samples.all():
+                for config in common.GENERATED_SAMPLE_DOWNLOAD_CONFIGURATIONS:
+                    sample_lock = locks.setdefault(sample.get_config_identifier(config), Lock())
+                    tasks.submit(
+                        ComputedFile.get_sample_file,
+                        sample,
+                        config,
+                        sample.get_download_config_file_output_name(config),
+                        sample_lock,
+                    ).add_done_callback(on_get_file)
+
+        project.update_downloadable_sample_count()
+
+        if kwargs["clean_up_input_data"]:
+            logger.info("Cleaning up input data")
+            self.clean_up_input_data()
+
+        if kwargs["clean_up_output_data"]:
+            logger.info("Cleaning up output directory")
+            self.clean_up_output_data()

--- a/api/scpca_portal/management/commands/generate_computed_files.py
+++ b/api/scpca_portal/management/commands/generate_computed_files.py
@@ -100,6 +100,9 @@ class Command(BaseCommand):
     ) -> None:
         """Generates a project's computed files according predetermined download configurations"""
         project = Project.objects.get(scpca_id=scpca_project_id)
+        # Purge all of a project's computed files (and optionally delete them from s3),
+        # before generating new ones
+        project.purge_computed_files(update_s3)
 
         # Prepare data input directory.
         common.INPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -3,7 +3,6 @@ import shutil
 from argparse import BooleanOptionalAction
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, Set
 
@@ -149,11 +148,6 @@ class Command(BaseCommand):
     def clean_up_input_data(project) -> None:
         shutil.rmtree(common.INPUT_DATA_PATH / project.scpca_id, ignore_errors=True)
 
-    @staticmethod
-    def clean_up_output_data() -> None:
-        for path in Path(common.OUTPUT_DATA_PATH).glob("*"):
-            path.unlink(missing_ok=True)
-
     def load_data(
         self,
         input_bucket_name: str,
@@ -244,7 +238,3 @@ class Command(BaseCommand):
             if clean_up_input_data:
                 logger.info(f"Cleaning up '{project}' input data")
                 self.clean_up_input_data(project)
-
-            if clean_up_output_data:
-                logger.info("Cleaning up output directory")
-                self.clean_up_output_data()

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -304,26 +304,32 @@ class Project(CommonDataAttributes, TimestampedModel):
                 if sample := self.samples.filter(scpca_id=sample_id).first():
                     Library.bulk_create_from_dicts([library_metadata], sample)
 
-    def purge(self, delete_from_s3=False) -> None:
+    def purge(self, delete_from_s3: bool = False) -> None:
         """Purges project and its related data."""
+        self.purge_computed_files(delete_from_s3)
         for sample in self.samples.all():
-            for computed_file in sample.computed_files:
-                if delete_from_s3:
-                    s3.delete_output_file(computed_file.s3_key, computed_file.s3_bucket)
-                computed_file.delete()
             for library in sample.libraries.all():
                 # If library has other samples that it is related to, then don't delete it
                 if len(library.samples.all()) == 1:
                     library.delete()
             sample.delete()
 
+        self.delete()
+
+    def purge_computed_files(self, delete_from_s3: bool = False) -> None:
+        """Purges all computed files associated with the project instance."""
+        # Delete project's sample computed files
+        for sample in self.samples.all():
+            for computed_file in sample.computed_files:
+                if delete_from_s3:
+                    s3.delete_output_file(computed_file.s3_key, computed_file.s3_bucket)
+                computed_file.delete()
+
+        # Delete project's project computed files
         for computed_file in self.computed_files:
             if delete_from_s3:
                 s3.delete_output_file(computed_file.s3_key, computed_file.s3_bucket)
             computed_file.delete()
-
-        ProjectSummary.objects.filter(project=self).delete()
-        self.delete()
 
     def update_sample_derived_properties(self):
         """

--- a/api/scpca_portal/test/management/commands/test_generate_computed_files.py
+++ b/api/scpca_portal/test/management/commands/test_generate_computed_files.py
@@ -1,0 +1,42 @@
+import shutil
+from functools import partial
+
+from django.core.management import call_command
+from django.test import TransactionTestCase
+
+from scpca_portal import common
+
+
+class TestGenerateComputedFiles(TransactionTestCase):
+    def setUp(self):
+        self.load_metadata = partial(call_command, "load_metadata")
+        self.generate_computed_files = partial(call_command, "generate_computed_files")
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
+
+    def test_project_SCPCP999990(self):
+        pass
+
+    def test_project_SCPCP999991(self):
+        pass
+
+    def test_project_SCPCP999992(self):
+        pass
+
+    def test_clean_up_input_data(self):
+        pass
+
+    def test_clean_up_output_data(self):
+        pass
+
+    def test_custom_max_workers(self):
+        pass
+
+    def test_passed_scpca_project_id(self):
+        pass
+
+    def test_update_s3(self):
+        pass

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -1,4 +1,5 @@
 import csv
+import os
 import shutil
 from functools import partial
 from io import TextIOWrapper
@@ -68,9 +69,9 @@ class TestLoadData(TransactionTestCase):
         )
 
         mock_clean_up_input_data.assert_called_once()
-        # would be good to check here that both input and output data dirs are empty
-        # this is necessary because we no longer call clean_up_output_data at the end,
-        # as it's done per computed file
+        # Because we clean up output data on a per computed file level,
+        # this is the best way to check that output data was cleaned up properly
+        self.assertListEqual(os.listdir(common.OUTPUT_DATA_PATH), [])
 
     def test_load_data(self):
         project_id = "SCPCP999990"

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -54,9 +54,8 @@ class TestLoadData(TransactionTestCase):
     def assertProjectReadmeContains(self, text, project_zip):
         self.assertIn(text, project_zip.read("README.md").decode("utf-8"))
 
-    @patch("scpca_portal.management.commands.load_data.Command.clean_up_output_data")
     @patch("scpca_portal.management.commands.load_data.Command.clean_up_input_data")
-    def test_data_clean_up(self, mock_clean_up_input_data, mock_clean_up_output_data):
+    def test_data_clean_up(self, mock_clean_up_input_data):
         project_id = "SCPCP999990"
         self.load_data(
             clean_up_input_data=True,
@@ -69,7 +68,9 @@ class TestLoadData(TransactionTestCase):
         )
 
         mock_clean_up_input_data.assert_called_once()
-        mock_clean_up_output_data.assert_called_once()
+        # would be good to check here that both input and output data dirs are empty
+        # this is necessary because we no longer call clean_up_output_data at the end,
+        # as it's done per computed file
 
     def test_load_data(self):
         project_id = "SCPCP999990"

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -69,8 +69,8 @@ class TestLoadData(TransactionTestCase):
         )
 
         mock_clean_up_input_data.assert_called_once()
-        # Because we clean up output data on a per computed file level,
-        # this is the best way to check that output data was cleaned up properly
+        # Because we clean up output data by deleting computed files as they're completed,
+        # doing this check at the end is the cleanest way to assess cleanup was done properly
         self.assertListEqual(os.listdir(common.OUTPUT_DATA_PATH), [])
 
     def test_load_data(self):


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/842

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Added a placeholder for the `generate_computed_files` command. Currently, the command take the functionality of the `load_data` command, as it pertains to the creation of a project's computed files.

This command will serve as the entry point for Batch instances, generating all of a passed project's computed files (according to a predetermined collection of download configs), and uploading them to s3.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A