### PR TITLE
Batch D-Test: 32 vCPU Compute Environment with 0.5 vCPUs per job

### DIFF
--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -22,6 +22,6 @@
   stage = var.stage
   batch_tags = {
     module = "batch",
-    revision = "third - 32 vCPU compute environment with 1 vCPU per job"
+    revision = "fourth - 32 vCPU compute environment with 0.5 vCPUs per job"
   }
 }

--- a/infrastructure/batch/job_definition.tf
+++ b/infrastructure/batch/job_definition.tf
@@ -71,7 +71,7 @@ resource "aws_batch_job_definition" "scpca_portal_project" {
     resourceRequirements = [
       {
         type  = "VCPU"
-        value = "1.0"
+        value = "0.5"
       },
       {
         type  = "MEMORY"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

For the Batch D-test, the following changes were made:
- Updated job_definition to decrease vcpus per job to 0.5 (after C-Test increased it to 1.0 per job)
- Updated batch_tags to reflect this change

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

N/A

## Screenshots

N/A