### PR TITLE
943 - Fix Multiplexed for Batch

### DIFF
--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -154,9 +154,11 @@ def _create_computed_file(
     if clean_up_output_data:
         computed_file.clean_up_local_computed_file()
 
-    computed_file.save()
     if computed_file.sample and computed_file.has_multiplexed_data:
-        ComputedFile.bulk_create_multiplexed_files(computed_file)
+        computed_files = computed_file.get_multiplexed_computed_files()
+        ComputedFile.objects.bulk_create(computed_files)
+    else:
+        computed_file.save()
 
 
 def _create_computed_file_callback(future, *, update_s3: bool, clean_up_output_data: bool) -> None:

--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -221,7 +221,7 @@ def generate_computed_files(
             ).add_done_callback(on_get_file)
 
         # Generated sample computed files
-        for sample in project.samples.all():
+        for sample in project.all_samples_no_multiplexed_duplicates:
             for config in common.GENERATED_SAMPLE_DOWNLOAD_CONFIGS:
                 sample_lock = locks.setdefault(sample.get_config_identifier(config), Lock())
                 tasks.submit(

--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -154,10 +154,9 @@ def _create_computed_file(
     if clean_up_output_data:
         computed_file.clean_up_local_computed_file()
 
+    computed_file.save()
     if computed_file.sample and computed_file.has_multiplexed_data:
         ComputedFile.bulk_create_multiplexed_files(computed_file)
-
-    computed_file.save()
 
 
 def _create_computed_file_callback(future, *, update_s3: bool, clean_up_output_data: bool) -> None:

--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -219,7 +219,7 @@ def generate_computed_files(
             ).add_done_callback(on_get_file)
 
         # Generated sample computed files
-        for sample in project.all_samples_no_multiplexed_duplicates:
+        for sample in project.samples_to_generate:
             for config in common.GENERATED_SAMPLE_DOWNLOAD_CONFIGS:
                 tasks.submit(
                     ComputedFile.get_sample_file,

--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -149,12 +149,14 @@ def _create_computed_file(
     Save computed file returned from future to the db.
     Upload file to s3 and clean up output data depending on passed options.
     """
-    # Only upload and clean up projects and the last sample if multiplexed
-    if computed_file.project or computed_file.sample.is_last_multiplexed_sample:
-        if update_s3:
-            s3.upload_output_file(computed_file.s3_key, computed_file.s3_bucket)
-        if clean_up_output_data:
-            computed_file.clean_up_local_computed_file()
+    if update_s3:
+        s3.upload_output_file(computed_file.s3_key, computed_file.s3_bucket)
+    if clean_up_output_data:
+        computed_file.clean_up_local_computed_file()
+
+    if computed_file.sample and computed_file.has_multiplexed_data:
+        ComputedFile.bulk_create_multiplexed_files(computed_file)
+
     computed_file.save()
 
 

--- a/api/scpca_portal/management/commands/dispatch_to_batch.py
+++ b/api/scpca_portal/management/commands/dispatch_to_batch.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                     project_id=project.scpca_id, download_config_name=download_config_name
                 )
 
-            for sample in project.all_samples_no_multiplexed_duplicates:
+            for sample in project.samples_to_generate:
                 for download_config_name in common.SAMPLE_DOWNLOAD_CONFIGS.keys():
                     self.submit_job(
                         sample_id=sample.scpca_id, download_config_name=download_config_name

--- a/api/scpca_portal/management/commands/dispatch_to_batch.py
+++ b/api/scpca_portal/management/commands/dispatch_to_batch.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                     project_id=project.scpca_id, download_config_name=download_config_name
                 )
 
-            for sample in project.samples.all():
+            for sample in project.all_samples_no_multiplexed_duplicates:
                 for download_config_name in common.SAMPLE_DOWNLOAD_CONFIGS.keys():
                     self.submit_job(
                         sample_id=sample.scpca_id, download_config_name=download_config_name

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -66,14 +66,12 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         )
 
     @classmethod
-    def bulk_create_multiplexed_files(cls, multiplexed_computed_file: Self) -> None:
-        computed_files = [multiplexed_computed_file]
-        for sample in multiplexed_computed_file.sample.multiplexed_with_samples:
-            computed_file = multiplexed_computed_file.copy()
+    def bulk_create_multiplexed_files(cls, computed_file: Self) -> None:
+        for sample in computed_file.sample.multiplexed_with_samples:
+            # According to the Django docs, this is the way to make a copy of a model instance
+            computed_file.pk = None
             computed_file.sample = sample
-            computed_files.append(computed_file)
-
-        ComputedFile.objects.bulk_create(computed_files)
+            computed_file.save()
 
     @staticmethod
     def get_local_project_metadata_path(project, download_config: Dict) -> Path:

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -65,6 +65,16 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
             f"computed file ({self.size_in_bytes}B)"
         )
 
+    @classmethod
+    def bulk_create_multiplexed_files(cls, multiplexed_computed_file: Self) -> None:
+        computed_files = [multiplexed_computed_file]
+        for sample in multiplexed_computed_file.sample.multiplexed_with_samples:
+            computed_file = multiplexed_computed_file.copy()
+            computed_file.sample = sample
+            computed_files.append(computed_file)
+
+        ComputedFile.objects.bulk_create(computed_files)
+
     @staticmethod
     def get_local_project_metadata_path(project, download_config: Dict) -> Path:
         file_name_parts = [project.scpca_id]

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -4,7 +4,6 @@ from zipfile import ZipFile
 
 from django.conf import settings
 from django.db import models
-from django.forms.models import model_to_dict
 
 from typing_extensions import Self
 
@@ -352,16 +351,26 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
     def get_multiplexed_computed_files(self):
         """
         Return computed file objects for all associated multiplexed samples.
-        The self computed file object is used as a template in building identical computed files,
-        differentiated only by sample, so that they can be bulk created at the same time.
         """
-        multiplexed_samples = list(self.sample.multiplexed_with_samples) + [self.sample]
-        self.sample = None
+        computed_files = [self]
+        for sample in self.sample.multiplexed_with_samples:
+            sample_computed_file = ComputedFile(
+                format=self.format,
+                includes_merged=self.includes_merged,
+                modality=self.modality,
+                metadata_only=self.metadata_only,
+                portal_metadata_only=self.portal_metadata_only,
+                s3_bucket=self.s3_bucket,
+                s3_key=self.s3_key,
+                size_in_bytes=self.size_in_bytes,
+                workflow_version=self.workflow_version,
+                includes_celltype_report=self.includes_celltype_report,
+                has_bulk_rna_seq=self.has_bulk_rna_seq,
+                has_cite_seq_data=self.has_cite_seq_data,
+                has_multiplexed_data=self.has_multiplexed_data,
+                sample=sample,
+            )
 
-        computed_files = []
-        for sample in multiplexed_samples:
-            sample_computed_file = ComputedFile(**model_to_dict(self))
-            sample_computed_file.sample = sample
             computed_files.append(sample_computed_file)
 
         return computed_files

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -78,6 +78,11 @@ class Project(CommonDataAttributes, TimestampedModel):
         return project
 
     @property
+    def all_samples_no_multiplexed_duplicates(self):
+        """Return all non multiplexed samples and only one sample from multiplexed library."""
+        return [sample for sample in self.samples_all if sample.is_last_multiplexed_sample]
+
+    @property
     def computed_files(self):
         return self.project_computed_files.order_by("created_at")
 

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -79,7 +79,7 @@ class Project(CommonDataAttributes, TimestampedModel):
 
     @property
     def all_samples_no_multiplexed_duplicates(self):
-        """Return all non multiplexed samples and only one sample from multiplexed library."""
+        """Return all non multiplexed samples and only one sample from multiplexed libraries."""
         return [sample for sample in self.samples.all() if sample.is_last_multiplexed_sample]
 
     @property

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -80,7 +80,7 @@ class Project(CommonDataAttributes, TimestampedModel):
     @property
     def all_samples_no_multiplexed_duplicates(self):
         """Return all non multiplexed samples and only one sample from multiplexed library."""
-        return [sample for sample in self.samples_all if sample.is_last_multiplexed_sample]
+        return [sample for sample in self.samples.all() if sample.is_last_multiplexed_sample]
 
     @property
     def computed_files(self):

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -78,7 +78,7 @@ class Project(CommonDataAttributes, TimestampedModel):
         return project
 
     @property
-    def all_samples_no_multiplexed_duplicates(self):
+    def samples_to_generate(self):
         """Return all non multiplexed samples and only one sample from multiplexed libraries."""
         return [sample for sample in self.samples.all() if sample.is_last_multiplexed_sample]
 

--- a/api/scpca_portal/test/expected_values/computed_file_sample.py
+++ b/api/scpca_portal/test/expected_values/computed_file_sample.py
@@ -106,7 +106,7 @@ class Computed_File_Sample:
 
     class MULTIPLEXED_SINGLE_CELL_SCE:
         PROJECT_ID = "SCPCP999991"
-        SAMPLE_ID = "SCPCS999992"
+        SAMPLE_IDS = ["SCPCS999992", "SCPCS999993"]
         DOWNLOAD_CONFIG_NAME = "SINGLE_CELL_SINGLE_CELL_EXPERIMENT"
         DOWNLOAD_CONFIG = common.SAMPLE_DOWNLOAD_CONFIGS[DOWNLOAD_CONFIG_NAME]
         LIBRARIES = {"SCPCL999992"}
@@ -129,7 +129,7 @@ class Computed_File_Sample:
             "metadata_only": False,
             "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
             "s3_key": "SCPCS999992-SCPCS999993_SINGLE-CELL_SINGLE-CELL-EXPERIMENT_MULTIPLEXED.zip",
-            "size_in_bytes": 7150,
+            "size_in_bytes": 7671,
             "workflow_version": "development",
             "includes_celltype_report": True,
         }

--- a/api/scpca_portal/test/test_loader.py
+++ b/api/scpca_portal/test/test_loader.py
@@ -998,7 +998,7 @@ class TestLoader(TransactionTestCase):
             # all multiplexed samples must be present to validate correctness here.
             # This is a result of how we create multiplexed sample computed files,
             # where we take the sample with the highest id for computed file generation,
-            # and build computed files for other samples from there the chosen sample.
+            # and build computed file objects for other samples from the chosen sample.
             self.purge_extra_samples(project, sample_ids)
             with patch("scpca_portal.common.GENERATED_SAMPLE_DOWNLOAD_CONFIGS", [download_config]):
                 self.generate_computed_files(project)

--- a/api/scpca_portal/test/test_loader.py
+++ b/api/scpca_portal/test/test_loader.py
@@ -2,7 +2,7 @@ import io
 from csv import DictReader
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, Set
+from typing import Any, Dict, List, Set
 from unittest.mock import patch
 from zipfile import ZipFile
 
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.test import TransactionTestCase
 
 from scpca_portal import loader
-from scpca_portal.models import Project
+from scpca_portal.models import ComputedFile, Project
 from scpca_portal.test import expected_values as test_data
 
 
@@ -40,10 +40,10 @@ class TestLoader(TransactionTestCase):
             clean_up_output_data=False,
         )
 
-    def purge_extra_samples(self, project: Project, sample_of_interest: str) -> None:
-        """Purges all of a project's samples that are not the sample of interest."""
+    def purge_extra_samples(self, project: Project, samples_of_interest: List[str]) -> None:
+        """Purges all of a project's samples that are not the samples of interest."""
         for sample in project.samples.all():
-            if sample != sample_of_interest:
+            if sample.scpca_id not in samples_of_interest:
                 sample.purge()
 
     def assertObjectProperties(self, obj: Any, expected_values: Dict[str, Any]) -> None:
@@ -843,7 +843,7 @@ class TestLoader(TransactionTestCase):
         with patch("scpca_portal.common.GENERATED_PROJECT_DOWNLOAD_CONFIGS", []):
             # Mocking project.samples.all() in loader module is restricted due to the Django ORM
             # Instead, we purge all samples that are not of interest to desired computed file
-            self.purge_extra_samples(project, sample)
+            self.purge_extra_samples(project, [sample_id])
             with patch("scpca_portal.common.GENERATED_SAMPLE_DOWNLOAD_CONFIGS", [download_config]):
                 self.generate_computed_files(project)
 
@@ -894,7 +894,7 @@ class TestLoader(TransactionTestCase):
         with patch("scpca_portal.common.GENERATED_PROJECT_DOWNLOAD_CONFIGS", []):
             # Mocking project.samples.all() in loader module is restricted due to the Django ORM
             # Instead, we purge all samples that are not of interest to desired computed file
-            self.purge_extra_samples(project, sample)
+            self.purge_extra_samples(project, [sample_id])
             with patch("scpca_portal.common.GENERATED_SAMPLE_DOWNLOAD_CONFIGS", [download_config]):
                 self.generate_computed_files(project)
 
@@ -945,7 +945,7 @@ class TestLoader(TransactionTestCase):
         with patch("scpca_portal.common.GENERATED_PROJECT_DOWNLOAD_CONFIGS", []):
             # Mocking project.samples.all() in loader module is restricted due to the Django ORM
             # Instead, we purge all samples that are not of interest to desired computed file
-            self.purge_extra_samples(project, sample)
+            self.purge_extra_samples(project, [sample_id])
             with patch("scpca_portal.common.GENERATED_SAMPLE_DOWNLOAD_CONFIGS", [download_config]):
                 self.generate_computed_files(project)
 
@@ -981,20 +981,25 @@ class TestLoader(TransactionTestCase):
             f"{test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.DOWNLOAD_CONFIG_NAME}",
         )
 
-        sample_id = test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.SAMPLE_ID
-        sample = project.samples.filter(scpca_id=sample_id).first()
-        self.assertIsNotNone(
-            sample,
-            "Problem retrieving sample, unable to test "
-            "test_multiplexed_sample_generate_computed_file_"
-            f"{test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.DOWNLOAD_CONFIG_NAME}",
-        )
+        sample_ids = test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.SAMPLE_IDS
+        for sample_id in sample_ids:
+            sample = project.samples.filter(scpca_id=sample_id).first()
+            self.assertIsNotNone(
+                sample,
+                f"Problem retrieving {sample_id}, unable to test "
+                "test_multiplexed_sample_generate_computed_file_"
+                f"{test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.DOWNLOAD_CONFIG_NAME}",  # noqa
+            )
 
         download_config = test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.DOWNLOAD_CONFIG
+
         with patch("scpca_portal.common.GENERATED_PROJECT_DOWNLOAD_CONFIGS", []):
-            # Mocking project.samples.all() in loader module is restricted due to the Django ORM
-            # Instead, we purge all samples that are not of interest to desired computed file
-            self.purge_extra_samples(project, sample)
+            # While only one sample of intended modality and format is necessary for other tests,
+            # all multiplexed samples must be present to validate correctness here.
+            # This is a result of how we create multiplexed sample computed files,
+            # where we take the sample with the highest id for computed file generation,
+            # and build computed files for other samples from there the chosen sample.
+            self.purge_extra_samples(project, sample_ids)
             with patch("scpca_portal.common.GENERATED_SAMPLE_DOWNLOAD_CONFIGS", [download_config]):
                 self.generate_computed_files(project)
 
@@ -1012,8 +1017,12 @@ class TestLoader(TransactionTestCase):
             )
 
         # CHECK COMPUTED FILE ATTRIBUTES
-        computed_file = sample.get_computed_file(download_config)
-        self.assertIsNotNone(computed_file)
-        self.assertObjectProperties(
-            computed_file, test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.VALUES
-        )
+        self.assertEqual(len(sample_ids), ComputedFile.objects.count())
+        for sample_id in sample_ids:
+            sample = project.samples.filter(scpca_id=sample_id).first()
+            computed_file = sample.get_computed_file(download_config)
+            self.assertIsNotNone(computed_file)
+            # Check for identical computed files amongst multiplexed samples
+            self.assertObjectProperties(
+                computed_file, test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.VALUES
+            )


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/943

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR addresses the suboptimal implementation for multiplexed sample computed files as it pertains to AWS Batch. As mentioned in the connected issue, the current approach utilizing a lock is only possible on a single machine where multiple threads are vying for compute resources. When each sample and download_config is broken up into a separate job, multiplexed samples will be recomputed and re-uploaded on each machine that the job runs on, which is wasteful and unnecessary.

This PR makes the following changes:
- Adds a Project::all_samples_no_multiplexed_duplicates property method which allows for querying of all non multiplexed samples and one multiplexed sample per multiplexed library in the caller.
- Removes the locking mechanism all together for multiplexed sample computed file generation
- Adds a ComputedFile::bulk_create_multiplexed_files class method which adds all of a representative multiplexed sample's associated computed files to the db
- Updates test_loader in light of the changes


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes

## Screenshots

N/A