### PR TITLE
897 - Remove obsolete type argument from trackDownload

### DIFF
--- a/client/src/config/ga.js
+++ b/client/src/config/ga.js
@@ -9,5 +9,5 @@ export const events = {
     `${change} ${filter}`,
     window.location
   ],
-  download: (type, project, sample) => ['Download', type, sample || project]
+  download: (project, sample) => ['Download', 'Clicked', sample || project]
 }

--- a/client/src/hooks/useDownloadModal.js
+++ b/client/src/hooks/useDownloadModal.js
@@ -47,8 +47,8 @@ export const useDownloadModal = (
 
   const tryDownload = () => {
     if (download && download.download_url) {
-      const { type, project, sample } = publicComputedFile
-      trackDownload(type, project, sample)
+      const { project, sample } = publicComputedFile
+      trackDownload(project, sample)
       surveyListForm.submit({ email, scpca_last_download_date: getDateISO() })
       window.open(download.download_url)
     }
@@ -84,8 +84,8 @@ export const useDownloadModal = (
       )
       if (downloadRequest.isOk) {
         // try to open download
-        const { type, project, sample } = publicComputedFile
-        trackDownload(type, project, sample)
+        const { project, sample } = publicComputedFile
+        trackDownload(project, sample)
         surveyListForm.submit({
           email,
           scpca_last_download_date: getDateISO()


### PR DESCRIPTION
## Issue Number

Closes #897

## Purpose/Implementation Notes
I've removed the obsolete `type` argument from `trackDownload`. 

Changes include:
- Removed the `type` argument from the `trackDownload` calls
- Replaced the `type` value with `Clicked` (for the `action` mapping) in `config/ga` 


## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests
N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
N/A