### PR TITLE
903 - Update Test Bucket to 2024-09-10

### DIFF
--- a/api/scpca_portal/config/local.py
+++ b/api/scpca_portal/config/local.py
@@ -17,7 +17,7 @@ class Local(Common):
     AWS_REGION = None
 
     # AWS S3
-    TEST_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-07-19/"
+    TEST_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-09-10/"
     AWS_S3_INPUT_BUCKET_NAME = TEST_INPUT_BUCKET_NAME if Common.TEST else "scpca-portal-inputs"
     AWS_S3_OUTPUT_BUCKET_NAME = "scpca-local-data"
 

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -28,6 +28,8 @@ PROJECT_METADATA_KEYS = [
     ("citation_doi", "doi", None),
 ]
 
+PROJECT_METADATA_VALUES_TRANSFORMS = {"diagnoses": lambda d: ", ".join(sorted(d.split(";")))}
+
 LIBRARY_METADATA_KEYS = [
     ("library_id", "scpca_library_id", None),
     ("sample_id", "scpca_sample_id", None),
@@ -48,6 +50,7 @@ def load_projects_metadata(*, filter_on_project_id: str = None):
 
     for project_metadata in projects_metadata:
         transform_keys(project_metadata, PROJECT_METADATA_KEYS)
+        transform_values(project_metadata, PROJECT_METADATA_VALUES_TRANSFORMS)
 
     if filter_on_project_id:
         return [pm for pm in projects_metadata if pm["scpca_project_id"] == filter_on_project_id]
@@ -80,6 +83,16 @@ def transform_keys(data_dict: Dict, key_transforms: List[Tuple]):
     for element in [KeyTransform._make(element) for element in key_transforms]:
         if element.old_key in data_dict:
             data_dict[element.new_key] = data_dict.pop(element.old_key, element.default_value)
+
+    return data_dict
+
+
+def transform_values(data_dict: Dict, value_transforms: List[Tuple]):
+    """
+    Transform values in data dict according to transformation functions in value transform dict.
+    """
+    for key, transformation_function in value_transforms.items():
+        data_dict[key] = transformation_function(data_dict[key])
 
     return data_dict
 

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -446,7 +446,6 @@ class Project(CommonDataAttributes, TimestampedModel):
         """
 
         additional_metadata_keys = set()
-        diagnoses = set()
         diagnoses_counts = Counter()
         disease_timings = set()
         modalities = set()
@@ -457,7 +456,6 @@ class Project(CommonDataAttributes, TimestampedModel):
 
         for sample in self.samples.all():
             additional_metadata_keys.update(sample.additional_metadata.keys())
-            diagnoses.add(sample.diagnosis)
             diagnoses_counts.update({sample.diagnosis: 1})
             disease_timings.add(sample.disease_timing)
             modalities.update(sample.modalities)
@@ -487,7 +485,6 @@ class Project(CommonDataAttributes, TimestampedModel):
             additional_metadata_keys.remove("multiplexed_with")
 
         self.additional_metadata_keys = ", ".join(sorted(additional_metadata_keys, key=str.lower))
-        self.diagnoses = ", ".join(sorted(diagnoses))
         self.diagnoses_counts = ", ".join(diagnoses_strings)
         self.disease_timings = ", ".join(disease_timings)
         self.modalities = sorted(modalities)

--- a/api/scpca_portal/test/expected_values/project_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999990.py
@@ -15,8 +15,8 @@ class Project_SCPCP999990:
             "SCPCP999990/bulk/SCPCP999990_bulk_metadata.tsv",
             "SCPCP999990/bulk/SCPCP999990_bulk_quant.tsv",
         ],
-        "diagnoses": "diagnosis1, diagnosis2, diagnosis5, diagnosis8",
-        "diagnoses_counts": "diagnosis1 (1), diagnosis2 (1), diagnosis5 (1), diagnosis8 (1)",
+        "diagnoses": "diagnosis1, diagnosis2, diagnosis5",
+        "diagnoses_counts": "diagnosis1 (1), diagnosis2 (1), diagnosis5 (2)",
         "disease_timings": "Initial diagnosis",
         # This value is not determined until after computed file generation, and should be 3
         "downloadable_sample_count": 0,
@@ -67,7 +67,7 @@ class Project_SCPCP999990:
             "is_cell_line": False,
             "is_xenograft": False,
             "multiplexed_with": [],
-            "sample_cell_count_estimate": 3432,
+            "sample_cell_count_estimate": 3424,
             "scpca_id": SCPCA_ID,
             "sex": "M",
             "seq_units": "cell",
@@ -137,7 +137,7 @@ class Project_SCPCP999990:
             "age": "2",
             "age_timing": "collection",
             "demux_cell_count_estimate": None,
-            "diagnosis": "diagnosis8",
+            "diagnosis": "diagnosis5",
             "disease_timing": "Initial diagnosis",
             "has_bulk_rna_seq": False,
             "has_cite_seq_data": False,
@@ -148,7 +148,7 @@ class Project_SCPCP999990:
             "is_cell_line": False,
             "is_xenograft": False,
             "multiplexed_with": [],
-            "sample_cell_count_estimate": 1568,
+            "sample_cell_count_estimate": 1570,
             "scpca_id": SCPCA_ID,
             "sex": "M",
             "seq_units": "cell",
@@ -260,7 +260,7 @@ class Project_SCPCP999990:
 
     class Summary4:
         VALUES = {
-            "diagnosis": "diagnosis8",
+            "diagnosis": "diagnosis5",
             "sample_count": 1,
             "seq_unit": "cell",
             "technology": "10Xv3",

--- a/api/scpca_portal/test/expected_values/project_SCPCP999991.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999991.py
@@ -49,7 +49,7 @@ class Project_SCPCP999991:
             "age": "2",
             "age_timing": "unknown",
             "demux_cell_count_estimate": 0,
-            "diagnosis": "diagnosis3",
+            "diagnosis": "diagnosis4",
             "disease_timing": "Initial diagnosis",
             "has_bulk_rna_seq": False,
             "has_cite_seq_data": False,
@@ -76,7 +76,7 @@ class Project_SCPCP999991:
             "age": "2",
             "age_timing": "diagnosis",
             "demux_cell_count_estimate": 0,
-            "diagnosis": "diagnosis4",
+            "diagnosis": "diagnosis3",
             "disease_timing": "Initial diagnosis",
             "has_bulk_rna_seq": False,
             "has_cite_seq_data": False,
@@ -114,7 +114,7 @@ class Project_SCPCP999991:
             "is_cell_line": False,
             "is_xenograft": False,
             "multiplexed_with": [],
-            "sample_cell_count_estimate": 3433,
+            "sample_cell_count_estimate": 3428,
             "scpca_id": SCPCA_ID,
             "sex": "M",
             "seq_units": "cell",
@@ -167,7 +167,7 @@ class Project_SCPCP999991:
 
     class Summary1:
         VALUES = {
-            "diagnosis": "diagnosis3",
+            "diagnosis": "diagnosis4",
             "sample_count": 1,
             "seq_unit": "nucleus",
             "technology": "10Xv3.1",
@@ -175,7 +175,7 @@ class Project_SCPCP999991:
 
     class Summary2:
         VALUES = {
-            "diagnosis": "diagnosis4",
+            "diagnosis": "diagnosis3",
             "sample_count": 1,
             "seq_unit": "nucleus",
             "technology": "10Xv3.1",

--- a/api/scpca_portal/test/expected_values/project_SCPCP999992.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999992.py
@@ -14,8 +14,8 @@ class Project_SCPCP999992:
             "SCPCP999992/merged/SCPCP999992_merged_adt.h5ad",
             "SCPCP999992/merged/SCPCP999992_merged_rna.h5ad",
         ],
-        "diagnoses": "diagnosis7, diagnosis9",
-        "diagnoses_counts": "diagnosis7 (1), diagnosis9 (1)",
+        "diagnoses": "diagnosis7",
+        "diagnoses_counts": "diagnosis7 (2)",
         "disease_timings": "Initial diagnosis",
         # This value is not determined until after computed file generation, and should be 2
         "downloadable_sample_count": 0,
@@ -79,7 +79,7 @@ class Project_SCPCP999992:
             "age": "2",
             "age_timing": "unknown",
             "demux_cell_count_estimate": None,
-            "diagnosis": "diagnosis9",
+            "diagnosis": "diagnosis7",
             "disease_timing": "Initial diagnosis",
             "has_bulk_rna_seq": False,
             "has_cite_seq_data": True,
@@ -90,7 +90,7 @@ class Project_SCPCP999992:
             "is_cell_line": False,
             "is_xenograft": False,
             "multiplexed_with": [],
-            "sample_cell_count_estimate": 5245,
+            "sample_cell_count_estimate": 5247,
             "scpca_id": SCPCA_ID,
             "sex": "M",
             "seq_units": "cell",
@@ -161,7 +161,7 @@ class Project_SCPCP999992:
 
     class Summary2:
         VALUES = {
-            "diagnosis": "diagnosis9",
+            "diagnosis": "diagnosis7",
             "sample_count": 1,
             "seq_unit": "cell",
             "technology": "10Xv2_5prime",

--- a/api/scpca_portal/test/views/test_filter_options.py
+++ b/api/scpca_portal/test/views/test_filter_options.py
@@ -26,7 +26,7 @@ class FilterOptionsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = response.json()
-        self.assertEqual(len(response["diagnoses"]), 4)
+        self.assertEqual(len(response["diagnoses"]), 2)
         self.assertEqual(len(response["modalities"]), 1)  # CITE-seq only.
         self.assertEqual(len(response["seq_units"]), 2)
         self.assertEqual(len(response["technologies"]), 5)


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/903

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR updates the test bucket from `scpca-portal-public-test-inputs/2024-07-19/` to `scpca-portal-public-test-inputs/2024-09-10/`.

In order to accommodate the change in how the `Project` attribute `diagnoses` is handled, a `PROJECT_METADATA_VALUES_TRANSFORMS` constant and `transform_values` helper function were added to `metadata_file`.

Values in the `expected_values/` files were also updated in order to match any changed values in the metadata files in the new test bucket.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A