### PR TITLE
upgrade terraform aws provider to latest 5.x.x

### DIFF
--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -146,9 +146,7 @@ def run_terraform(args):
 
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
-        terraform_process = subprocess.Popen(
-            ["terraform", "taint", "aws_instance.api_server_1"], stdout=subprocess.PIPE
-        )
+        terraform_process = subprocess.Popen(["terraform", "taint", "aws_instance.api_server_1"])
 
         terraform_process.wait()
 
@@ -160,10 +158,7 @@ def run_terraform(args):
 
         terraform_process.wait()
 
-        terraform_process = subprocess.Popen(
-            ["terraform", "apply", var_file_arg, "-auto-approve"],
-            stdout=subprocess.PIPE,
-        )
+        terraform_process = subprocess.Popen(["terraform", "apply", var_file_arg, "-auto-approve"])
 
         terraform_process.wait()
 

--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 5.0.0"
+      version = ">= 5.0.0 < 6.0.0"
     }
   }
   required_version = "1.0.8"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- upgrade terraform aws provider to latest 5.x.x
- adds back terrform outputs to see deprecation warnings etc.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
