### PR TITLE
862 - Create config/test Module

### DIFF
--- a/api/manage.py
+++ b/api/manage.py
@@ -6,7 +6,11 @@ import sys
 
 def main():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scpca_portal.config")
-    os.environ.setdefault("DJANGO_CONFIGURATION", "Local")
+
+    # Indicates running in test environment.
+    test_env_active = len(sys.argv) > 1 and sys.argv[1] == "test"
+    default_config = "Test" if test_env_active else "Local"
+    os.environ.setdefault("DJANGO_CONFIGURATION", default_config)
 
     try:
         from configurations.management import execute_from_command_line

--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -1,22 +1,4 @@
-from pathlib import Path
-
-from django.conf import settings
-
-# Locally the docker container puts the code in a folder called code.
-# This allows us to run the same command on production or locally.
-CODE_PATH = (
-    code_path
-    if (code_path := Path("/home/user/code")) and code_path.exists()
-    else Path("/home/user")
-)
-
 CSV_MULTI_VALUE_DELIMITER = ";"
-
-DATA_PATH = CODE_PATH / ("test_data" if settings.TEST else "data")
-INPUT_DATA_PATH = DATA_PATH / "input"
-OUTPUT_DATA_PATH = DATA_PATH / "output"
-
-TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"
 
 TAB = "\t"
 NA = "NA"  # "Not Available"

--- a/api/scpca_portal/config/__init__.py
+++ b/api/scpca_portal/config/__init__.py
@@ -1,7 +1,10 @@
 import os
 
 DJANGO_CONFIGURATION = os.environ.get("DJANGO_CONFIGURATION", "Local")
-if DJANGO_CONFIGURATION == "Local":
+
+if DJANGO_CONFIGURATION == "Test":
+    from scpca_portal.config.test import Test  # noqa
+elif DJANGO_CONFIGURATION == "Local":
     from scpca_portal.config.local import Local  # noqa
 elif DJANGO_CONFIGURATION == "Production":
     from scpca_portal.config.production import Production  # noqa

--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from distutils.util import strtobool
 from pathlib import Path
 
@@ -109,9 +108,6 @@ class Common(Configuration):
     # Set DEBUG to False as a default for safety.
     # https://docs.djangoproject.com/en/dev/ref/settings/#debug
     DEBUG = strtobool(os.getenv("DJANGO_DEBUG", "no"))
-
-    # Indicates running in test environment.
-    TEST = len(sys.argv) > 1 and sys.argv[1] == "test"
 
     # Indicates running in prod environment.
     PRODUCTION = False

--- a/api/scpca_portal/config/local.py
+++ b/api/scpca_portal/config/local.py
@@ -27,10 +27,7 @@ class Local(Common):
     DEV_HOST = os.getenv("DEV_HOST")
 
     # Code Paths
-    CODE_PATH = Path("/home/user/code")
-
-    DATA_PATH = CODE_PATH / "data"
-    INPUT_DATA_PATH = DATA_PATH / "input"
-    OUTPUT_DATA_PATH = DATA_PATH / "output"
-
-    TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"
+    INPUT_DATA_PATH = Path("/home/user/code/data/input")
+    OUTPUT_DATA_PATH = Path("/home/user/code/data/output")
+    README_PATH = Path("/home/user/code/data/readmes")
+    TEMPLATE_PATH = Path("/home/user/code/scpca_portal/templates")

--- a/api/scpca_portal/config/local.py
+++ b/api/scpca_portal/config/local.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from scpca_portal.config.common import Common
 
@@ -25,3 +26,12 @@ class Local(Common):
 
     # This is only needed locally because everything else will use S3.
     DEV_HOST = os.getenv("DEV_HOST")
+
+    # Code Paths
+    CODE_PATH = Path("/home/user/code")
+
+    DATA_PATH = CODE_PATH / ("test_data" if Common.TEST else "data")
+    INPUT_DATA_PATH = DATA_PATH / "input"
+    OUTPUT_DATA_PATH = DATA_PATH / "output"
+
+    TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"

