### PR TITLE
1049 - Add test_sync_original_files module

### DIFF
--- a/api/scpca_portal/test/management/commands/test_sync_original_files.py
+++ b/api/scpca_portal/test/management/commands/test_sync_original_files.py
@@ -120,7 +120,7 @@ class TestSyncOriginalFiles(TestCase):
             sorted(modified_files.values_list("s3_key", flat=True)),
         )
 
-        # TEST ATTEMPTED DELETION OF ALL FILES - ALLOW_BUCKET_WIPE FLAG `NOT` PASSED
+        # TEST ATTEMPTED DELETION OF ALL FILES - allow_bucket_wipe flag NOT passed
         with patch("scpca_portal.s3.list_bucket_objects", return_value=self.empty_objects_list):
             self.sync_original_files()
         self.assertListEqual(
@@ -128,7 +128,7 @@ class TestSyncOriginalFiles(TestCase):
             sorted(OriginalFile.objects.all().values_list("s3_key", flat=True)),
         )
 
-        # TEST SUCCESSFUL DELETION OF ALL FILES - ALLOW_BUCKET_WIPE FLAG PASSED
+        # TEST SUCCESSFUL DELETION OF ALL FILES - allow_bucket_wipe flag passed
         with patch("scpca_portal.s3.list_bucket_objects", return_value=self.empty_objects_list):
             self.sync_original_files(allow_bucket_wipe=True)
         self.assertFalse(OriginalFile.objects.exists())

--- a/api/scpca_portal/test/management/commands/test_sync_original_files.py
+++ b/api/scpca_portal/test/management/commands/test_sync_original_files.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from functools import partial
 from unittest.mock import patch
 
@@ -13,7 +12,7 @@ class TestSyncOriginalFiles(TestCase):
         self.sync_original_files = partial(call_command, "sync_original_files")
 
         # dummy data mocking the s3 response
-        self.listed_objects = [
+        self.original_objects_list = [
             {
                 "LastModified": "2024-04-19T18:44:06.000Z",
                 "StorageClass": "STANDARD",
@@ -35,86 +34,101 @@ class TestSyncOriginalFiles(TestCase):
                 "size_in_bytes": 770,
                 "hash": "422956680f050e305588cfe2501fe0b3",
             },
+            {
+                "LastModified": "2024-01-11T17:44:32.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "SCPCP999990/SCPCS999990/SCPCL999990_filtered_rna.h5ad",
+                "size_in_bytes": 801,
+                "hash": "422956680f050e305588cfe2501fe0b3",
+            },
+            {
+                "LastModified": "2024-10-01T21:23:24.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "SCPCP999990/SCPCS999991/SCPCL999991_spatial/SCPCL999991_metadata.json",
+                "size_in_bytes": 544,
+                "hash": "03f55d5cc6ff64352bbcc2a3a7b72ac7",
+            },
         ]
+
+        self.modified_objects_list = [
+            {
+                "LastModified": "2024-04-19T18:44:06.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "SCPCP999990/SCPCP999990_bulk_metadata.tsv",
+                "size_in_bytes": 442,
+                "hash": "7bf430b2c2832db1405c254553fe5c30",
+            },
+            {
+                "LastModified": "2024-02-21T00:22:08.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "SCPCP999990/SCPCS999990/SCPCL999990_metadata.json",
+                "size_in_bytes": 947,
+                "hash": "8b583063ad636f7969f6529abcadc18a",
+            },
+            {
+                "LastModified": "2024-01-11T17:44:32.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "SCPCP999990/SCPCS999990/SCPCL999990_filtered.rds",
+                "size_in_bytes": 770,
+                "hash": "modified_hash",
+            },
+            {
+                "LastModified": "2024-01-11T17:44:32.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "SCPCP999990/SCPCS999990/SCPCL999990_filtered_rna.h5ad",
+                "size_in_bytes": 801,
+                "hash": "modified_hash",
+            },
+        ]
+
+        self.empty_objects_list = []
 
     def test_sync_original_files(self):
         self.assertFalse(OriginalFile.objects.exists())
 
-        # test original file creation
-        with patch("scpca_portal.s3.list_bucket_objects", return_value=self.listed_objects):
+        # TEST ORIGINAL FILE CREATION
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=self.original_objects_list):
             self.sync_original_files()
