### PR TITLE
Lock Docker base image to python 3.10.14

### DIFF
--- a/api/Dockerfile.local
+++ b/api/Dockerfile.local
@@ -3,7 +3,7 @@
 # changed the server can detect that and use the newer code without being
 # restarted.
 
-FROM python:3.10
+FROM python:3.10.14
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/api/Dockerfile.prod
+++ b/api/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10.14
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Issue Number

#950

## Purpose/Implementation Notes

Production deployments are currently unable to be build via github actions. This PR pins the base image to 3.10.14 to see if builds may be resumed. If it works we can create a new issue to debug further after deploying the latest data to the portal.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
