### PR TITLE
batch secrets

### DIFF
--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -12,9 +12,9 @@
   postgres_db = aws_db_instance.postgres_db
 
   # job_definition secret envars
-  django_secret_key = aws_secrets_manager_secret.django_secret_key
-  database_password = aws_secrets_manager_secret.database_password
-  sentry_dsn = aws_secrets_manager_secret.sentry_dsn
+  django_secret_key = aws_secretsmanager_secret.django_secret_key
+  database_password = aws_secretsmanager_secret.database_password
+  sentry_dsn = aws_secretsmanager_secret.sentry_dsn
 
   # security
   scpca_portal_db_security_group = aws_security_group.scpca_portal_db

--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -7,12 +7,14 @@
 
   # job_definition envars
   dockerhub_account = var.dockerhub_account
-  django_secret_key = var.django_secret_key
-  database_password = var.database_password
   region = var.region
   scpca_portal_bucket = aws_s3_bucket.scpca_portal_bucket
-  sentry_dsn = var.sentry_dsn
   postgres_db = aws_db_instance.postgres_db
+
+  # job_definition secret envars
+  django_secret_key = aws_secrets_manager_secret.django_secret_key
+  database_password = aws_secrets_manager_secret.database_password
+  sentry_dsn = aws_secrets_manager_secret.sentry_dsn
 
   # security
   scpca_portal_db_security_group = aws_security_group.scpca_portal_db

--- a/infrastructure/batch/job_definition.tf
+++ b/infrastructure/batch/job_definition.tf
@@ -22,10 +22,6 @@ resource "aws_batch_job_definition" "scpca_portal_project" {
         name  = "DJANGO_DEBUG"
         value = "false"
       },
-      # {
-      #   name  = "DJANGO_SECRET_KEY"
-      #   value = var.django_secret_key
-      # },
       {
         name  = "DATABASE_HOST"
         value = var.postgres_db.address

--- a/infrastructure/batch/job_definition.tf
+++ b/infrastructure/batch/job_definition.tf
@@ -22,10 +22,10 @@ resource "aws_batch_job_definition" "scpca_portal_project" {
         name  = "DJANGO_DEBUG"
         value = "false"
       },
-      {
-        name  = "DJANGO_SECRET_KEY"
-        value = var.django_secret_key
-      },
+      # {
+      #   name  = "DJANGO_SECRET_KEY"
+      #   value = var.django_secret_key
+      # },
       {
         name  = "DATABASE_HOST"
         value = var.postgres_db.address
@@ -43,10 +43,6 @@ resource "aws_batch_job_definition" "scpca_portal_project" {
         value = var.postgres_db.db_name
       },
       {
-        name  = "DATABASE_PASSWORD"
-        value = var.database_password
-      },
-      {
         name  = "AWS_REGION"
         value = var.region
       },
@@ -55,13 +51,24 @@ resource "aws_batch_job_definition" "scpca_portal_project" {
         value = var.scpca_portal_bucket.bucket
       },
       {
-        name  = "SENTRY_DSN"
-        value = var.sentry_dsn
-      },
-      {
         name  = "SENTRY_ENV"
         value = "${var.stage}-batch"
       }
+    ]
+
+    secrets = [
+      {
+        name      = "DJANGO_SECRET_KEY",
+        valueFrom = "${var.django_secret_key.arn}"
+      },
+      {
+        name      = "DATABASE_PASSWORD",
+        valueFrom = "${var.database_password.arn}"
+      },
+      {
+        name      = "SENTRY_DSN"
+        valueFrom = "${var.sentry_dsn.arn}"
+      },
     ]
 
     fargatePlatformConfiguration = {

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -23,3 +23,4 @@ resource "aws_secretsmanager_secret" "sentry_dsn" {
 resource "aws_secretsmanager_secret_version" "sentry_dsn" {
   secret_id = aws_secretsmanager_secret.sentry_dsn.id
   secret_string = var.sentry_dsn
+}

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -1,0 +1,25 @@
+resource "aws_secretsmanager_secret" "django_secret_key" {
+  name_prefix = "scpca-portal-${var.user}-${var.stage}-django-secret-key"
+}
+
+resource "aws_secretsmanager_secret_version" "django_secret_key" {
+  secret_id = aws_secretsmanager_secret.django_secret_key.id
+  secret_string = var.django_secret_key
+}
+
+resource "aws_secretsmanager_secret" "database_password" {
+  name_prefix = "scpca-portal-${var.user}-${var.stage}-database-password"
+}
+
+resource "aws_secretsmanager_secret_version" "database_password" {
+  secret_id = aws_secretsmanager_secret.database_password.id
+  secret_string = var.database_password
+}
+
+resource "aws_secretsmanager_secret" "sentry_dsn" {
+  name_prefix = "scpca-portal-${var.user}-${var.stage}-raven-dsn"
+}
+
+resource "aws_secretsmanager_secret_version" "sentry_dsn" {
+  secret_id = aws_secretsmanager_secret.sentry_dsn.id
+  secret_string = var.sentry_dsn


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This is a security hygiene improvement. While I was digging through our batch implementation this morning I came across some internally exposed credentials. This PR moves the sensitive envars from `environment` to `secrets` when creating the batch job definition container properties. This change should land before cycling the sensitive values later today.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
