### PR TITLE
add quotes to regex for terraform outputs

### DIFF
--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
         exit(terraform_code)
 
     ip_address_match = re.match(
-        r".*\napi_server_1_ip = (\d+\.\d+\.\d+\.\d+)\n.*", terraform_output, re.DOTALL
+        r".*\napi_server_1_ip = \"(\d+\.\d+\.\d+\.\d+)\"\n.*", terraform_output, re.DOTALL
     )
 
     if ip_address_match:


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Deploys look like they are failing but they are fine. This issue is caused by upgrading to terraform 0.14.0 where
output strings are wrapped in quotes. This PR updates our regex to account for them.

## Types of changes

What types of changes does your code introduce?
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
