### PR TITLE
Upgrade terraform to version 1.0.8

### DIFF
--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 0.13.0
+          terraform_version: 1.0.8
 
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -e prod -u deployer -d ccdl -v $(git rev-parse HEAD)

--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 0.13.0
+          terraform_version: 1.0.8
 
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -e staging -u deployer -d ccdlstaging -v $(git rev-parse HEAD)

--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -6,7 +6,7 @@ terraform {
 #      version = "~> 5.0.0"
     }
   }
-  required_version = "0.13.0"
+  required_version = "1.0.8"
 }
 
 provider "aws" {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/964

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

After completing the updating the `replace_provider` command, we should now be able to upgrade to 1.0.8. From there, we should be able to continue the transition to aws_provider 5.x.

## Types of changes

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

N/A

## Screenshots

N/A
