### PR TITLE
Fix no white space in Batch job name error

### DIFF
--- a/api/scpca_portal/management/commands/dispatch_send_test_email.py
+++ b/api/scpca_portal/management/commands/dispatch_send_test_email.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
     def dispatch_send_email(self, sender: str, recipient: str, **kwargs):
         sender_flag = f"--sender {sender}" if sender else ""
         recipient_flag = f"--recipient {recipient}" if recipient else ""
-        job_name = f"Test email from {sender} - {str(datetime.now())}"
+        job_name = f"{sender}-{str(datetime.now())}"
 
         response = batch.submit_job(
             jobName=job_name,
@@ -47,4 +47,4 @@ class Command(BaseCommand):
             },
         )
 
-        logger.info(f'{job_name} submitted to Batch with jobId {response["jobId"]}')
+        logger.info(f'Job `{job_name}` submitted to Batch with jobId `{response["jobId"]}`')


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/issues/1045

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Remove illegal white space in Batch job name


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)


## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes


## Screenshots

N/A