-        self.assertEqual(OriginalFile.objects.count(), len(self.listed_objects))
+        self.assertEqual(OriginalFile.objects.count(), len(self.original_objects_list))
         first_sync_timestamp = OriginalFile.objects.first().bucket_sync_at
 
-        # test original file updating
-        updatable_objects = deepcopy(self.listed_objects)
-        updatable_objects[-1]["hash"] = "updated_hash"
-        with patch("scpca_portal.s3.list_bucket_objects", return_value=updatable_objects):
+        # TEST ORIGINAL FILE UPDATING AND SINGLE FILE DELETION
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=self.modified_objects_list):
             self.sync_original_files()
         second_sync_timestamp = OriginalFile.objects.first().bucket_sync_at
 
-        updated_files = OriginalFile.objects.filter(hash_change_at=second_sync_timestamp)
-        non_updated_files = OriginalFile.objects.filter(hash_change_at=first_sync_timestamp)
+        # assert that correct numbers of files exist, and correct number were deleted
+        self.assertEqual(OriginalFile.objects.count(), len(self.modified_objects_list))
 
-        self.assertEqual(updated_files.count(), 1)
-        self.assertNotIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[0]["s3_key"]).first(),
-            updated_files,
-        )
-        self.assertNotIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[1]["s3_key"]).first(),
-            updated_files,
-        )
-        self.assertIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[2]["s3_key"]).first(),
-            updated_files,
+        non_modified_files = OriginalFile.objects.filter(hash_change_at=first_sync_timestamp)
+        self.assertListEqual(
+            sorted(
+                file.get("s3_key")
+                for file in self.modified_objects_list
+                if file.get("hash") != "modified_hash"
+            ),
+            sorted(non_modified_files.values_list("s3_key", flat=True)),
         )
 
-        self.assertEqual(non_updated_files.count(), 2)
-        self.assertIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[0]["s3_key"]).first(),
-            non_updated_files,
-        )
-        self.assertIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[1]["s3_key"]).first(),
-            non_updated_files,
-        )
-        self.assertNotIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[2]["s3_key"]).first(),
-            non_updated_files,
+        modified_files = OriginalFile.objects.filter(hash_change_at=second_sync_timestamp)
+        self.assertListEqual(
+            sorted(
+                file.get("s3_key")
+                for file in self.modified_objects_list
+                if file.get("hash") == "modified_hash"
+            ),
+            sorted(modified_files.values_list("s3_key", flat=True)),
         )
 
-        # test original file deletion of a single file
-        deletable_objects = deepcopy(self.listed_objects)
-        deletable_objects.pop()
-        with patch("scpca_portal.s3.list_bucket_objects", return_value=deletable_objects):
+        # TEST ATTEMPTED DELETION OF ALL FILES - ALLOW_BUCKET_WIPE FLAG `NOT` PASSED
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=self.empty_objects_list):
             self.sync_original_files()
-        remaining_files = OriginalFile.objects.all()
-        self.assertEqual(remaining_files.count(), 2)
-        self.assertIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[0]["s3_key"]).first(),
-            remaining_files,
-        )
-        self.assertIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[1]["s3_key"]).first(),
-            remaining_files,
+        self.assertListEqual(
+            sorted(file.get("s3_key") for file in self.modified_objects_list),
+            sorted(OriginalFile.objects.all().values_list("s3_key", flat=True)),
         )
 
-        # test original file attempted deletion of all files - allow_bucket_wipe flag NOT passed
-        with patch("scpca_portal.s3.list_bucket_objects", return_value=[]):
-            self.sync_original_files()
-        remaining_files = OriginalFile.objects.all()
-        self.assertEqual(remaining_files.count(), 2)
-        self.assertIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[0]["s3_key"]).first(),
-            remaining_files,
-        )
-        self.assertIn(
-            OriginalFile.objects.filter(s3_key=self.listed_objects[1]["s3_key"]).first(),
-            remaining_files,
-        )
-
-        # test original file deletion of all files - allow_bucket_wipe flag passed
-        with patch("scpca_portal.s3.list_bucket_objects", return_value=[]):
+        # TEST SUCCESSFUL DELETION OF ALL FILES - ALLOW_BUCKET_WIPE FLAG PASSED
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=self.empty_objects_list):
             self.sync_original_files(allow_bucket_wipe=True)
         self.assertFalse(OriginalFile.objects.exists())