--- a/api/scpca_portal/config/local.py
+++ b/api/scpca_portal/config/local.py
@@ -18,8 +18,7 @@ class Local(Common):
     AWS_REGION = None
 
     # AWS S3
-    TEST_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-09-10/"
-    AWS_S3_INPUT_BUCKET_NAME = TEST_INPUT_BUCKET_NAME if Common.TEST else "scpca-portal-inputs"
+    AWS_S3_INPUT_BUCKET_NAME = "scpca-portal-inputs"
     AWS_S3_OUTPUT_BUCKET_NAME = "scpca-local-data"
 
     CSRF_TRUSTED_ORIGINS = ["localhost", "127.0.0.1"]
@@ -30,7 +29,7 @@ class Local(Common):
     # Code Paths
     CODE_PATH = Path("/home/user/code")
 
-    DATA_PATH = CODE_PATH / ("test_data" if Common.TEST else "data")
+    DATA_PATH = CODE_PATH / "data"
     INPUT_DATA_PATH = DATA_PATH / "input"
     OUTPUT_DATA_PATH = DATA_PATH / "output"
 

--- a/api/scpca_portal/config/production.py
+++ b/api/scpca_portal/config/production.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -51,3 +52,12 @@ class Production(Common):
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=True,
     )
+
+    # Code Paths
+    CODE_PATH = Path("/home/user")
+
+    DATA_PATH = CODE_PATH / "data"
+    INPUT_DATA_PATH = DATA_PATH / "input"
+    OUTPUT_DATA_PATH = DATA_PATH / "output"
+
+    TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"

--- a/api/scpca_portal/config/production.py
+++ b/api/scpca_portal/config/production.py
@@ -54,10 +54,7 @@ class Production(Common):
     )
 
     # Code Paths
-    CODE_PATH = Path("/home/user")
-
-    DATA_PATH = CODE_PATH / "data"
-    INPUT_DATA_PATH = DATA_PATH / "input"
-    OUTPUT_DATA_PATH = DATA_PATH / "output"
-
-    TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"
+    INPUT_DATA_PATH = Path("/home/user/data/input")
+    OUTPUT_DATA_PATH = Path("/home/user/data/output")
+    README_PATH = Path("/home/user/data/readmes")
+    TEMPLATE_PATH = Path("/home/user/scpca_portal/templates")

--- a/api/scpca_portal/config/test.py
+++ b/api/scpca_portal/config/test.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+
+from scpca_portal.config.common import Common
+
+
+class Test(Common):
+    DEBUG = True
+
+    # Mail
+    EMAIL_HOST = "localhost"
+    EMAIL_PORT = 1025
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+    UPDATE_S3_DATA = False
+
+    # AWS
+    AWS_REGION = None
+
+    # AWS S3
+    AWS_S3_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-09-10/"
+    AWS_S3_OUTPUT_BUCKET_NAME = "scpca-local-data"
+
+    CSRF_TRUSTED_ORIGINS = ["localhost", "127.0.0.1"]
+
+    # This is only needed locally because everything else will use S3.
+    DEV_HOST = os.getenv("DEV_HOST")
+
+    # Code Paths
+    CODE_PATH = Path("/home/user/code")
+
+    DATA_PATH = CODE_PATH / "test_data"
+    INPUT_DATA_PATH = DATA_PATH / "input"
+    OUTPUT_DATA_PATH = DATA_PATH / "output"
+
+    TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"

--- a/api/scpca_portal/config/test.py
+++ b/api/scpca_portal/config/test.py
@@ -5,7 +5,6 @@ class Test(Local):
     # AWS S3
     # Note: Data must be resynced when test bucket is updated
     AWS_S3_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-09-10/"
-    AWS_S3_OUTPUT_BUCKET_NAME = "scpca-local-data"
 
     # Code Paths
     DATA_PATH = Local.CODE_PATH / "test_data"

--- a/api/scpca_portal/config/test.py
+++ b/api/scpca_portal/config/test.py
@@ -1,19 +1,13 @@
-from pathlib import Path
-
 from scpca_portal.config.local import Local
 
 
 class Test(Local):
     # AWS S3
