### PR TITLE
Downgrade to Terraform 0.13.0 in Github GHA workflows

### DIFF
--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.9.8
+          terraform_version: 0.13.0
 
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -e prod -u deployer -d ccdl -v $(git rev-parse HEAD)

--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.9.8
+          terraform_version: 0.13.0
 
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -e staging -u deployer -d ccdlstaging -v $(git rev-parse HEAD)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/964

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

There is an intermediate step when upgrading from TF 0.12.x to 1.x.x.
TF will automatically apply `terraform 0.13upgrade`, which should resolve the `Invalid legacy provider address` error.

First we'll upgrade to 0.13.x, and then transition to 1.x.x.

Discussion here - https://discuss.hashicorp.com/t/unqualified-provider-aws/18554
Upgrade steps -https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/0-13


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes


## Screenshots

N/A