--- a/api/scpca_portal/test/management/commands/test_sync_original_files.py
+++ b/api/scpca_portal/test/management/commands/test_sync_original_files.py
@@ -4,36 +4,99 @@ from unittest.mock import patch
 from django.core.management import call_command
 from django.test import TestCase
 
+from scpca_portal.models import OriginalFile
+
 
 class TestSyncOriginalFiles(TestCase):
     def setUp(self):
         self.sync_original_files = partial(call_command, "sync_original_files")
 
         # dummy data mocking the s3 response
-        listed_objects = [
+        self.listed_objects = [
             {
                 "LastModified": "2024-04-19T18:44:06.000Z",
                 "StorageClass": "STANDARD",
-                "s3_key": "2024-04-19/SCPCP999990/SCPCP999990_bulk_metadata.tsv",
+                "s3_key": "SCPCP999990/SCPCP999990_bulk_metadata.tsv",
                 "size_in_bytes": 442,
                 "hash": "7bf430b2c2832db1405c254553fe5c30",
             },
             {
                 "LastModified": "2024-02-21T00:22:08.000Z",
                 "StorageClass": "STANDARD",
-                "s3_key": "2024-02-20/SCPCP999990/SCPCS999990/SCPCL999990_metadata.json",
+                "s3_key": "SCPCP999990/SCPCS999990/SCPCL999990_metadata.json",
                 "size_in_bytes": 947,
                 "hash": "8b583063ad636f7969f6529abcadc18a",
             },
             {
                 "LastModified": "2024-01-11T17:44:32.000Z",
                 "StorageClass": "STANDARD",
-                "s3_key": "project-metadata-changes/SCPCP999990/SCPCP999990_bulk_metadata.tsv",
-                "size_in_bytes": 442,
+                "s3_key": "SCPCP999990/SCPCS999990/SCPCL999990_filtered.rds",
+                "size_in_bytes": 770,
                 "hash": "422956680f050e305588cfe2501fe0b3",
             },
         ]
-        # patch s3::list_bucket_objects in each test so that mocked s3 response is the return value
-        patcher = patch("scpca_portal.s3", "list_bucket_objects", return_value=listed_objects)
-        self.mock_list_bucket_objects = patcher.start()
-        self.addCleanup(patcher.stop)
+
+    def test_sync_original_files(self):
+        self.assertFalse(OriginalFile.objects.exists())
+
+        # test original file creation
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=self.listed_objects):
+            self.sync_original_files()
+        self.assertEqual(OriginalFile.objects.count(), len(self.listed_objects))
+        first_sync_timestamp = OriginalFile.objects.first().bucket_sync_at
+
+        # test originnal file updating
+        self.listed_objects[0]["hash"] = "updated_hash"
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=self.listed_objects):
+            self.sync_original_files()
+        second_sync_timestamp = OriginalFile.objects.first().bucket_sync_at
+
+        updated_files = OriginalFile.objects.filter(hash_change_at=second_sync_timestamp)
+        non_updated_files = OriginalFile.objects.filter(hash_change_at=first_sync_timestamp)
+
+        self.assertEqual(len(updated_files), 1)
+        self.assertIn(
+            OriginalFile.objects.filter(s3_key=self.listed_objects[0]["s3_key"]).first(),
+            updated_files,
+        )
+        self.assertNotIn(
+            OriginalFile.objects.filter(s3_key=self.listed_objects[1]["s3_key"]).first(),
+            updated_files,
+        )
+        self.assertNotIn(
+            OriginalFile.objects.filter(s3_key=self.listed_objects[2]["s3_key"]).first(),
+            updated_files,
+        )
+
+        self.assertEqual(len(non_updated_files), 2)
+        self.assertNotIn(
+            OriginalFile.objects.filter(s3_key=self.listed_objects[0]["s3_key"]).first(),
+            non_updated_files,
+        )
+        self.assertIn(
+            OriginalFile.objects.filter(s3_key=self.listed_objects[1]["s3_key"]).first(),
+            non_updated_files,
+        )
+        self.assertIn(
+            OriginalFile.objects.filter(s3_key=self.listed_objects[2]["s3_key"]).first(),
+            non_updated_files,
+        )
+
+        # test original file deletion of one file
+        self.listed_objects.pop()
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=self.listed_objects):
+            self.sync_original_files()
+        remaining_files = OriginalFile.objects.all()
+        self.assertEqual(remaining_files.count(), 2)
+
+        # test original file attempted deletion of all files - allow_bucket_wipe flag NOT passed
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=[]):
+            self.sync_original_files()
+        remaining_files = OriginalFile.objects.all()
+        self.assertEqual(remaining_files.count(), 2)
+
+        # test original file deletion of all files - allow_bucket_wipe flag passed
+        with patch("scpca_portal.s3.list_bucket_objects", return_value=[]):
+            self.sync_original_files(allow_bucket_wipe=True)
+        remaining_files = OriginalFile.objects.all()
+        self.assertEqual(remaining_files.count(), 0)

