### PR TITLE
1065 - Move FileFormats to enums/file_formats.py

### DIFF
--- a/api/scpca_portal/enums/__init__.py
+++ b/api/scpca_portal/enums/__init__.py
@@ -1,0 +1,1 @@
+from scpca_portal.enums.file_formats import FileFormats

--- a/api/scpca_portal/enums/file_formats.py
+++ b/api/scpca_portal/enums/file_formats.py
@@ -1,0 +1,8 @@
+class FileFormats:
+    ANN_DATA = "ANN_DATA"
+    SINGLE_CELL_EXPERIMENT = "SINGLE_CELL_EXPERIMENT"
+
+    CHOICES = (
+        (ANN_DATA, "AnnData"),
+        (SINGLE_CELL_EXPERIMENT, "Single cell experiment"),
+    )

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.db import models
 
-from scpca_portal.enums.file_formats import FileFormats
+from scpca_portal.enums import FileFormats
 from scpca_portal.models import APIToken, ComputedFile
 from scpca_portal.models.base import TimestampedModel
 

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.db import models
 
+from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.models import APIToken, ComputedFile
 from scpca_portal.models.base import TimestampedModel
 
@@ -11,15 +12,6 @@ class Dataset(TimestampedModel):
         db_table = "datasets"
         get_latest_by = "updated_at"
         ordering = ["updated_at"]
-
-    class FileFormats:
-        ANN_DATA = "ANN_DATA"
-        SINGLE_CELL_EXPERIMENT = "SINGLE_CELL_EXPERIMENT"
-
-        CHOICES = (
-            (ANN_DATA, "AnnData"),
-            (SINGLE_CELL_EXPERIMENT, "Single cell experiment"),
-        )
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 

--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -6,6 +6,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
 from scpca_portal import common, s3
+from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.models.base import TimestampedModel
 from scpca_portal.models.original_file import OriginalFile
 
@@ -15,15 +16,6 @@ class Library(TimestampedModel):
         db_table = "libraries"
         get_latest_by = "updated_at"
         ordering = ["updated_at"]
-
-    class FileFormats:
-        ANN_DATA = "ANN_DATA"
-        SINGLE_CELL_EXPERIMENT = "SINGLE_CELL_EXPERIMENT"
-
-        CHOICES = (
-            (ANN_DATA, "AnnData"),
-            (SINGLE_CELL_EXPERIMENT, "Single cell experiment"),
-        )
 
     class Modalities:
         SINGLE_CELL = "SINGLE_CELL"
@@ -113,7 +105,7 @@ class Library(TimestampedModel):
     @classmethod
     def get_formats_from_file_paths(cls, file_paths: List[Path]) -> List[str]:
         if Library.get_modality_from_file_paths(file_paths) is Library.Modalities.SPATIAL:
