### PR TITLE
Sum estimated demux sample counts

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -385,10 +385,8 @@ class Project(CommonDataAttributes, TimestampedModel):
                 # Sum demux_cell_count_estimate from all related library's
                 # sample_cell_estimates for that sample.
                 sample.demux_cell_count_estimate = sum(
-                    [
-                        library.metadata["sample_cell_estimates"].get(sample.scpca_id, 0)
-                        for library in multiplexed_libraries
-                    ]
+                    library.metadata["sample_cell_estimates"].get(sample.scpca_id, 0)
+                    for library in multiplexed_libraries
                 )
             else:
                 sample.sample_cell_count_estimate = sample_cell_count_estimate

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -175,6 +175,14 @@ class Sample(CommonDataAttributes, TimestampedModel):
         return self.sample_computed_files.order_by("created_at")
 
     @property
+    def multiplexed_with_samples(self):
+        return (
+            Sample.objects.filter(libraries__in=self.libraries.filter(is_multiplexed=True))
+            .distinct()
+            .exclude(scpca_id=self.scpca_id)
+        )
+
+    @property
     def multiplexed_ids(self):
         multiplexed_sample_ids = [self.scpca_id]
         multiplexed_sample_ids.extend(self.multiplexed_with)


### PR DESCRIPTION
## Issue Number

N/A though related to #898

## Purpose/Implementation Notes

The goal of this PR was to correctly sum multiplexed libraries sample counts located in the library's metadata json file attribute `sample_cell_estimates`. This dictionary contains the partial number for each sample and needs to be summed up when assigning `demux_cell_count_estimate` on a multiplexed sample.

Additionally, I updated the evaluation of `sample.multiplexed_with` to use a new property `sample.multiplexed_with_samples` under the hood. This was a change for clarity and ultimately does the same as the original implementation.

Coverage for this change will be available once `feature/loader` is merged into dev.

**Edit** see comment below about test coverage.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

- Loaded SCPCP000009 locally and looked at the local sample table.

Ex. for sample SCPCS000133 the estimated demux sample counts are the sum of two libraries:
```bash
# ls SCPCS000133,SCPCS000134,SCPCS000135,SCPCS000136/
.rw-r--r-- 1.2k david 12 Aug 13:54 SCPCL000533_metadata.json
.rw-r--r-- 1.2k david 12 Aug 13:54 SCPCL000535_metadata.json

# cat ./* | grep \"SCPCS000133\":
    "SCPCS000133": 2841,
    "SCPCS000133": 2141,
```

The sum of 4982 is now on the samples table.
<img width="870" alt="Screenshot 2024-09-24 at 10 38 45 AM" src="https://github.com/user-attachments/assets/eda5606e-0418-42a7-b9fd-1c8f151dc842">


## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A see above
