### PR TITLE
Remove identical default tags definitions as they're already included in the provider block

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -25,8 +25,6 @@ resource "aws_db_parameter_group" "postgres12_parameters" {
   lifecycle {
     create_before_destroy = true
   }
-
-  tags = var.default_tags
 }
 
 resource "aws_db_instance" "postgres_db" {

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -126,8 +126,6 @@ resource "aws_lb" "scpca_portal_api_load_balancer" {
     subnet_id = aws_subnet.scpca_portal_1a.id
     allocation_id = aws_eip.scpca_portal_api_ip.id
   }
-
-  tags = var.default_tags
 }
 
 resource "aws_lb_target_group" "api-http" {

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -21,8 +21,6 @@ resource "aws_iam_role" "scpca_portal_instance" {
   ]
 }
 EOF
-
-  tags = var.default_tags
 }
 
 resource "aws_iam_instance_profile" "scpca_portal_instance_profile" {
@@ -63,8 +61,6 @@ resource "aws_iam_policy" "scpca_portal_cloudwatch" {
     ]
 }
 EOF
-
-  tags = var.default_tags
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch" {
@@ -115,8 +111,6 @@ resource "aws_iam_policy" "s3_access_policy" {
    ]
 }
 EOF
-
-  tags = var.default_tags
 }
 
 resource "aws_iam_role_policy_attachment" "s3" {
@@ -159,8 +153,6 @@ resource "aws_iam_policy" "input_bucket_access_policy" {
    ]
 }
 EOF
-
-  tags = var.default_tags
 }
 
 resource "aws_iam_role_policy_attachment" "input_bucket" {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/964

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

We updated here the errors from tags being duplicated, likely due to them being included in the provider block as well as where resources were defined.

We've left the deprecation warning `acl="private"` in place for now, and will handle it later.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

N/A

## Screenshots

N/A