### PR TITLE
1041 - Add `NA` to common.IGNORED_INPUT_VALUES for Publication and ExternalAccession links

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -3,7 +3,7 @@ CSV_MULTI_VALUE_DELIMITER = ";"
 TAB = "\t"
 NA = "NA"  # "Not Available"
 
-IGNORED_INPUT_VALUES = {"", "N/A", "TBD"}
+IGNORED_INPUT_VALUES = {"", NA, "TBD"}
 STRIPPED_INPUT_VALUES = "< >"
 
 # Formats

--- a/api/scpca_portal/test/test_utils.py
+++ b/api/scpca_portal/test/test_utils.py
@@ -200,5 +200,5 @@ class TestGetCsvZippedValues(TestCase):
         }
         args = ["country", "language", "population", "currency"]
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ValueError):
             utils.get_csv_zipped_values(data, *args)

--- a/api/scpca_portal/utils.py
+++ b/api/scpca_portal/utils.py
@@ -95,4 +95,5 @@ def get_csv_zipped_values(
     zips together the values within the new iterables which share the same index,
     and returns the zipped values as a list.
     """
-    return list(zip(*(data.get(key).split(delimiter) for key in args), strict=True))
+    # Fallback to an empty string for missing keys
+    return list(zip(*(data.get(key, "").split(delimiter) for key in args), strict=True))


### PR DESCRIPTION
## Issue Number

Closes #1041

## Purpose/Implementation Notes
Change includes:
- Added `NA` to `common.IGNORED_INPUT_VALUES`
- Added a fallback `""` for missing keys in `utils.get_csv_zipped_values`
- Replaced `AttributeError` with `ValueError` in `test_get_csv_zipped_values_keys_not_present`

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
