### PR TITLE
918 - Move and update provider block

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -1,18 +1,6 @@
 # The configuration contained in this file specifies AWS resources
 # related to networking.
 
-provider "aws" {
-  version = "3.37.0"
-  region = var.region
-
-  default_tags {
-    tags = {
-      team = "engineering"
-      project = "ScPCA Portal"
-    }
-  }
-}
-
 resource "aws_vpc" "scpca_portal_vpc" {
   cidr_block = "10.0.0.0/16"
   enable_dns_support = true

--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  version = "3.37.0"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      team    = "engineering"
+      project = "ScPCA Portal"
+    }
+  }
+}

--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "3.37.0"
+  version = "5.12.0"
   region  = var.region
 
   default_tags {


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/918

## Purpose/Implementation Notes

This PR moves the AWS provider terraform code block from `infrastructure/networking.tf` to its own file in `infrastructure/provider.tf`. The version is also updated to 5.12.0 in order to allow for usage of newer features utilized in the new Batch implementation.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes

## Screenshots

N/A