-    # Data must be resynced when test bucket is updated
+    # Note: Data must be resynced when test bucket is updated
     AWS_S3_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-09-10/"
     AWS_S3_OUTPUT_BUCKET_NAME = "scpca-local-data"
 
     # Code Paths
-    CODE_PATH = Path("/home/user/code")
-
-    DATA_PATH = CODE_PATH / "test_data"
+    DATA_PATH = Local.CODE_PATH / "test_data"
     INPUT_DATA_PATH = DATA_PATH / "input"
     OUTPUT_DATA_PATH = DATA_PATH / "output"
-
-    TEMPLATE_PATH = CODE_PATH / "scpca_portal" / "templates"

--- a/api/scpca_portal/config/test.py
+++ b/api/scpca_portal/config/test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from scpca_portal.config.local import Local
 
 
@@ -7,6 +9,7 @@ class Test(Local):
     AWS_S3_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-09-10/"
 
     # Code Paths
-    DATA_PATH = Local.CODE_PATH / "test_data"
-    INPUT_DATA_PATH = DATA_PATH / "input"
-    OUTPUT_DATA_PATH = DATA_PATH / "output"
+    INPUT_DATA_PATH = Path("/home/user/code/test_data/input")
+    OUTPUT_DATA_PATH = Path("/home/user/code/test_data/output")
+    README_PATH = Path("/home/user/code/test_data/readmes")
+    TEMPLATE_PATH = Path("/home/user/code/scpca_portal/templates")

--- a/api/scpca_portal/config/test.py
+++ b/api/scpca_portal/config/test.py
@@ -1,30 +1,13 @@
-import os
 from pathlib import Path
 
-from scpca_portal.config.common import Common
+from scpca_portal.config.local import Local
 
 
-class Test(Common):
-    DEBUG = True
-
-    # Mail
-    EMAIL_HOST = "localhost"
-    EMAIL_PORT = 1025
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
-    UPDATE_S3_DATA = False
-
-    # AWS
-    AWS_REGION = None
-
+class Test(Local):
     # AWS S3
+    # Data must be resynced when test bucket is updated
     AWS_S3_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-09-10/"
     AWS_S3_OUTPUT_BUCKET_NAME = "scpca-local-data"
-
-    CSRF_TRUSTED_ORIGINS = ["localhost", "127.0.0.1"]
-
-    # This is only needed locally because everything else will use S3.
-    DEV_HOST = os.getenv("DEV_HOST")
 
     # Code Paths
     CODE_PATH = Path("/home/user/code")

--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -4,6 +4,7 @@ from functools import partial
 from threading import Lock
 from typing import Any, Dict, List, Set
 
+from django.conf import settings
 from django.db import connection
 from django.template.defaultfilters import pluralize
 
@@ -26,18 +27,18 @@ def prep_data_dirs(wipe_input_dir: bool = False, wipe_output_dir: bool = True) -
     """
     # Prepare data input directory.
     if wipe_input_dir:
-        shutil.rmtree(common.INPUT_DATA_PATH, ignore_errors=True)
-    common.INPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
+        shutil.rmtree(settings.INPUT_DATA_PATH, ignore_errors=True)
+    settings.INPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
 
     # Prepare data output directory.
     if wipe_output_dir:
-        shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
-    common.OUTPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
+        shutil.rmtree(settings.OUTPUT_DATA_PATH, ignore_errors=True)
+    settings.OUTPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
 
 
 def remove_project_input_files(project_id: str) -> None:
     """Remove the input files located at the project_id's input directory."""
