### PR TITLE
Hot Fix - dispatch_to_batch is null bug

### DIFF
--- a/api/scpca_portal/management/commands/dispatch_to_batch.py
+++ b/api/scpca_portal/management/commands/dispatch_to_batch.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         within that project.
         """
         projects = (
-            Project.objects.filter(project_computed_files__is_null=True)
+            Project.objects.filter(project_computed_files__isnull=True)
             if not project_id
             else Project.objects.filter(scpca_id=project_id)
         )


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

The correct null check for a foreign key is via `isnull`, instead of `is_null`. This PR makes fixes this error in `dispatch_to_batch`.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

N/A

## Screenshots

N/A