### PR TITLE
921 - Remove sample_cell_count_estimate from metadata output

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -57,7 +57,6 @@ METADATA_COLUMN_SORT_ORDER = [
     "demux_samples",
     "total_reads",
     "mapped_reads",
-    "sample_cell_count_estimate",
     "sample_cell_estimate",  # ONLY FOR MULTIPLEXED
     "unfiltered_cells",
     "filtered_cell_count",

--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -197,12 +197,8 @@ class Library(TimestampedModel):
         combined_metadatas = []
         for sample in self.samples.all():
             metadata = self.project.get_metadata() | sample.get_metadata() | self.get_metadata()
-            # Estimate attributes per modality:
-            #   Single Cell: "sample_cell_count_estimate"
-            #   Single Cell Multiplexed: "sample_cell_estimates"
-            #   Spatial: None
-            if self.modality == Library.Modalities.SPATIAL or self.is_multiplexed:
-                del metadata["sample_cell_count_estimate"]
+
+            # Only single cell multiplexed sample libraries should pass through sample_cell_estimate
             if not self.is_multiplexed:
                 del metadata["sample_cell_estimate"]
 

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -125,7 +125,6 @@ class Sample(CommonDataAttributes, TimestampedModel):
 
         derived_attributes = {
             "demux_cell_count_estimate",
-            "sample_cell_count_estimate",
             "includes_anndata",
         }
         sample_metadata.update({key: getattr(self, key) for key in derived_attributes})

--- a/api/scpca_portal/test/expected_values/computed_file_project.py
+++ b/api/scpca_portal/test/expected_values/computed_file_project.py
@@ -36,7 +36,7 @@ class Computed_File_Project:
             "metadata_only": False,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCP999990_SINGLE-CELL_SINGLE-CELL-EXPERIMENT.zip",
-            "size_in_bytes": 9077,
+            "size_in_bytes": 9040,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }
@@ -70,7 +70,7 @@ class Computed_File_Project:
             "metadata_only": False,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCP999991_SINGLE-CELL_SINGLE-CELL-EXPERIMENT_MULTIPLEXED.zip",
-            "size_in_bytes": 9511,
+            "size_in_bytes": 9473,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }
@@ -102,7 +102,7 @@ class Computed_File_Project:
             "metadata_only": False,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCP999990_SINGLE-CELL_SINGLE-CELL-EXPERIMENT_MERGED.zip",
-            "size_in_bytes": 8474,
+            "size_in_bytes": 8437,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }
@@ -138,7 +138,7 @@ class Computed_File_Project:
             "metadata_only": False,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCP999990_SINGLE-CELL_ANN-DATA.zip",
-            "size_in_bytes": 9492,
+            "size_in_bytes": 9455,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }
@@ -170,7 +170,7 @@ class Computed_File_Project:
             "metadata_only": False,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCP999990_SINGLE-CELL_ANN-DATA_MERGED.zip",
-            "size_in_bytes": 8600,
+            "size_in_bytes": 8563,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }
@@ -229,7 +229,7 @@ class Computed_File_Project:
             "metadata_only": True,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCP999990_ALL_METADATA.zip",
-            "size_in_bytes": 5185,
+            "size_in_bytes": 5145,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }

--- a/api/scpca_portal/test/expected_values/computed_file_sample.py
+++ b/api/scpca_portal/test/expected_values/computed_file_sample.py
@@ -30,7 +30,7 @@ class Computed_File_Sample:
             "metadata_only": False,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCS999990_SINGLE-CELL_SINGLE-CELL-EXPERIMENT.zip",
-            "size_in_bytes": 7089,
+            "size_in_bytes": 7057,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }
@@ -60,7 +60,7 @@ class Computed_File_Sample:
             "metadata_only": False,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCS999990_SINGLE-CELL_ANN-DATA.zip",
-            "size_in_bytes": 7401,
+            "size_in_bytes": 7369,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/921

## Purpose/Implementation Notes

This PR removes the Sample attribute `sample_cell_count_estimate` from the output metadata file.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A