-            return [Library.FileFormats.SINGLE_CELL_EXPERIMENT]
+            return [FileFormats.SINGLE_CELL_EXPERIMENT]
 
         extensions_format = {v: k for k, v in common.FORMAT_EXTENSIONS.items()}
         formats = set(

--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -6,7 +6,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
 from scpca_portal import common, s3
-from scpca_portal.enums.file_formats import FileFormats
+from scpca_portal.enums import FileFormats
 from scpca_portal.models.base import TimestampedModel
 from scpca_portal.models.original_file import OriginalFile
 

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -9,7 +9,7 @@ from django.db import models
 
 from scpca_portal import common, metadata_file, s3, utils
 from scpca_portal.config.logging import get_and_configure_logger
-from scpca_portal.enums.file_formats import FileFormats
+from scpca_portal.enums import FileFormats
 from scpca_portal.models.base import CommonDataAttributes, TimestampedModel
 from scpca_portal.models.computed_file import ComputedFile
 from scpca_portal.models.contact import Contact

--- a/api/scpca_portal/models/project.py
+++ b/api/scpca_portal/models/project.py
@@ -9,6 +9,7 @@ from django.db import models
 
 from scpca_portal import common, metadata_file, s3, utils
 from scpca_portal.config.logging import get_and_configure_logger
+from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.models.base import CommonDataAttributes, TimestampedModel
 from scpca_portal.models.computed_file import ComputedFile
 from scpca_portal.models.contact import Contact
@@ -224,12 +225,12 @@ class Project(CommonDataAttributes, TimestampedModel):
             # If the download config requests merged and there is no merged file in the project,
             # return an empty queryset
             if (
-                download_config["format"] == Library.FileFormats.SINGLE_CELL_EXPERIMENT
+                download_config["format"] == FileFormats.SINGLE_CELL_EXPERIMENT
                 and not self.includes_merged_sce
             ):
                 return self.libraries.none()
             elif (
-                download_config["format"] == Library.FileFormats.ANN_DATA
+                download_config["format"] == FileFormats.ANN_DATA
                 and not self.includes_merged_anndata
             ):
                 return self.libraries.none()
@@ -410,7 +411,7 @@ class Project(CommonDataAttributes, TimestampedModel):
                 modality=Library.Modalities.SPATIAL
             ).exists()
             sample.includes_anndata = sample.libraries.filter(
-                formats__contains=[Library.FileFormats.ANN_DATA]
+                formats__contains=[FileFormats.ANN_DATA]
             ).exists()
             sample.save(
                 update_fields=(

--- a/api/scpca_portal/test/expected_values/project_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999990.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.models import Library, Sample
 
 
@@ -169,8 +170,8 @@ class Project_SCPCP999990:
                 "SCPCP999990/SCPCS999990/SCPCL999990_unfiltered_rna.h5ad",
             ],
             "formats": [
-                Library.FileFormats.ANN_DATA,
-                Library.FileFormats.SINGLE_CELL_EXPERIMENT,
+                FileFormats.ANN_DATA,
+                FileFormats.SINGLE_CELL_EXPERIMENT,
             ],
             "has_cite_seq_data": False,
             "is_multiplexed": False,
@@ -199,7 +200,7 @@ class Project_SCPCP999990:
                 "SCPCP999990/SCPCS999991/SCPCL999991_spatial/spatial/tissue_positions_list.csv",
             ],
             "formats": [
-                Library.FileFormats.SINGLE_CELL_EXPERIMENT,
+                FileFormats.SINGLE_CELL_EXPERIMENT,
             ],
             "has_cite_seq_data": False,
             "is_multiplexed": False,
@@ -222,8 +223,8 @@ class Project_SCPCP999990:
                 "SCPCP999990/SCPCS999997/SCPCL999997_unfiltered_rna.h5ad",
             ],
             "formats": [
-                Library.FileFormats.ANN_DATA,
-                Library.FileFormats.SINGLE_CELL_EXPERIMENT,
+                FileFormats.ANN_DATA,
+                FileFormats.SINGLE_CELL_EXPERIMENT,
             ],
             "has_cite_seq_data": False,
             "is_multiplexed": False,

--- a/api/scpca_portal/test/expected_values/project_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999990.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from scpca_portal.enums.file_formats import FileFormats
+from scpca_portal.enums import FileFormats
 from scpca_portal.models import Library, Sample
 
 

--- a/api/scpca_portal/test/expected_values/project_SCPCP999991.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999991.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.models import Library, Sample
 
 
@@ -132,7 +133,7 @@ class Project_SCPCP999991:
                 "SCPCP999991/SCPCS999992,SCPCS999993/SCPCL999992_unfiltered.rds",
             ],
             "formats": [
-                Library.FileFormats.SINGLE_CELL_EXPERIMENT,
+                FileFormats.SINGLE_CELL_EXPERIMENT,
             ],
             "has_cite_seq_data": False,
             "is_multiplexed": True,
@@ -154,7 +155,7 @@ class Project_SCPCP999991:
                 "SCPCP999991/SCPCS999995/SCPCL999995_unfiltered.rds",
                 "SCPCP999991/SCPCS999995/SCPCL999995_unfiltered_rna.h5ad",
             ],
-            "formats": [Library.FileFormats.ANN_DATA, Library.FileFormats.SINGLE_CELL_EXPERIMENT],
+            "formats": [FileFormats.ANN_DATA, FileFormats.SINGLE_CELL_EXPERIMENT],
             "has_cite_seq_data": False,
             "is_multiplexed": False,
             "modality": Library.Modalities.SINGLE_CELL,

--- a/api/scpca_portal/test/expected_values/project_SCPCP999991.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999991.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from scpca_portal.enums.file_formats import FileFormats
+from scpca_portal.enums import FileFormats
 from scpca_portal.models import Library, Sample
 
 

