### PR TITLE
Rollback aws provider version to 4.x, before terraform upgrade

### DIFF
--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -2,7 +2,8 @@ terraform {
   required_providers {
     aws = {
       source = "-/aws"
-      version = "~> 5.0.0"
+      version = ">= 4.9.0, < 5.0.0"
+#      version = "~> 5.0.0"
     }
   }
   required_version = "0.13.0"


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/964

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

As mentioned here https://github.com/terraform-aws-modules/terraform-aws-vpc/releases/tag/v4.0.0, terraform must be upgraded to version 1.0 in order to utilize aws provider version 4.x. Here we're rolling back the aws provider version from 5.x to 4.x, as 5.x had errors.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

N/A

## Screenshots

N/A
