### PR TITLE
1012 - Fix job_queue compute_env Deprecation Warning

### DIFF
--- a/infrastructure/batch/job_queue.tf
+++ b/infrastructure/batch/job_queue.tf
@@ -3,9 +3,10 @@ resource "aws_batch_job_queue" "scpca_portal_project" {
   state    = "ENABLED"
   priority = 1
 
-  compute_environments = [
-    aws_batch_compute_environment.scpca_portal_project.arn,
-  ]
+  compute_environment_order {
+    order = 1
+    compute_environment = aws_batch_compute_environment.scpca_portal_project.arn
+  }
 
   tags = var.batch_tags
 }


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1012

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR fixes the deprecation warning regarding how compute_environments are defined inside of job_queue modules in Terraform which was updated in aws_version 5.x.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

N/A

## Screenshots

N/A