--- a/api/scpca_portal/test/expected_values/project_SCPCP999992.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999992.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.models import Library, Sample
 
 
@@ -111,8 +112,8 @@ class Project_SCPCP999992:
                 "SCPCP999992/SCPCS999996/SCPCL999996_unfiltered_rna.h5ad",
             ],
             "formats": [
-                Library.FileFormats.ANN_DATA,
-                Library.FileFormats.SINGLE_CELL_EXPERIMENT,
+                FileFormats.ANN_DATA,
+                FileFormats.SINGLE_CELL_EXPERIMENT,
             ],
             "has_cite_seq_data": False,
             "is_multiplexed": False,
@@ -138,8 +139,8 @@ class Project_SCPCP999992:
                 "SCPCP999992/SCPCS999998/SCPCL999998_unfiltered_rna.h5ad",
             ],
             "formats": [
-                Library.FileFormats.ANN_DATA,
-                Library.FileFormats.SINGLE_CELL_EXPERIMENT,
+                FileFormats.ANN_DATA,
+                FileFormats.SINGLE_CELL_EXPERIMENT,
             ],
             "has_cite_seq_data": True,
             "is_multiplexed": False,

--- a/api/scpca_portal/test/expected_values/project_SCPCP999992.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999992.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from scpca_portal.enums.file_formats import FileFormats
+from scpca_portal.enums import FileFormats
 from scpca_portal.models import Library, Sample
 
 

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -1,5 +1,6 @@
 import factory
 
+from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.models import ComputedFile, Library
 
 
@@ -126,7 +127,7 @@ class LibraryFactory(factory.django.DjangoModelFactory):
             lambda n: f"SCPCP{str(n).zfill(6)}/SCPCS{str(n).zfill(6)}/SCPCL{str(n).zfill(6)}"
         )
     ]
-    formats = [Library.FileFormats.SINGLE_CELL_EXPERIMENT]
+    formats = [FileFormats.SINGLE_CELL_EXPERIMENT]
     is_multiplexed = False
     modality = Library.Modalities.SINGLE_CELL
     project = factory.SubFactory(LeafProjectFactory)

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from scpca_portal.enums.file_formats import FileFormats
+from scpca_portal.enums import FileFormats
 from scpca_portal.models import ComputedFile, Library
 
 

--- a/api/scpca_portal/test/models/test_sample.py
+++ b/api/scpca_portal/test/models/test_sample.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from scpca_portal import common
+from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.models import Library
 from scpca_portal.test.factories import LibraryFactory, SampleFactory
 
@@ -11,18 +12,18 @@ class TestGetLibraries(TestCase):
 
         library1 = LibraryFactory(
             modality=Library.Modalities.SINGLE_CELL,
-            formats=[Library.FileFormats.SINGLE_CELL_EXPERIMENT, Library.FileFormats.ANN_DATA],
+            formats=[FileFormats.SINGLE_CELL_EXPERIMENT, FileFormats.ANN_DATA],
         )
         library2 = LibraryFactory(
             modality=Library.Modalities.SINGLE_CELL,
-            formats=[Library.FileFormats.SINGLE_CELL_EXPERIMENT],
+            formats=[FileFormats.SINGLE_CELL_EXPERIMENT],
         )
         library3 = LibraryFactory(
-            modality=Library.Modalities.SINGLE_CELL, formats=[Library.FileFormats.ANN_DATA]
+            modality=Library.Modalities.SINGLE_CELL, formats=[FileFormats.ANN_DATA]
         )
         library4 = LibraryFactory(
             modality=Library.Modalities.SPATIAL,
-            formats=[Library.FileFormats.SINGLE_CELL_EXPERIMENT],
+            formats=[FileFormats.SINGLE_CELL_EXPERIMENT],
         )
         self.sample.libraries.add(library1, library2, library3, library4)
 

--- a/api/scpca_portal/test/models/test_sample.py
+++ b/api/scpca_portal/test/models/test_sample.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from scpca_portal import common
-from scpca_portal.enums.file_formats import FileFormats
+from scpca_portal.enums import FileFormats
 from scpca_portal.models import Library
 from scpca_portal.test.factories import LibraryFactory, SampleFactory
 


### PR DESCRIPTION
## Issue Number

Closes #1065

## Purpose/Implementation Notes

I've moved the inner class `FileFormats` from the following models to `enums/file_formats.py` and updated all the references:

- `Dataset`
- `Library`

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
