### PR TITLE
allow major version upgrade

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -53,6 +53,7 @@ resource "aws_db_instance" "postgres_db" {
   storage_type = "gp2"
   engine = "postgres"
   engine_version = "16.3"
+  allow_major_version_upgrade = true
   auto_minor_version_upgrade = false
   instance_class = var.database_instance_type
   db_name = "scpca_portal"


### PR DESCRIPTION
## Issue Number

#1071 

## Purpose/Implementation Notes

- Sets `allow_major_version_upgrade` flag to `true`

This should allow the upgrade to be performed, I think we will want to remove this after the maintenance window where the upgrade has been performed.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
