### PR TITLE
add unlock_state and use it to unlock failed command

### DIFF
--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -9,6 +9,7 @@ import time
 
 from init_terraform import init_terraform
 from replace_provider import replace_provider
+from unlock_state import unlock_state
 
 PRIVATE_KEY_FILE_PATH = "scpca-portal-key.pem"
 PUBLIC_KEY_FILE_PATH = "scpca-portal-key.pub"
@@ -240,6 +241,11 @@ if __name__ == "__main__":
 
     if init_code != 0:
         exit(init_code)
+
+    unlock_code = unlock_state("5eb1ff49-db2d-949a-a4f4-91692b16c525")
+
+    if unlock_code != 0:
+        exit(unlock_code)
 
     replace_provider_code = replace_provider("hashicorp", "aws")
 

--- a/infrastructure/unlock_state.py
+++ b/infrastructure/unlock_state.py
@@ -1,0 +1,27 @@
+import signal
+import subprocess
+
+
+def replace_provider(lock_id):
+    """
+    Replaces the aws provider.
+    Takes an org name, and a provider,
+    and changes the terraform state to use the new qualified provider.
+    """
+
+    # Make sure that Terraform is allowed to shut down gracefully.
+    try:
+        command = [
+            "terraform",
+            "force-unlock",
+            "-force",
+            lock_id
+        ]
+        terraform_process = subprocess.Popen(command)
+        terraform_process.wait()
+    except KeyboardInterrupt:
+        terraform_process.send_signal(signal.SIGINT)
+        terraform_process.wait()
+
+    # ignore error
+    return 1


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- Adds functionality to unlock a specific state lock in terraform
- passes the current lock to ignore so we can unblock ourselves
- this should be removed from deploy before going to prod

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
