### PR TITLE
879 - Update setting of Project::unavailable_samples_count

### DIFF
--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -509,8 +509,7 @@ class Project(CommonDataAttributes, TimestampedModel):
         Retrieves downloadable sample counts after the uploading of computed files to s3,
         updates the corresponding attributes on the project object, and saves the object to the db.
         """
-        downloadable_sample_count = (
+        self.downloadable_sample_count = (
             self.samples.filter(sample_computed_files__isnull=False).distinct().count()
         )
-        self.downloadable_sample_count = downloadable_sample_count
         self.save()

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -492,6 +492,9 @@ class Project(CommonDataAttributes, TimestampedModel):
         self.sample_count = sample_count
         self.seq_units = ", ".join(seq_units)
         self.technologies = ", ".join(technologies)
+        self.unavailable_samples_count = self.samples.filter(
+            has_single_cell_data=False, has_spatial_data=False
+        ).count()
         self.save()
 
         for (diagnosis, seq_unit, technology), count in summaries_counts.items():
@@ -509,14 +512,5 @@ class Project(CommonDataAttributes, TimestampedModel):
         downloadable_sample_count = (
             self.samples.filter(sample_computed_files__isnull=False).distinct().count()
         )
-        sample_count = self.samples.count()
-        non_downloadable_samples_count = self.samples.filter(
-            has_multiplexed_data=False, has_single_cell_data=False, has_spatial_data=False
-        ).count()
-        unavailable_samples_count = max(
-            sample_count - downloadable_sample_count - non_downloadable_samples_count, 0
-        )
-
         self.downloadable_sample_count = downloadable_sample_count
-        self.unavailable_samples_count = unavailable_samples_count
         self.save()

--- a/api/scpca_portal/test/expected_values/project_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999990.py
@@ -44,10 +44,7 @@ class Project_SCPCP999990:
         "seq_units": "cell, spot",
         "technologies": "10Xv3, visium",
         "title": "TBD",
-        # unavailable_samples_count should be 1 here, but is returning the default 0.
-        # This is due to the fact that it's not being assigned until after comp file generation.
-        # This should be updated when the bug is handled.
-        # "unavailable_samples_count": 1
+        "unavailable_samples_count": 1,
     }
 
     class Sample_SCPCS999990:

--- a/api/scpca_portal/test/expected_values/project_SCPCP999991.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999991.py
@@ -37,9 +37,6 @@ class Project_SCPCP999991:
         "seq_units": "cell, nucleus",
         "technologies": "10Xv3, 10Xv3.1",
         "title": "TBD",
-        # unavailable_samples_count should be 1 here, but is returning the default 0.
-        # This is due to the fact that it's not being assigned until after comp file generation.
-        # This should be updated when the bug is handled.
         "unavailable_samples_count": 0,
     }
 

--- a/api/scpca_portal/test/expected_values/project_SCPCP999992.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999992.py
@@ -40,9 +40,6 @@ class Project_SCPCP999992:
         "seq_units": "cell",
         "technologies": "10Xv2_5prime, 10Xv3",
         "title": "TBD",
-        # unavailable_samples_count should be 1 here, but is returning the default 0.
-        # This is due to the fact that it's not being assigned until after comp file generation.
-        # This should be updated when the bug is handled.
         "unavailable_samples_count": 0,
     }
 


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/879

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

The `Project`  attribute `unavailable_samples_count` was being set after computed file generation, although this value was known at the end of the loading of metadata. This PR moves the setting of this attribute to its correct location.

There was also a bug in how this attribute was being set that was handled in this PR.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A