### PR TITLE
Max upgrade minor version 16.3 - 12.19 -> 16.3

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -52,7 +52,7 @@ resource "aws_db_instance" "postgres_db" {
   allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
-  engine_version = "16.6"
+  engine_version = "16.3"
   auto_minor_version_upgrade = false
   instance_class = var.database_instance_type
   db_name = "scpca_portal"


### PR DESCRIPTION
## Issue Number

#1071 

## Purpose/Implementation Notes

As per their documentation max minor version on 16 is actually 16.3 when upgrading from 12.19

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.MajorVersion.html

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
