### PR TITLE
902 - Add test_readme_file for readme tests 

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -16,8 +16,6 @@ DATA_PATH = CODE_PATH / ("test_data" if settings.TEST else "data")
 INPUT_DATA_PATH = DATA_PATH / "input"
 OUTPUT_DATA_PATH = DATA_PATH / "output"
 
-EXPECTED_VALUES_PATH = CODE_PATH / "scpca_portal" / "test" / "expected_values"
-
 TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"
 
 TAB = "\t"

--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -16,6 +16,8 @@ DATA_PATH = CODE_PATH / ("test_data" if settings.TEST else "data")
 INPUT_DATA_PATH = DATA_PATH / "input"
 OUTPUT_DATA_PATH = DATA_PATH / "output"
 
+EXPECTED_VALUES_PATH = CODE_PATH / "scpca_portal" / "test" / "expected_values"
+
 TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"
 
 TAB = "\t"

--- a/api/scpca_portal/templates/readme/contents/METADATA_ONLY.md
+++ b/api/scpca_portal/templates/readme/contents/METADATA_ONLY.md
@@ -1,7 +1,8 @@
 ## Contents
 
 {% if projects|length > 1 %}This download includes associated metadata for samples from all projects currently available at time of download in the ScPCA portal.
-{% else %}{% for project in projects %}This download includes associated metadata for samples from project [{{ project.scpca_id }}]({{ project.url }}) in the ScPCA portal.{% endfor %}{% endif %}
+{% else %}{% for project in projects %}This download includes associated metadata for samples from project [{{ project.scpca_id }}]({{ project.url }}) in the ScPCA portal.{% endfor %}
+{% endif %}
 The metadata included in this download contains sample, library, and project-related metadata (e.g., age, sex, diagnosis, sequencing unit, etc.) along with any relevant processing metadata (e.g., software versions, filtering methods used, etc.).
 
 See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html) section in our documentation for more detailed information on files included in the download.

--- a/api/scpca_portal/test/expected_values/computed_file_project.py
+++ b/api/scpca_portal/test/expected_values/computed_file_project.py
@@ -229,7 +229,7 @@ class Computed_File_Project:
             "metadata_only": True,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCP999990_ALL_METADATA.zip",
-            "size_in_bytes": 5184,
+            "size_in_bytes": 5185,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }

