### PR TITLE
1069 - Add and attach batch job secretsmanager access policy

### DIFF
--- a/infrastructure/batch/roles.tf
+++ b/infrastructure/batch/roles.tf
@@ -115,3 +115,31 @@ resource "aws_iam_role_policy_attachment" "batch_job_s3_access" {
   role       = aws_iam_role.batch_job_role.name
   policy_arn = aws_iam_policy.batch_job_s3_access.arn
 }
+
+resource "aws_iam_policy" "batch_job_secretsmanager_access" {
+  name = "scpca-portal-batch-job-secretsmanager-access-${var.user}-${var.stage}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${var.django_secret_key.arn}",
+        "${var.database_password.arn}"
+        "${var.sentry_dsn.arn}"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "batch_job_secretsmanager_access" {
+  role       = aws_iam_role.batch_job_role.name
+  policy_arn = aws_iam_policy.batch_job_secretsmanager_access.arn
+}


### PR DESCRIPTION
## Issue Number

#1069 

## Purpose/Implementation Notes

Does what it says on the tin

- creates policy that allows access to read secrets from secrets manager
- attaches policy to batch job role

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

`terraform validate`

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
