### PR TITLE
Add upgrade instructions and apply immediately to database instance

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -53,7 +53,14 @@ resource "aws_db_instance" "postgres_db" {
   storage_type = "gp2"
   engine = "postgres"
   engine_version = "16.3"
+
+  # When doing a major version upgrade it is easier
+  # to apply changes immediately to allow for subsequent deployments.
+  # `allow_major_version_upgrade` and `apply_immediately`
+  # should be commented out when the old parameter group is removed.
   allow_major_version_upgrade = true
+  apply_immediately = true
+
   auto_minor_version_upgrade = false
   instance_class = var.database_instance_type
   db_name = "scpca_portal"


### PR DESCRIPTION
## Issue Number

#1071 

## Purpose/Implementation Notes

- adds instructions on commenting out `allow_major_version_upgrade` and `apply_immediately` when not in the process of upgrading db version
- sets`apply_immediately` to true on rds instance


## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
