### PR TITLE
add missing comma to secretsmanager policy

### DIFF
--- a/infrastructure/batch/roles.tf
+++ b/infrastructure/batch/roles.tf
@@ -130,7 +130,7 @@ resource "aws_iam_policy" "batch_job_secretsmanager_access" {
       ],
       "Resource": [
         "${var.django_secret_key.arn}",
-        "${var.database_password.arn}"
+        "${var.database_password.arn}",
         "${var.sentry_dsn.arn}"
       ]
     }


### PR DESCRIPTION
## Issue Number

#1069 

## Purpose/Implementation Notes

Apparently terraform validate doesn't evaluate json strings, terraform plan should be done instead.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
