### PR TITLE
propagate tags from aws_batch_job_definition

### DIFF
--- a/infrastructure/batch/job_definition.tf
+++ b/infrastructure/batch/job_definition.tf
@@ -94,5 +94,7 @@ resource "aws_batch_job_definition" "scpca_portal_project" {
     attempts = 3
   }
 
+  propagate_tags = "SERVICE"
+
   tags = var.batch_tags
 }

--- a/infrastructure/batch/job_definition.tf
+++ b/infrastructure/batch/job_definition.tf
@@ -94,7 +94,7 @@ resource "aws_batch_job_definition" "scpca_portal_project" {
     attempts = 3
   }
 
-  propagate_tags = "SERVICE"
+  propagate_tags = true
 
   tags = var.batch_tags
 }


### PR DESCRIPTION
## Issue Number

#959 

## Purpose/Implementation Notes

By default custom tags are not passed from the job definition to individual jobs/tasks. This PR forces the job/task's tags to be assigned at time of creation from the job_description.

Note: propagated tags do not take priority and may be overridden at time of job/task creation.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A 

terraform validate passed

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