-    shutil.rmtree(common.INPUT_DATA_PATH / project_id, ignore_errors=True)
+    shutil.rmtree(settings.INPUT_DATA_PATH / project_id, ignore_errors=True)
 
 
 def get_projects_metadata(
@@ -60,8 +61,8 @@ def _can_process_project(project_metadata: Dict[str, Any], submitter_whitelist: 
     - Input files exist for the project
     - The project's pi is on the whitelist of acceptable submitters
     """
-    project_path = common.INPUT_DATA_PATH / project_metadata["scpca_project_id"]
-    if project_path not in common.INPUT_DATA_PATH.iterdir():
+    project_path = settings.INPUT_DATA_PATH / project_metadata["scpca_project_id"]
+    if project_path not in settings.INPUT_DATA_PATH.iterdir():
         logger.warning(
             f"Metadata found for {project_metadata['scpca_project_id']},"
             "but no s3 folder of that name exists."

--- a/api/scpca_portal/management/commands/create_portal_metadata.py
+++ b/api/scpca_portal/management/commands/create_portal_metadata.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
 
     def create_portal_metadata(self, clean_up_output_data: bool, update_s3: bool, **kwargs):
         # Prepare the data output directory
-        output_directory = common.OUTPUT_DATA_PATH
+        output_directory = settings.OUTPUT_DATA_PATH
         # Remove the existing data output directory if any
         shutil.rmtree(output_directory, ignore_errors=True)
         logger.info("Creating the data output directory")

--- a/api/scpca_portal/metadata_file.py
+++ b/api/scpca_portal/metadata_file.py
@@ -5,9 +5,11 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from django.conf import settings
+
 from scpca_portal import common, utils
 
-PROJECT_METADATA_PATH = common.INPUT_DATA_PATH / "project_metadata.csv"
+PROJECT_METADATA_PATH = settings.INPUT_DATA_PATH / "project_metadata.csv"
 PROJECT_METADATA_KEYS = [
     # Fields used in Project model object creation
     ("has_bulk", "has_bulk_rna_seq", False),

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -75,7 +75,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
                 file_name_parts.append("MULTIPLEXED")
         file_name_parts.append("METADATA.tsv")
 
-        return common.OUTPUT_DATA_PATH / "_".join(file_name_parts)
+        return settings.OUTPUT_DATA_PATH / "_".join(file_name_parts)
 
     @staticmethod
     def get_local_sample_metadata_path(sample, download_config: Dict) -> Path:
@@ -83,18 +83,18 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         file_name_parts.extend(
             [download_config["modality"], download_config["format"], "METADATA.tsv"]
         )
-        return common.OUTPUT_DATA_PATH / "_".join(file_name_parts)
+        return settings.OUTPUT_DATA_PATH / "_".join(file_name_parts)
 
     @staticmethod
     def get_local_portal_metadata_path() -> Path:
-        return common.OUTPUT_DATA_PATH / common.PORTAL_METADATA_COMPUTED_FILE_NAME
+        return settings.OUTPUT_DATA_PATH / common.PORTAL_METADATA_COMPUTED_FILE_NAME
 
     @staticmethod
     def get_local_file_path(download_config: Dict) -> Path:
         """Takes a download_config dictionary and returns the filepath
         where the zipfile will be saved locally before upload."""
         if download_config is common.PORTAL_METADATA_DOWNLOAD_CONFIG:
-            return common.OUTPUT_DATA_PATH / common.PORTAL_METADATA_COMPUTED_FILE_NAME
+            return settings.OUTPUT_DATA_PATH / common.PORTAL_METADATA_COMPUTED_FILE_NAME
 
     @classmethod
     def get_portal_metadata_file(cls, projects, download_config: Dict) -> Self:
@@ -171,7 +171,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             library_data_file_paths + project_data_file_paths, project.s3_input_bucket
         )
 
-        zip_file_path = common.OUTPUT_DATA_PATH / computed_file_name
+        zip_file_path = settings.OUTPUT_DATA_PATH / computed_file_name
         with ZipFile(zip_file_path, "w") as zip_file:
             # Readme file
             zip_file.writestr(
@@ -259,7 +259,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         ]
         s3.download_input_files(library_data_file_paths, sample.project.s3_input_bucket)
 
-        zip_file_path = common.OUTPUT_DATA_PATH / computed_file_name
+        zip_file_path = settings.OUTPUT_DATA_PATH / computed_file_name
         # This lock is primarily for multiplex. We added it here as a patch to keep things generic.
         with lock:  # It should be removed later for a cleaner solution.
             if not zip_file_path.exists():
@@ -356,7 +356,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
 
     @property
     def zip_file_path(self):
-        return common.OUTPUT_DATA_PATH / self.s3_key
+        return settings.OUTPUT_DATA_PATH / self.s3_key
 
     def clean_up_local_computed_file(self):
         """Delete local computed file."""

--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Dict, List
 
+from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
@@ -169,7 +170,7 @@ class Library(TimestampedModel):
 
     @staticmethod
     def get_local_path_from_data_file_path(data_file_path: Path) -> Path:
-        return common.INPUT_DATA_PATH / data_file_path
+        return settings.INPUT_DATA_PATH / data_file_path
 
     def get_metadata(self) -> Dict:
         library_metadata = {
@@ -232,7 +233,7 @@ class Library(TimestampedModel):
 
     @staticmethod
     def get_local_file_path(file_path: Path):
-        return common.INPUT_DATA_PATH / file_path
+        return settings.INPUT_DATA_PATH / file_path
 
     @staticmethod
     def get_zip_file_path(file_path: Path, download_config: Dict) -> Path:

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -83,7 +83,7 @@ class Project(CommonDataAttributes, TimestampedModel):
 
     @property
     def input_data_path(self):
-        return common.INPUT_DATA_PATH / self.scpca_id
+        return settings.INPUT_DATA_PATH / self.scpca_id
 
     @property
     def input_merged_data_path(self):

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -1,9 +1,10 @@
 from typing import Dict, List
 
+from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
-from scpca_portal import common, utils
+from scpca_portal import utils
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.models.base import CommonDataAttributes, TimestampedModel
 from scpca_portal.models.computed_file import ComputedFile
@@ -152,11 +153,11 @@ class Sample(CommonDataAttributes, TimestampedModel):
     @staticmethod
     def get_output_metadata_file_path(scpca_sample_id, modality):
         return {
-            Sample.Modalities.MULTIPLEXED: common.OUTPUT_DATA_PATH
+            Sample.Modalities.MULTIPLEXED: settings.OUTPUT_DATA_PATH
             / f"{scpca_sample_id}_multiplexed_metadata.tsv",
-            Sample.Modalities.SINGLE_CELL: common.OUTPUT_DATA_PATH
+            Sample.Modalities.SINGLE_CELL: settings.OUTPUT_DATA_PATH
             / f"{scpca_sample_id}_libraries_metadata.tsv",
-            Sample.Modalities.SPATIAL: common.OUTPUT_DATA_PATH
+            Sample.Modalities.SPATIAL: settings.OUTPUT_DATA_PATH
             / f"{scpca_sample_id}_spatial_metadata.tsv",
         }.get(modality)
 

--- a/api/scpca_portal/readme_file.py
+++ b/api/scpca_portal/readme_file.py
@@ -1,12 +1,13 @@
 from typing import Dict, Iterable
 
+from django.conf import settings
 from django.template.loader import render_to_string
 
 from scpca_portal import common, utils
 
 OUTPUT_NAME = "README.md"
 
-TEMPLATE_ROOT = common.TEMPLATE_PATH / "readme"
+TEMPLATE_ROOT = settings.TEMPLATE_PATH / "readme"
 TEMPLATE_FILE_PATH = TEMPLATE_ROOT / "readme.md"
 
 

--- a/api/scpca_portal/s3.py
+++ b/api/scpca_portal/s3.py
@@ -3,10 +3,11 @@ from collections import namedtuple
 from pathlib import Path
 from typing import List
 
+from django.conf import settings
+
 import boto3
 from botocore.client import Config
 
-from scpca_portal import common
 from scpca_portal.config.logging import get_and_configure_logger
 
 logger = get_and_configure_logger(__name__)
@@ -81,7 +82,7 @@ def list_input_paths(
 
 def download_input_files(file_paths: List[Path], bucket_name: str) -> bool:
     """Download all passed data file paths which have not previously been downloaded.'"""
-    command_parts = ["aws", "s3", "sync", f"s3://{bucket_name}", common.INPUT_DATA_PATH]
+    command_parts = ["aws", "s3", "sync", f"s3://{bucket_name}", settings.INPUT_DATA_PATH]
 
     download_queue = [fp for fp in file_paths if not fp.exists()]
     # If download_queue is empty, exit early
@@ -105,7 +106,7 @@ def download_input_files(file_paths: List[Path], bucket_name: str) -> bool:
 
 def download_input_metadata(bucket_name: str) -> bool:
     """Download all metadata files to the local file system."""
-    command_parts = ["aws", "s3", "sync", f"s3://{bucket_name}", common.INPUT_DATA_PATH]
+    command_parts = ["aws", "s3", "sync", f"s3://{bucket_name}", settings.INPUT_DATA_PATH]
 
     command_parts.append("--exclude=*")
     command_parts.append("--include=*_metadata.*")
@@ -139,7 +140,7 @@ def delete_output_file(key: str, bucket_name: str) -> bool:
 def upload_output_file(key: str, bucket_name: str) -> bool:
     """Upload a computed file to S3 using the AWS CLI tool."""
 
-    local_path = common.OUTPUT_DATA_PATH / key
+    local_path = settings.OUTPUT_DATA_PATH / key
     aws_path = f"s3://{bucket_name}/{key}"
     command_parts = ["aws", "s3", "cp", local_path, aws_path]
 

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -15,11 +15,10 @@ from django.test import TransactionTestCase
 from scpca_portal import common, metadata_file, readme_file, utils
 from scpca_portal.models import ComputedFile, Library, Project, Sample
 
-# NOTE: Test data bucket is defined in `scpca_porta/common.py`.
+# NOTE: Test data bucket is defined in `config/test.py`.
 # When common.INPUT_BUCKET_NAME is changed, please delete the contents of
 # api/test_data/input before testing to ensure test files are updated correctly.
 
-README_DIR = settings.DATA_PATH / "readmes"
 README_FILE = readme_file.OUTPUT_NAME
 METADATA_FILE = metadata_file.MetadataFilenames.METADATA_ONLY_FILE_NAME
 
@@ -72,7 +71,7 @@ class TestCreatePortalMetadata(TransactionTestCase):
 
         # Get the corresponding saved readme output path based on the zip filename
         readme_filename = re.sub(r"^[A-Z]{5}\d{6}_", "", Path(zip_file.filename).stem) + ".md"
-        saved_readme_output_path = README_DIR / readme_filename
+        saved_readme_output_path = settings.README_PATH / readme_filename
         # Convert expected and output contents to line lists for easier debugging
         with zip_file.open(README_FILE) as readme_file:
             output_content = readme_file.read().decode("utf-8").splitlines(True)

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -16,7 +16,7 @@ from scpca_portal import common, metadata_file, readme_file, utils
 from scpca_portal.models import ComputedFile, Library, Project, Sample
 
 # NOTE: Test data bucket is defined in `config/test.py`.
-# When common.INPUT_BUCKET_NAME is changed, please delete the contents of
+# When settings.INPUT_BUCKET_NAME is changed, please delete the contents of
 # api/test_data/input before testing to ensure test files are updated correctly.
 
 README_FILE = readme_file.OUTPUT_NAME

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -19,7 +19,7 @@ from scpca_portal.models import ComputedFile, Library, Project, Sample
 # When common.INPUT_BUCKET_NAME is changed, please delete the contents of
 # api/test_data/input before testing to ensure test files are updated correctly.
 
-README_DIR = common.DATA_PATH / "readmes"
+README_DIR = settings.DATA_PATH / "readmes"
 README_FILE = readme_file.OUTPUT_NAME
 METADATA_FILE = metadata_file.MetadataFilenames.METADATA_ONLY_FILE_NAME
 
@@ -32,7 +32,7 @@ class TestCreatePortalMetadata(TransactionTestCase):
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
+        shutil.rmtree(settings.OUTPUT_DATA_PATH, ignore_errors=True)
 
     def load_test_data(self):
         # Expected object counts

--- a/api/scpca_portal/test/management/commands/test_generate_computed_files.py
+++ b/api/scpca_portal/test/management/commands/test_generate_computed_files.py
@@ -1,10 +1,9 @@
 import shutil
 from functools import partial
 
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TransactionTestCase
-
-from scpca_portal import common
 
 
 class TestGenerateComputedFiles(TransactionTestCase):
@@ -15,7 +14,7 @@ class TestGenerateComputedFiles(TransactionTestCase):
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        shutil.rmtree(common.OUTPUT_DATA_PATH, ignore_errors=True)
+        shutil.rmtree(settings.OUTPUT_DATA_PATH, ignore_errors=True)
 
     def test_project_SCPCP999990(self):
         pass

--- a/api/scpca_portal/test/test_loader.py
+++ b/api/scpca_portal/test/test_loader.py
@@ -9,7 +9,7 @@ from zipfile import ZipFile
 from django.conf import settings
 from django.test import TransactionTestCase
 
-from scpca_portal import common, loader
+from scpca_portal import loader
 from scpca_portal.models import Project
 from scpca_portal.test import expected_values as test_data
 
@@ -524,7 +524,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = project.get_output_file_name(download_config)
-        project_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        project_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(project_zip_path) as project_zip:
             # Check if correct libraries were added in
             expected_libraries = test_data.Computed_File_Project.SINGLE_CELL_SCE.LIBRARIES
@@ -569,7 +569,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = project.get_output_file_name(download_config)
-        project_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        project_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(project_zip_path) as project_zip:
             # Check if correct libraries were added in
             expected_libraries = (
@@ -613,7 +613,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = project.get_output_file_name(download_config)
-        project_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        project_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(project_zip_path) as project_zip:
             # Check if correct libraries were added in
             expected_libraries = test_data.Computed_File_Project.SINGLE_CELL_SCE_MERGED.LIBRARIES
@@ -655,7 +655,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = project.get_output_file_name(download_config)
-        project_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        project_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(project_zip_path) as project_zip:
             # Check if correct libraries were added in
             expected_libraries = test_data.Computed_File_Project.SINGLE_CELL_ANN_DATA.LIBRARIES
@@ -699,7 +699,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = project.get_output_file_name(download_config)
-        project_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        project_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(project_zip_path) as project_zip:
             # Check if correct libraries were added in
             expected_libraries = (
@@ -745,7 +745,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = project.get_output_file_name(download_config)
-        project_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        project_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(project_zip_path) as project_zip:
             # Check if correct libraries were added in
             expected_libraries = (
@@ -786,7 +786,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = project.get_output_file_name(download_config)
-        project_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        project_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(project_zip_path) as project_zip:
             # Check if correct libraries were added in
             expected_libraries = test_data.Computed_File_Project.ALL_METADATA.LIBRARIES
@@ -840,7 +840,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = sample.get_output_file_name(download_config)
-        sample_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        sample_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(sample_zip_path) as sample_zip:
             # Check if correct libraries were added in
             self.assertLibraries(
@@ -891,7 +891,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = sample.get_output_file_name(download_config)
-        sample_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        sample_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(sample_zip_path) as sample_zip:
             # Check if correct libraries were added in
             self.assertLibraries(
@@ -942,7 +942,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = sample.get_output_file_name(download_config)
-        sample_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        sample_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(sample_zip_path) as sample_zip:
             # Check if correct libraries were added in
             self.assertLibraries(sample_zip, test_data.Computed_File_Sample.SPATIAL_SCE.LIBRARIES)
@@ -991,7 +991,7 @@ class TestLoader(TransactionTestCase):
 
         # CHECK ZIP FILE
         output_file_name = sample.get_output_file_name(download_config)
-        sample_zip_path = common.OUTPUT_DATA_PATH / output_file_name
+        sample_zip_path = settings.OUTPUT_DATA_PATH / output_file_name
         with ZipFile(sample_zip_path) as sample_zip:
             # Check if correct libraries were added in
             self.assertLibraries(


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/862

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR adds a `config` module for the testing environment. It inherits from the `local` config module, but changes the `AWS_S3_INPUT_BUCKET_NAME` to the `test_bucket`, and updates the `DATA_PATH` attribute to point to `CODE_PATH / "test_data"`.

As well, this PR moves environment based constants from `common.py` to the `config` modules.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A