--- a/api/scpca_portal/test/expected_values/readmes/ALL_METADATA.md
+++ b/api/scpca_portal/test/expected_values/readmes/ALL_METADATA.md
@@ -1,0 +1,47 @@
+Generated on: TEST_TODAYS_DATE
+
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes associated metadata for samples from project [PROJECT_ID_0](https://scpca.alexslemonade.org/projects/PROJECT_ID_0) in the ScPCA portal.
+
+The metadata included in this download contains sample, library, and project-related metadata (e.g., age, sex, diagnosis, sequencing unit, etc.) along with any relevant processing metadata (e.g., software versions, filtering methods used, etc.).
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html) section in our documentation for more detailed information on files included in the download.
+
+## CHANGELOG
+
+A summary of changes impacting downloads from the ScPCA Portal is available in [the CHANGELOG section of our documentation](https://scpca.readthedocs.io/en/stable/CHANGELOG.html).
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citation
+
+If you use these data in your research, you must cite:
+- The data submitter using language provided as part of the project abstract (as applicable), the publication listed for the project (as applicable), or both.
+- The ScPCA Portal using the language below.
+
+For more information, please see [the How to Cite section of our documentation](https://scpca.readthedocs.io/en/stable/citation.html).
+
+### Citing this project
+
+To cite data from PROJECT_ID_0, please see the project abstract and publication information at [PROJECT_ID_0 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)
+
+### Citing the ScPCA Portal
+
+When citing the ScPCA Portal, please cite the following preprint:
+
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+### Additional Restrictions
+
+This dataset is designated as research or academic purposes only.

--- a/api/scpca_portal/test/expected_values/readmes/PORTAL_ALL_METADATA.md
+++ b/api/scpca_portal/test/expected_values/readmes/PORTAL_ALL_METADATA.md
@@ -1,0 +1,53 @@
+Generated on: TEST_TODAYS_DATE
+
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes associated metadata for samples from all projects currently available at time of download in the ScPCA portal.
+
+The metadata included in this download contains sample, library, and project-related metadata (e.g., age, sex, diagnosis, sequencing unit, etc.) along with any relevant processing metadata (e.g., software versions, filtering methods used, etc.).
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html) section in our documentation for more detailed information on files included in the download.
+
+## CHANGELOG
+
+A summary of changes impacting downloads from the ScPCA Portal is available in [the CHANGELOG section of our documentation](https://scpca.readthedocs.io/en/stable/CHANGELOG.html).
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citation
+
+If you use these data in your research, you must cite:
+- The data submitter using language provided as part of the project abstract (as applicable), the publication listed for the project (as applicable), or both.
+- The ScPCA Portal using the language below.
+
+For more information, please see [the How to Cite section of our documentation](https://scpca.readthedocs.io/en/stable/citation.html).
+
+### Citing this project
+
+To cite data from PROJECT_ID_0, please see the project abstract and publication information at [PROJECT_ID_0 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)
+To cite data from PROJECT_ID_1, please see the project abstract and publication information at [PROJECT_ID_1 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_1)
+To cite data from PROJECT_ID_2, please see the project abstract and publication information at [PROJECT_ID_2 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_2)
+
+### Citing the ScPCA Portal
+
+When citing the ScPCA Portal, please cite the following preprint:
+
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+### Additional Restrictions
+
+|Project ID|Data Usage Restrictions|
+|:---------|:----------------------|
+|[PROJECT_ID_0](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)|Research or academic purposes only|
+|[PROJECT_ID_1](https://scpca.alexslemonade.org/projects/PROJECT_ID_1)|Research or academic purposes only|
+|[PROJECT_ID_2](https://scpca.alexslemonade.org/projects/PROJECT_ID_2)|Research or academic purposes only|

--- a/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_ANN_DATA.md
+++ b/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_ANN_DATA.md
@@ -1,0 +1,76 @@
+Generated on: TEST_TODAYS_DATE
+
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes single-cell or single-nuclei gene expression files and associated metadata for samples from project [PROJECT_ID_0](https://scpca.alexslemonade.org/projects/PROJECT_ID_0) in the ScPCA portal.
+
+Each sample folder (indicated by the `SCPCS` prefix) contains the files for all libraries (`SCPCL` prefix) derived from that biological sample.
+Most samples only have one library that has been sequenced.
+See the [FAQ section about samples and libraries](https://scpca.readthedocs.io/en/stable/faq.html#what-is-the-difference-between-samples-and-libraries) for more information.
+
+The files associated with each library are (example shown for a library with ID `SCPCL000000`):
+
+- An unfiltered counts file: `SCPCL000000_unfiltered_rna.h5ad`,
+- A filtered counts file: `SCPCL000000_filtered_rna.h5ad`,
+- A processed counts file: `SCPCL000000_processed_rna.h5ad`,
+- A quality control report: `SCPCL000000_qc.html`,
+- A supplemental cell type report: `SCPCL000000_celltype-report.html`
+
+Also included in each download is `single_cell_metadata.tsv`, a tab-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.
+
+Gene expression files, available as H5AD files containing an `AnnData` object, house the expression data, cell and gene metrics, and associated metadata (see [Single-cell gene expression file contents](https://scpca.readthedocs.io/en/stable/sce_file_contents.html) for more information).
+
+In the case of multi-modal data like CITE-seq (ADT tags), the ADT expression matrices will be provided in separate files corresponding to the same three stages of data processing: an unfiltered object (`_unfiltered_adt.h5ad`), a filtered object (`_filtered_adt.h5ad`), and a processed object (`_processed_adt.h5ad`).
+These files will only contain ADT expression data and not RNA expression data.
+
+Samples that are part of multiplexed libraries are not available as `AnnData` objects and are not included in this download.
+Please see [FAQ: Which samples can I download as AnnData objects?](https://scpca.readthedocs.io/en/stable/faq.html#which-samples-can-i-download-as-anndata-objects).
+
+If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download.
+The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
+The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html) section in our documentation for more detailed information on files included in the download.
+
+## Usage
+
+For instructions on using the H5AD files, please see [FAQ: How do I use the provided H5AD files in Python?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-h5ad-files-in-python).
+For more information on working with the processed `AnnData` objects, see [`Getting started with an ScPCA dataset`](https://scpca.readthedocs.io/en/stable/getting_started.html).
+
+## CHANGELOG
+
+A summary of changes impacting downloads from the ScPCA Portal is available in [the CHANGELOG section of our documentation](https://scpca.readthedocs.io/en/stable/CHANGELOG.html).
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citation
+
+If you use these data in your research, you must cite:
+- The data submitter using language provided as part of the project abstract (as applicable), the publication listed for the project (as applicable), or both.
+- The ScPCA Portal using the language below.
+
+For more information, please see [the How to Cite section of our documentation](https://scpca.readthedocs.io/en/stable/citation.html).
+
+### Citing this project
+
+To cite data from PROJECT_ID_0, please see the project abstract and publication information at [PROJECT_ID_0 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)
+
+### Citing the ScPCA Portal
+
+When citing the ScPCA Portal, please cite the following preprint:
+
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+### Additional Restrictions
+
+This dataset is designated as research or academic purposes only.

--- a/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_ANN_DATA_MERGED.md
+++ b/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_ANN_DATA_MERGED.md
@@ -1,0 +1,71 @@
+Generated on: TEST_TODAYS_DATE
+
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes single-cell or single-nuclei gene expression data and associated metadata for all samples and libraries from a project [PROJECT_ID_0](https://scpca.alexslemonade.org/projects/PROJECT_ID_0) in the ScPCA portal.
+All gene expression data for all samples and libraries have been merged into a single `AnnData` object, stored as an `.h5ad` file.
+In addition to the merged object, each download includes a summary report describing the contents of the merged file and a folder with all quality control reports, and, if applicable, cell type annotation reports, for each library included in the merged object.
+
+The download will include the following files for the selected project (example shown for project with ID `SCPCP000000`):
+
+- A merged file containing all gene expression data: `SCPCP000000_merged_rna.h5ad`
+- A summary report: `SCPCP000000_merged-summary-report.html`
+- A folder containing all reports for individual libraries:
+  - A quality control report: `SCPCL000000_qc.html`
+  - A supplemental cell type report: `SCPCL000000_celltype-report.html`
+
+Also included in each download is `single_cell_metadata.tsv`, a tab-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.
+
+Merged objects, available as H5AD files containing a `AnnData` object, house the expression data, cell and gene metrics, associated metadata for all samples and libraries from the selected project (see [Merged objects](https://scpca.readthedocs.io/en/stable/merged_objects.html) for more information).
+
+In the case of multi-modal data like CITE-seq (ADT tags), the merged ADT expression matrix will be provided in a separate file, `_merged_adt.h5ad`.
+This file will only contain ADT expression data and not RNA expression data.
+
+If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download.
+The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
+The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html) section in our documentation for more detailed information on files included in the download.
+
+## Usage
+
+For instructions on using the H5AD files, please see [FAQ: How do I use the provided H5AD files in Python?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-h5ad-files-in-python).
+For more information on working with the processed `AnnData` objects, see [`Getting started with an ScPCA dataset`](https://scpca.readthedocs.io/en/stable/getting_started.html).
+
+## CHANGELOG
+
+A summary of changes impacting downloads from the ScPCA Portal is available in [the CHANGELOG section of our documentation](https://scpca.readthedocs.io/en/stable/CHANGELOG.html).
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citation
+
+If you use these data in your research, you must cite:
+- The data submitter using language provided as part of the project abstract (as applicable), the publication listed for the project (as applicable), or both.
+- The ScPCA Portal using the language below.
+
+For more information, please see [the How to Cite section of our documentation](https://scpca.readthedocs.io/en/stable/citation.html).
+
+### Citing this project
+
+To cite data from PROJECT_ID_0, please see the project abstract and publication information at [PROJECT_ID_0 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)
+
+### Citing the ScPCA Portal
+
+When citing the ScPCA Portal, please cite the following preprint:
+
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+### Additional Restrictions
+
+This dataset is designated as research or academic purposes only.

--- a/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_SINGLE_CELL_EXPERIMENT.md
+++ b/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_SINGLE_CELL_EXPERIMENT.md
@@ -1,0 +1,73 @@
+Generated on: TEST_TODAYS_DATE
+
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes single-cell or single-nuclei gene expression files and associated metadata for samples from project [PROJECT_ID_0](https://scpca.alexslemonade.org/projects/PROJECT_ID_0) in the ScPCA portal.
+
+Each sample folder (indicated by the `SCPCS` prefix) contains the files for all libraries (`SCPCL` prefix) derived from that biological sample.
+Most samples only have one library that has been sequenced.
+See the [FAQ section about samples and libraries](https://scpca.readthedocs.io/en/stable/faq.html#what-is-the-difference-between-samples-and-libraries) for more information.
+
+The files associated with each library are (example shown for a library with ID `SCPCL000000`):
+
+- An unfiltered counts file: `SCPCL000000_unfiltered.rds`,
+- A filtered counts file: `SCPCL000000_filtered.rds`,
+- A processed counts file: `SCPCL000000_processed.rds`,
+- A quality control report: `SCPCL000000_qc.html`,
+- A supplemental cell type report: `SCPCL000000_celltype-report.html`
+
+Also included in each download is `single_cell_metadata.tsv`, a tab-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.
+
+Gene expression files, available as RDS files containing a `SingleCellExperiment` object, house the expression data, cell and gene metrics, associated metadata, and in the case of multi-modal data like CITE-seq, data from the additional cell-based assays (see [Single-cell gene expression file contents](https://scpca.readthedocs.io/en/stable/sce_file_contents.html) for more information).
+
+This download does not include any samples that are part of multiplexed libraries.
+To download all samples in this project, including multiplexed libraries, if present, visit the [project page](https://scpca.alexslemonade.org/projects/PROJECT_ID_0).
+
+If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download.
+The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
+The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html) section in our documentation for more detailed information on files included in the download.
+
+## Usage
+
+For instructions on using the RDS files, please see [FAQ: How do I use the provided files in R?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-rds-files-in-r).
+For more information on working with the processed `SingleCellExperiment` objects, see [`Getting started with an ScPCA dataset`](https://scpca.readthedocs.io/en/stable/getting_started.html).
+
+## CHANGELOG
+
+A summary of changes impacting downloads from the ScPCA Portal is available in [the CHANGELOG section of our documentation](https://scpca.readthedocs.io/en/stable/CHANGELOG.html).
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citation
+
+If you use these data in your research, you must cite:
+- The data submitter using language provided as part of the project abstract (as applicable), the publication listed for the project (as applicable), or both.
+- The ScPCA Portal using the language below.
+
+For more information, please see [the How to Cite section of our documentation](https://scpca.readthedocs.io/en/stable/citation.html).
+
+### Citing this project
+
+To cite data from PROJECT_ID_0, please see the project abstract and publication information at [PROJECT_ID_0 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)
+
+### Citing the ScPCA Portal
+
+When citing the ScPCA Portal, please cite the following preprint:
+
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+### Additional Restrictions
+
+This dataset is designated as research or academic purposes only.

--- a/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MERGED.md
+++ b/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MERGED.md
@@ -1,0 +1,68 @@
+Generated on: TEST_TODAYS_DATE
+
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes single-cell or single-nuclei gene expression data and associated metadata for all samples and libraries from a project [PROJECT_ID_0](https://scpca.alexslemonade.org/projects/PROJECT_ID_0) in the ScPCA portal.
+All gene expression data for all samples and libraries have been merged into a single `SingleCellExperiment` object, stored as an `.rds` file.
+In addition to the merged object, each download includes a summary report describing the contents of the merged file and a folder with all quality control reports, and, if applicable, cell type annotation reports, for each library included in the merged object.
+
+The download will include the following files for the selected project (example shown for project with ID `SCPCP000000`):
+
+- A merged file containing all gene expression data: `SCPCP000000_merged.rds`
+- A summary report: `SCPCP000000_merged-summary-report.html`
+- A folder containing all reports for individual libraries:
+  - A quality control report: `SCPCL000000_qc.html`
+  - A supplemental cell type report: `SCPCL000000_celltype-report.html`
+
+Also included in each download is `single_cell_metadata.tsv`, a tab-separated table, with one row per library and columns containing pertinent metadata corresponding to that library.
+
+Merged objects, available as RDS files containing a `SingleCellExperiment` object, house the expression data, cell and gene metrics, associated metadata, and in the case of multi-modal data like CITE-seq, data from the additional cell-based assays for all samples and libraries from the selected project (see [Merged objects](https://scpca.readthedocs.io/en/stable/merged_objects.html) for more information).
+
+If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download.
+The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
+The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html) section in our documentation for more detailed information on files included in the download.
+
+## Usage
+
+For instructions on using the RDS files, please see [FAQ: How do I use the provided files in R?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-rds-files-in-r).
+For more information on working with the processed `SingleCellExperiment` objects, see [`Getting started with an ScPCA dataset`](https://scpca.readthedocs.io/en/stable/getting_started.html).
+
+## CHANGELOG
+
+A summary of changes impacting downloads from the ScPCA Portal is available in [the CHANGELOG section of our documentation](https://scpca.readthedocs.io/en/stable/CHANGELOG.html).
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citation
+
+If you use these data in your research, you must cite:
+- The data submitter using language provided as part of the project abstract (as applicable), the publication listed for the project (as applicable), or both.
+- The ScPCA Portal using the language below.
+
+For more information, please see [the How to Cite section of our documentation](https://scpca.readthedocs.io/en/stable/citation.html).
+
+### Citing this project
+
+To cite data from PROJECT_ID_0, please see the project abstract and publication information at [PROJECT_ID_0 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)
+
+### Citing the ScPCA Portal
+
+When citing the ScPCA Portal, please cite the following preprint:
+
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+### Additional Restrictions
+
+This dataset is designated as research or academic purposes only.

--- a/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MULTIPLEXED.md
+++ b/api/scpca_portal/test/expected_values/readmes/SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MULTIPLEXED.md
@@ -1,0 +1,71 @@
+Generated on: TEST_TODAYS_DATE
+
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes single-cell or single-nuclei gene expression files and associated metadata for samples from project [PROJECT_ID_0](https://scpca.alexslemonade.org/projects/PROJECT_ID_0) in the ScPCA portal.
+
+This project includes multiplexed samples, where multiple biological samples have been combined into libraries using cellhashing or similar technologies.
+The data files are divided into folders named with an underscore-separated list of the sample ids (each with an `SCPCS` prefix) for each set of multiplexed samples.
+Each of these folders contains the files for all libraries (`SCPCL` prefix) derived from that set of samples.
+See the FAQ sections about [samples and libraries](https://scpca.readthedocs.io/en/stable/faq.html#what-is-the-difference-between-samples-and-libraries) and [multiplexed samples](https://scpca.readthedocs.io/en/stable/faq.html#what-is-a-multiplexed-sample) for more information.
+
+The files associated with each library are (example shown for a library with ID `SCPCL000000`):
+
+- An unfiltered counts file: `SCPCL000000_unfiltered.rds`,
+- A filtered counts file: `SCPCL000000_filtered.rds`,
+- A processed counts file: `SCPCL000000_processed.rds`,
+- A quality control report: `SCPCL000000_qc.html`,
+
+Also included in each download is a `single_cell_metadata.tsv`, a tab-separated table, with one row per sample/library pair and columns containing pertinent metadata corresponding to that sample and library.
+
+Gene expression files, available as RDS files containing a `SingleCellExperiment` object, house the expression data, cell and gene metrics, associated metadata, and, in the case of multiplexed samples, data from the the cellhash assay (see [Single-cell gene expression file contents](https://scpca.readthedocs.io/en/stable/sce_file_contents.html) for more information).
+Please note that the libraries derived from multiplexed samples are _not demultiplexed_, however, [results from demultiplexing algorithms](https://scpca.readthedocs.io/en/stable/sce_file_contents.html#additional-singlecellexperiment-components-for-multiplexed-libraries) are included in the `_filtered.rds` files.
+
+If a project contains bulk RNA-seq data, two tab-separated value files, `bulk_quant.tsv` and `bulk_metadata.tsv`, will be included in the download.
+The `bulk_quant.tsv` file contains a gene by sample matrix (each row a gene, each column a sample) containing raw gene expression counts quantified by Salmon.
+The `bulk_metadata.tsv` file contains associated metadata for all samples with bulk RNA-seq data.
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html) section in our documentation for more detailed information on files included in the download.
+
+## Usage
+
+For instructions on using the RDS files, please see [FAQ: How do I use the provided files in R?](https://scpca.readthedocs.io/en/stable/faq.html#how-do-i-use-the-provided-rds-files-in-r).
+For information on how to use the demultiplexing results that the filtered data files contain, see the ["Getting started" section about multiplex samples](https://scpca.readthedocs.io/en/stable/getting_started.html#special-considerations-for-multiplexed-samples).
+
+## CHANGELOG
+
+A summary of changes impacting downloads from the ScPCA Portal is available in [the CHANGELOG section of our documentation](https://scpca.readthedocs.io/en/stable/CHANGELOG.html).
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citation
+
+If you use these data in your research, you must cite:
+- The data submitter using language provided as part of the project abstract (as applicable), the publication listed for the project (as applicable), or both.
+- The ScPCA Portal using the language below.
+
+For more information, please see [the How to Cite section of our documentation](https://scpca.readthedocs.io/en/stable/citation.html).
+
+### Citing this project
+
+To cite data from PROJECT_ID_0, please see the project abstract and publication information at [PROJECT_ID_0 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)
+
+### Citing the ScPCA Portal
+
+When citing the ScPCA Portal, please cite the following preprint:
+
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+### Additional Restrictions
+
+This dataset is designated as research or academic purposes only.

--- a/api/scpca_portal/test/expected_values/readmes/SPATIAL_SINGLE_CELL_EXPERIMENT.md
+++ b/api/scpca_portal/test/expected_values/readmes/SPATIAL_SINGLE_CELL_EXPERIMENT.md
@@ -1,0 +1,60 @@
+Generated on: TEST_TODAYS_DATE
+
+# Alex's Lemonade Stand Foundation Single-cell Pediatric Cancer Atlas
+
+The [Single-cell Pediatric Cancer Atlas](https://scpca.alexslemonade.org) is a database of single-cell and single-nuclei data from pediatric cancer clinical samples and xenografts, built by the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) at [Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/).
+
+## Contents
+
+This download includes gene expression data from libraries processed using spatial transcriptomics and associated metadata for samples from project [PROJECT_ID_0](https://scpca.alexslemonade.org/projects/PROJECT_ID_0) in the ScPCA portal.
+
+For all spatial transcriptomics libraries (indicated by the `SCPCL` prefix) , a `SCPCL000000_spatial` folder will be nested inside the corresponding sample folder (`SCPCS` prefix) in the download.
+See the [FAQ section about samples and libraries](https://scpca.readthedocs.io/en/stable/faq.html#what-is-the-difference-between-samples-and-libraries) for more information.
+
+Inside the `SCPCL000000_spatial` folder will be the following folders and files:
+
+- A `raw_feature_bc_matrix` folder containing the [unfiltered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
+- A `filtered_feature_bc_matrix` folder containing the [filtered counts files](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/matrices)
+- A `spatial` folder containing [images and position information](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/images)
+- A `SCPCL000000_spaceranger_summary.html` file containing the [summary html report provided by Space Ranger](https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/summary)
+- A `SCPCL000000_metadata.json` file containing library processing information.
+
+Also included in each download is a `spatial_metadata.tsv`, a tab separated values table, with one row per library and columns containing pertinent metadata corresponding to that library.
+
+See the [Downloadable files](https://scpca.readthedocs.io/en/stable/download_files.html#spatial-transcriptomics-libraries) section in our documentation for more detailed information on files included in the download for spatial transcriptomics libraries.
+
+For more information on how the spatial libraries were processed, see the [Spatial Transcriptomics section in the Processing information](https://scpca.readthedocs.io/en/stable/processing_information.html#spatial-transcriptomics) page of the ScPCA Portal documentation.
+
+## CHANGELOG
+
+A summary of changes impacting downloads from the ScPCA Portal is available in [the CHANGELOG section of our documentation](https://scpca.readthedocs.io/en/stable/CHANGELOG.html).
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub.](https://github.com/AlexsLemonade/scpca-portal/issues/new) If you would prefer to report issues via e-mail, please contact us at [scpca@ccdatalab.org](mailto:scpca@ccdatalab.org).
+
+## Citation
+
+If you use these data in your research, you must cite:
+- The data submitter using language provided as part of the project abstract (as applicable), the publication listed for the project (as applicable), or both.
+- The ScPCA Portal using the language below.
+
+For more information, please see [the How to Cite section of our documentation](https://scpca.readthedocs.io/en/stable/citation.html).
+
+### Citing this project
+
+To cite data from PROJECT_ID_0, please see the project abstract and publication information at [PROJECT_ID_0 page.](https://scpca.alexslemonade.org/projects/PROJECT_ID_0)
+
+### Citing the ScPCA Portal
+
+When citing the ScPCA Portal, please cite the following preprint:
+
+Hawkins A. G., J. A. Shapiro, S. J. Spielman, D. S. Mejia, D. V. Prasad, et al., 2024 The Single-cell Pediatric Cancer Atlas: Data portal and open-source tools for single-cell transcriptomics of pediatric tumors. _bioRxiv._ https://doi.org/10.1101/2024.04.19.590243
+
+## Terms of Use
+
+In using these data, you agree to our [Terms of Use](https://scpca.alexslemonade.org/terms-of-use).
+
+### Additional Restrictions
+
+This dataset is designated as research or academic purposes only.

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -50,6 +50,7 @@ class LeafProjectFactory(factory.django.DjangoModelFactory):
     immediately accessible to the research community, with the aim of
     accelerating our efforts to find new ways to cure all children
     with AML"""
+    additional_restrictions = "Research or academic purposes only"
     disease_timings = "Diagnosis, Relapse/Diagnosis at LPCH, Relapsed, Healthy control"
     diagnoses = "AML, Normal"
     diagnoses_counts = "AML (20), Normal (40)"

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -28,7 +28,7 @@ class LeafProjectFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "scpca_portal.Project"
 
-    scpca_id = factory.Sequence(lambda n: "SCPCS0000%d" % n)
+    scpca_id = factory.Sequence(lambda n: f"SCPCP{str(n).zfill(6)}")
     pi_name = "gawad"
     human_readable_pi_name = "Gawad"
     title = (
@@ -85,10 +85,10 @@ class SampleFactory(factory.django.DjangoModelFactory):
     diagnosis = "pilocytic astrocytoma"
     disease_timing = "primary diagnosis"
     has_cite_seq_data = True
-    multiplexed_with = ["SCPCP000000"]
+    multiplexed_with = ["SCPCS000000"]
     project = factory.SubFactory(LeafProjectFactory)
     sample_cell_count_estimate = 42
-    scpca_id = factory.Sequence(lambda n: "SCPCS0000%d" % n)
+    scpca_id = factory.Sequence(lambda n: f"SCPCS{str(n).zfill(6)}")
     seq_units = "cell"
     sex = "M"
     subdiagnosis = "NA"
@@ -100,12 +100,16 @@ class LibraryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "scpca_portal.Library"
 
-    data_file_paths = [factory.Sequence(lambda n: f"SCPCP0000{n}/SCPCS0000{n}/SCPCL0000{n}")]
+    data_file_paths = [
+        factory.Sequence(
+            lambda n: f"SCPCP{str(n).zfill(6)}/SCPCS{str(n).zfill(6)}/SCPCL{str(n).zfill(6)}"
+        )
+    ]
     formats = [Library.FileFormats.SINGLE_CELL_EXPERIMENT]
     is_multiplexed = False
     modality = Library.Modalities.SINGLE_CELL
     project = factory.SubFactory(LeafProjectFactory)
-    scpca_id = factory.Sequence(lambda n: "SCPCL0000%d" % n)
+    scpca_id = factory.Sequence(lambda n: f"SCPCL{str(n).zfill(6)}")
     workflow_version = "development"
     # With factory_body, factory instances share attributes by default
     # Use LazyFunction to populate metadata dict so that changes don't propogate to all instances

--- a/api/scpca_portal/test/test_readme_file.py
+++ b/api/scpca_portal/test/test_readme_file.py
@@ -1,0 +1,137 @@
+from django.test import TestCase
+
+from scpca_portal import common, readme_file, utils
+from scpca_portal.test.factories import ProjectFactory
+
+README_DIR = common.EXPECTED_VALUES_PATH / "readmes"
+
+
+class TestReadmeFileContents(TestCase):
+    def assertReadmeContents(self, expected_file_path: str, output_content: str) -> None:
+        def get_updated_content(content: str) -> str:
+            """
+            Replace the placeholder TEST_TODAYS_DATE in test/expected_values/readmes
+            with the given project_id and today's date respectively for format testing.
+            """
+            content = content.replace(
+                "Generated on: TEST_TODAYS_DATE", f"Generated on: {utils.get_today_string()}"
+            )
+
+            return content.strip()
+
+        with open(expected_file_path, "r", encoding="utf-8") as expected_file:
+            expected_content = get_updated_content(expected_file.read())
+
+        # Convert expected and output contents to line lists for easier debugging
+        self.assertEqual(
+            expected_content.splitlines(True),
+            output_content.splitlines(True),
+            f"{self._testMethodName}: Comparison with {expected_file_path} does not match.",
+        )
+
+    def test_readme_file_PORTAL_ALL_METADATA(self):
+        DOWNLOAD_CONFIG_NAME = "PORTAL_ALL_METADATA"
+        DOWNLOAD_CONFIG = common.PORTAL_METADATA_DOWNLOAD_CONFIG
+        PROJECT_IDS = ["PROJECT_ID_0", "PROJECT_ID_1", "PROJECT_ID_2"]
+
+        projects = [
+            ProjectFactory(
+                additional_restrictions="Research or academic purposes only", scpca_id=project_id
+            )
+            for project_id in PROJECT_IDS
+        ]
+
+        result = readme_file.get_file_contents(DOWNLOAD_CONFIG, projects)
+        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expect_contents_file, result)
+
+    def test_readme_file_ALL_METADATA(self):
+        DOWNLOAD_CONFIG_NAME = "ALL_METADATA"
+        DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
+        PROJECT_ID = "PROJECT_ID_0"
+
+        project = ProjectFactory(
+            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
+        )
+
+        result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
+        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expect_contents_file, result)
+
+    def test_readme_file_SINGLE_CELL_SINGLE_CELL_EXPERIMENT(self):
+        DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_SINGLE_CELL_EXPERIMENT"
+        DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
+        PROJECT_ID = "PROJECT_ID_0"
+
+        project = ProjectFactory(
+            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
+        )
+
+        result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
+        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expect_contents_file, result)
+
+    def test_readme_file_SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MULTIPLEXED(self):
+        DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MULTIPLEXED"
+        DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
+        PROJECT_ID = "PROJECT_ID_0"
+
+        project = ProjectFactory(
+            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
+        )
+
+        result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
+        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expect_contents_file, result)
+
+    def test_readme_file_SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MERGED(self):
+        DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MERGED"
+        DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
+        PROJECT_ID = "PROJECT_ID_0"
+
+        project = ProjectFactory(
+            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
+        )
+
+        result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
+        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expect_contents_file, result)
+
+    def test_readme_file_SINGLE_CELL_ANN_DATA(self):
+        DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_ANN_DATA"
+        DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
+        PROJECT_ID = "PROJECT_ID_0"
+
+        project = ProjectFactory(
+            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
+        )
+
+        result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
+        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expect_contents_file, result)
+
+    def test_readme_file_SINGLE_CELL_ANN_DATA_MERGED(self):
+        DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_ANN_DATA_MERGED"
+        DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
+        PROJECT_ID = "PROJECT_ID_0"
+
+        project = ProjectFactory(
+            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
+        )
+
+        result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
+        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expect_contents_file, result)
+
+    def test_readme_file_SPATIAL_SINGLE_CELL_EXPERIMENT(self):
+        DOWNLOAD_CONFIG_NAME = "SPATIAL_SINGLE_CELL_EXPERIMENT"
+        DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
+        PROJECT_ID = "PROJECT_ID_0"
+
+        project = ProjectFactory(
+            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
+        )
+
+        result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
+        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expect_contents_file, result)

--- a/api/scpca_portal/test/test_readme_file.py
+++ b/api/scpca_portal/test/test_readme_file.py
@@ -3,24 +3,20 @@ from django.test import TestCase
 from scpca_portal import common, readme_file, utils
 from scpca_portal.test.factories import ProjectFactory
 
-README_DIR = common.EXPECTED_VALUES_PATH / "readmes"
+README_DIR = common.CODE_PATH / "scpca_portal" / "test" / "expected_values" / "readmes"
 
 
 class TestReadmeFileContents(TestCase):
     def assertReadmeContents(self, expected_file_path: str, result_content: str) -> None:
-        def get_updated_content(content: str) -> str:
-            """
-            Replace the placeholder TEST_TODAYS_DATE in test/expected_values/readmes
-            with today's date for format testing.
-            """
-            content = content.replace(
-                "Generated on: TEST_TODAYS_DATE", f"Generated on: {utils.get_today_string()}"
-            )
-
-            return content.strip()
-
         with open(expected_file_path, encoding="utf-8") as expected_file:
-            expected_content = get_updated_content(expected_file.read())
+            # Replace the placeholder TEST_TODAYS_DATE in expected_values/readmes with today
+            expected_content = (
+                expected_file.read()
+                .replace(
+                    "Generated on: TEST_TODAYS_DATE", f"Generated on: {utils.get_today_string()}"
+                )
+                .strip()
+            )
         # Convert expected and result contents to line lists for easier debugging
         self.assertEqual(
             expected_content.splitlines(True),
@@ -33,12 +29,7 @@ class TestReadmeFileContents(TestCase):
         DOWNLOAD_CONFIG = common.PORTAL_METADATA_DOWNLOAD_CONFIG
         PROJECT_IDS = ["PROJECT_ID_0", "PROJECT_ID_1", "PROJECT_ID_2"]
 
-        projects = [
-            ProjectFactory(
-                additional_restrictions="Research or academic purposes only", scpca_id=project_id
-            )
-            for project_id in PROJECT_IDS
-        ]
+        projects = [ProjectFactory(scpca_id=project_id) for project_id in PROJECT_IDS]
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, projects)
         expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
         self.assertReadmeContents(expected_file_path, result)
@@ -48,9 +39,7 @@ class TestReadmeFileContents(TestCase):
         DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
         PROJECT_ID = "PROJECT_ID_0"
 
-        project = ProjectFactory(
-            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
-        )
+        project = ProjectFactory(scpca_id=PROJECT_ID)
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
         expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
         self.assertReadmeContents(expected_file_path, result)
@@ -60,9 +49,7 @@ class TestReadmeFileContents(TestCase):
         DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
         PROJECT_ID = "PROJECT_ID_0"
 
-        project = ProjectFactory(
-            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
-        )
+        project = ProjectFactory(scpca_id=PROJECT_ID)
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
         expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
         self.assertReadmeContents(expected_file_path, result)
@@ -72,9 +59,7 @@ class TestReadmeFileContents(TestCase):
         DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
         PROJECT_ID = "PROJECT_ID_0"
 
-        project = ProjectFactory(
-            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
-        )
+        project = ProjectFactory(scpca_id=PROJECT_ID)
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
         expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
         self.assertReadmeContents(expected_file_path, result)
@@ -84,9 +69,7 @@ class TestReadmeFileContents(TestCase):
         DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
         PROJECT_ID = "PROJECT_ID_0"
 
-        project = ProjectFactory(
-            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
-        )
+        project = ProjectFactory(scpca_id=PROJECT_ID)
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
         expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
         self.assertReadmeContents(expected_file_path, result)
@@ -96,9 +79,7 @@ class TestReadmeFileContents(TestCase):
         DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
         PROJECT_ID = "PROJECT_ID_0"
 
-        project = ProjectFactory(
-            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
-        )
+        project = ProjectFactory(scpca_id=PROJECT_ID)
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
         expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
         self.assertReadmeContents(expected_file_path, result)
@@ -108,9 +89,7 @@ class TestReadmeFileContents(TestCase):
         DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
         PROJECT_ID = "PROJECT_ID_0"
 
-        project = ProjectFactory(
-            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
-        )
+        project = ProjectFactory(scpca_id=PROJECT_ID)
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
         expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
         self.assertReadmeContents(expected_file_path, result)
@@ -120,9 +99,7 @@ class TestReadmeFileContents(TestCase):
         DOWNLOAD_CONFIG = common.PROJECT_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
         PROJECT_ID = "PROJECT_ID_0"
 
-        project = ProjectFactory(
-            additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
-        )
+        project = ProjectFactory(scpca_id=PROJECT_ID)
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
         expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
         self.assertReadmeContents(expected_file_path, result)

--- a/api/scpca_portal/test/test_readme_file.py
+++ b/api/scpca_portal/test/test_readme_file.py
@@ -7,11 +7,11 @@ README_DIR = common.EXPECTED_VALUES_PATH / "readmes"
 
 
 class TestReadmeFileContents(TestCase):
-    def assertReadmeContents(self, expected_file_path: str, output_content: str) -> None:
+    def assertReadmeContents(self, expected_file_path: str, result_content: str) -> None:
         def get_updated_content(content: str) -> str:
             """
             Replace the placeholder TEST_TODAYS_DATE in test/expected_values/readmes
-            with the given project_id and today's date respectively for format testing.
+            with today's date for format testing.
             """
             content = content.replace(
                 "Generated on: TEST_TODAYS_DATE", f"Generated on: {utils.get_today_string()}"
@@ -19,13 +19,12 @@ class TestReadmeFileContents(TestCase):
 
             return content.strip()
 
-        with open(expected_file_path, "r", encoding="utf-8") as expected_file:
+        with open(expected_file_path, encoding="utf-8") as expected_file:
             expected_content = get_updated_content(expected_file.read())
-
-        # Convert expected and output contents to line lists for easier debugging
+        # Convert expected and result contents to line lists for easier debugging
         self.assertEqual(
             expected_content.splitlines(True),
-            output_content.splitlines(True),
+            result_content.splitlines(True),
             f"{self._testMethodName}: Comparison with {expected_file_path} does not match.",
         )
 
@@ -40,10 +39,9 @@ class TestReadmeFileContents(TestCase):
             )
             for project_id in PROJECT_IDS
         ]
-
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, projects)
-        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
-        self.assertReadmeContents(expect_contents_file, result)
+        expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expected_file_path, result)
 
     def test_readme_file_ALL_METADATA(self):
         DOWNLOAD_CONFIG_NAME = "ALL_METADATA"
@@ -53,10 +51,9 @@ class TestReadmeFileContents(TestCase):
         project = ProjectFactory(
             additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
         )
-
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
-        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
-        self.assertReadmeContents(expect_contents_file, result)
+        expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expected_file_path, result)
 
     def test_readme_file_SINGLE_CELL_SINGLE_CELL_EXPERIMENT(self):
         DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_SINGLE_CELL_EXPERIMENT"
@@ -66,10 +63,9 @@ class TestReadmeFileContents(TestCase):
         project = ProjectFactory(
             additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
         )
-
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
-        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
-        self.assertReadmeContents(expect_contents_file, result)
+        expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expected_file_path, result)
 
     def test_readme_file_SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MULTIPLEXED(self):
         DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MULTIPLEXED"
@@ -79,10 +75,9 @@ class TestReadmeFileContents(TestCase):
         project = ProjectFactory(
             additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
         )
-
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
-        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
-        self.assertReadmeContents(expect_contents_file, result)
+        expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expected_file_path, result)
 
     def test_readme_file_SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MERGED(self):
         DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MERGED"
@@ -92,10 +87,9 @@ class TestReadmeFileContents(TestCase):
         project = ProjectFactory(
             additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
         )
-
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
-        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
-        self.assertReadmeContents(expect_contents_file, result)
+        expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expected_file_path, result)
 
     def test_readme_file_SINGLE_CELL_ANN_DATA(self):
         DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_ANN_DATA"
@@ -105,10 +99,9 @@ class TestReadmeFileContents(TestCase):
         project = ProjectFactory(
             additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
         )
-
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
-        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
-        self.assertReadmeContents(expect_contents_file, result)
+        expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expected_file_path, result)
 
     def test_readme_file_SINGLE_CELL_ANN_DATA_MERGED(self):
         DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_ANN_DATA_MERGED"
@@ -118,10 +111,9 @@ class TestReadmeFileContents(TestCase):
         project = ProjectFactory(
             additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
         )
-
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
-        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
-        self.assertReadmeContents(expect_contents_file, result)
+        expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expected_file_path, result)
 
     def test_readme_file_SPATIAL_SINGLE_CELL_EXPERIMENT(self):
         DOWNLOAD_CONFIG_NAME = "SPATIAL_SINGLE_CELL_EXPERIMENT"
@@ -131,7 +123,6 @@ class TestReadmeFileContents(TestCase):
         project = ProjectFactory(
             additional_restrictions="Research or academic purposes only", scpca_id=PROJECT_ID
         )
-
         result = readme_file.get_file_contents(DOWNLOAD_CONFIG, [project])
-        expect_contents_file = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
-        self.assertReadmeContents(expect_contents_file, result)
+        expected_file_path = README_DIR / f"{DOWNLOAD_CONFIG_NAME}.md"
+        self.assertReadmeContents(expected_file_path, result)


### PR DESCRIPTION
## Issue Number

Closes #902

Feature branch: `feature/loader`
Base branch:  the latest `feature/loader` (#896)

## Purpose/Implementation Notes

I've added the dedicated `test_readme_file` to support complete coverage of all readme file variations for each computed file type by project ID.

Changes includes:
- Add `test/test_readme_file`
- Added saved readme files in `test/expected_values/readmes`
- Added a new constant `common.EXPECTED_VALUES_PATH` (for the `expected_values` folder)
- Adjust `templates/readmes/contents/METADATA_ONLY.md`

Other changes:
- Adjusted `test/factories` to generate five-character prefixes followed by six-digit IDs, and fix a typo
- Adjust the assertion values in `test/expected_values/computed_file_project`for test

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
