### PR TITLE
964 - Update Terraform version in GHA Workflows

### DIFF
--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -31,7 +31,7 @@ jobs:
           SENTRY_DSN: "${{ secrets.OP_SENTRY_DSN }}"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.9.8
 

--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Load 1Password Secrets
         id: op-load-secrets
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.26
+          terraform_version: 1.9.8
 
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -e prod -u deployer -d ccdl -v $(git rev-parse HEAD)

--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -31,7 +31,7 @@ jobs:
           SENTRY_DSN: "${{ secrets.OP_SENTRY_DSN }}"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.9.8
 

--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Load 1Password Secrets
         id: op-load-secrets
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.26
+          terraform_version: 1.9.8
 
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -e staging -u deployer -d ccdlstaging -v $(git rev-parse HEAD)


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/964

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR updates the TF version in the GHA workflows from `0.12.26` to the newest version, `1.9.8`. 
Spinning up a devstack with this new version was successful.

The `actions/checkout` action was also updated by `v2` to `v4`.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A