--- a/api/scpca_portal/test/management/commands/test_sync_original_files.py
+++ b/api/scpca_portal/test/management/commands/test_sync_original_files.py
@@ -98,5 +98,4 @@ class TestSyncOriginalFiles(TestCase):
         # test original file deletion of all files - allow_bucket_wipe flag passed
         with patch("scpca_portal.s3.list_bucket_objects", return_value=[]):
             self.sync_original_files(allow_bucket_wipe=True)
-        remaining_files = OriginalFile.objects.all()
-        self.assertEqual(remaining_files.count(), 0)
+        self.assertFalse(OriginalFile.objects.exists())

--- a/api/scpca_portal/test/management/commands/test_sync_original_files.py
+++ b/api/scpca_portal/test/management/commands/test_sync_original_files.py
@@ -46,7 +46,7 @@ class TestSyncOriginalFiles(TestCase):
         self.assertEqual(OriginalFile.objects.count(), len(self.listed_objects))
         first_sync_timestamp = OriginalFile.objects.first().bucket_sync_at
 
-        # test originnal file updating
+        # test original file updating
         updatable_objects = deepcopy(self.listed_objects)
         updatable_objects[-1]["hash"] = "updated_hash"
         with patch("scpca_portal.s3.list_bucket_objects", return_value=updatable_objects):
@@ -84,7 +84,7 @@ class TestSyncOriginalFiles(TestCase):
             non_updated_files,
         )
 
-        # test original file deletion of one file
+        # test original file deletion of a single file
         deletable_objects = deepcopy(self.listed_objects)
         deletable_objects.pop()
         with patch("scpca_portal.s3.list_bucket_objects", return_value=deletable_objects):

--- a/api/scpca_portal/test/management/commands/test_sync_original_files.py
+++ b/api/scpca_portal/test/management/commands/test_sync_original_files.py
@@ -1,0 +1,39 @@
+from functools import partial
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestSyncOriginalFiles(TestCase):
+    def setUp(self):
+        self.sync_original_files = partial(call_command, "sync_original_files")
+
+        # dummy data mocking the s3 response
+        listed_objects = [
+            {
+                "LastModified": "2024-04-19T18:44:06.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "2024-04-19/SCPCP999990/SCPCP999990_bulk_metadata.tsv",
+                "size_in_bytes": 442,
+                "hash": "7bf430b2c2832db1405c254553fe5c30",
+            },
+            {
+                "LastModified": "2024-02-21T00:22:08.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "2024-02-20/SCPCP999990/SCPCS999990/SCPCL999990_metadata.json",
+                "size_in_bytes": 947,
+                "hash": "8b583063ad636f7969f6529abcadc18a",
+            },
+            {
+                "LastModified": "2024-01-11T17:44:32.000Z",
+                "StorageClass": "STANDARD",
+                "s3_key": "project-metadata-changes/SCPCP999990/SCPCP999990_bulk_metadata.tsv",
+                "size_in_bytes": 442,
+                "hash": "422956680f050e305588cfe2501fe0b3",
+            },
+        ]
+        # patch s3::list_bucket_objects in each test so that mocked s3 response is the return value
+        patcher = patch("scpca_portal.s3", "list_bucket_objects", return_value=listed_objects)
+        self.mock_list_bucket_objects = patcher.start()
+        self.addCleanup(patcher.stop)


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1049.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Add testing for sync_original_files command which tests
- creating files
- updating files
- deleting a single file
- attempting to delete all files without passing the `--allow-bucket-wipe` flag
- deleting all files while passing the `--allow-bucket-wipe` flag

## Types of changes


<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

- `test_sync_original_files`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A