### PR TITLE
upgrade to terraform 1.0.8

### DIFF
--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 0.14.0
+          terraform_version: 1.0.8
 
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -e prod -u deployer -d ccdl -v $(git rev-parse HEAD)

--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 0.14.0
+          terraform_version: 1.0.8
 
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -e staging -u deployer -d ccdlstaging -v $(git rev-parse HEAD)

--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -6,7 +6,7 @@ terraform {
 #      version = "~> 5.0.0"
     }
   }
-  required_version = "0.14.0"
+  required_version = "1.0.8"
 }
 
 provider "aws" {


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- Upgrades terraform to 1.0.8 so that we can upgrade aws provider to 5.x.x

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
