### PR TITLE
1106 - Update classes in the enums folder to Enum subclasses

### DIFF
--- a/api/scpca_portal/enums/file_formats.py
+++ b/api/scpca_portal/enums/file_formats.py
@@ -1,12 +1,8 @@
-class FileFormats:
+from django.db.models import TextChoices
+
+
+class FileFormats(TextChoices):
     ANN_DATA = "ANN_DATA"
     SINGLE_CELL_EXPERIMENT = "SINGLE_CELL_EXPERIMENT"
     METADATA = "METADATA"
     SUPPLEMENTARY = "SUPPLEMENTARY"
-
-    CHOICES = (
-        (ANN_DATA, "AnnData"),
-        (SINGLE_CELL_EXPERIMENT, "Single cell experiment"),
-        (METADATA, "Metadata"),
-        (SUPPLEMENTARY, "Supplementary"),
-    )

--- a/api/scpca_portal/enums/job_states.py
+++ b/api/scpca_portal/enums/job_states.py
@@ -1,12 +1,8 @@
-class JobStates:
+from django.db.models import TextChoices
+
+
+class JobStates(TextChoices):
     CREATED = "CREATED"
     SUBMITTED = "SUBMITTED"
     COMPLETED = "COMPLETED"
     TERMINATED = "TERMINATED"
-
-    CHOICES = (
-        (CREATED, "Created"),
-        (SUBMITTED, "Submitted"),
-        (COMPLETED, "Completed"),
-        (COMPLETED, "Terminated"),
-    )

--- a/api/scpca_portal/enums/modalities.py
+++ b/api/scpca_portal/enums/modalities.py
@@ -2,8 +2,8 @@ from django.db.models import TextChoices
 
 
 class Modalities(TextChoices):
-    BULK_RNA_SEQ = "BULK_RNA_SEQ"
-    CITE_SEQ = "CITE_SEQ"
-    MULTIPLEXED = "MULTIPLEXED"
-    SINGLE_CELL = "SINGLE_CELL"
-    SPATIAL = "SPATIAL"
+    BULK_RNA_SEQ = "BULK_RNA_SEQ", "Bulk RNA-seq"
+    CITE_SEQ = "CITE_SEQ", "CITE-seq"
+    MULTIPLEXED = "MULTIPLEXED", "Multiplexed"
+    SINGLE_CELL = "SINGLE_CELL", "Single Cell"
+    SPATIAL = "SPATIAL", "Spatial Data"

--- a/api/scpca_portal/enums/modalities.py
+++ b/api/scpca_portal/enums/modalities.py
@@ -1,18 +1,9 @@
-class Modalities:
+from django.db.models import TextChoices
+
+
+class Modalities(TextChoices):
     BULK_RNA_SEQ = "BULK_RNA_SEQ"
     CITE_SEQ = "CITE_SEQ"
     MULTIPLEXED = "MULTIPLEXED"
     SINGLE_CELL = "SINGLE_CELL"
     SPATIAL = "SPATIAL"
-
-    CHOICES = (
-        (SINGLE_CELL, "Single Cell"),
-        (SPATIAL, "Spatial"),
-    )
-
-    NAME_MAPPING = {
-        BULK_RNA_SEQ: "Bulk RNA-seq",
-        CITE_SEQ: "CITE-seq",
-        MULTIPLEXED: "Multiplexed",
-        SPATIAL: "Spatial Data",
-    }

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -20,7 +20,7 @@ class Dataset(TimestampedModel):
     email = models.EmailField(null=True)
     start = models.BooleanField(default=False)
     # Format or regenerated_from is required at the time of creation
-    format = models.TextField(choices=FileFormats.CHOICES)
+    format = models.TextField(choices=FileFormats.choices)
     regenerated_from = models.ForeignKey(
         "self",
         null=True,

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -16,7 +16,7 @@ class Job(TimestampedModel):
     critical_error = models.BooleanField(default=False)  # Set to True if the job is irrecoverable
     failure_reason = models.TextField(blank=True, null=True)
     retry_on_termination = models.BooleanField(default=False)
-    state = models.TextField(choices=JobStates.CHOICES, default=JobStates.CREATED)
+    state = models.TextField(choices=JobStates.choices, default=JobStates.CREATED)
 
     submitted_at = models.DateTimeField(null=True)
     completed_at = models.DateTimeField(null=True)

--- a/api/scpca_portal/models/library.py
+++ b/api/scpca_portal/models/library.py
@@ -17,11 +17,11 @@ class Library(TimestampedModel):
         get_latest_by = "updated_at"
         ordering = ["updated_at"]
 
-    formats = ArrayField(models.TextField(choices=FileFormats.CHOICES), default=list)
+    formats = ArrayField(models.TextField(choices=FileFormats.choices), default=list)
     has_cite_seq_data = models.BooleanField(default=False)
     is_multiplexed = models.BooleanField(default=False)
     metadata = models.JSONField(default=dict)
-    modality = models.TextField(choices=Modalities.CHOICES)
+    modality = models.TextField(choices=Modalities.choices)
     scpca_id = models.TextField(unique=True)
     workflow_version = models.TextField()
 

--- a/api/scpca_portal/models/original_file.py
+++ b/api/scpca_portal/models/original_file.py
@@ -46,7 +46,7 @@ class OriginalFile(TimestampedModel):
     is_cite_seq = models.BooleanField(default=False)  # indicates if file is exclusively cite_seq
     is_bulk = models.BooleanField(default=False)
     # formats
-    formats = ArrayField(models.TextField(choices=FileFormats.CHOICES), default=list)
+    formats = ArrayField(models.TextField(choices=FileFormats.choices), default=list)
     is_single_cell_experiment = models.BooleanField(default=False)
     is_anndata = models.BooleanField(default=False)
     is_supplementary = models.BooleanField(default=False)

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -20,18 +20,6 @@ class Sample(CommonDataAttributes, TimestampedModel):
         get_latest_by = "updated_at"
         ordering = ["updated_at"]
 
-    class ModalitiesNameMapping:
-        names = {
-            Modalities.BULK_RNA_SEQ: "Bulk RNA-seq",
-            Modalities.CITE_SEQ: "CITE-seq",
-            Modalities.MULTIPLEXED: "Multiplexed",
-            Modalities.SPATIAL: "Spatial Data",
-        }
-
-        @staticmethod
-        def get_name(modality):
-            return Sample.ModalitiesNameMapping.names.get(modality)
-
     age = models.TextField()
     age_timing = models.TextField()
     demux_cell_count_estimate_sum = models.IntegerField(null=True)
@@ -187,7 +175,7 @@ class Sample(CommonDataAttributes, TimestampedModel):
 
         return sorted(
             [
-                Sample.ModalitiesNameMapping.get_name(modality_name)
+                modality_name.label
                 for attr_name, modality_name in attr_name_modality_mapping.items()
                 if getattr(self, attr_name)
             ]

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -20,14 +20,6 @@ class Sample(CommonDataAttributes, TimestampedModel):
         get_latest_by = "updated_at"
         ordering = ["updated_at"]
 
-    MODALITY_NAME_MAPPING = {
-        Modalities.BULK_RNA_SEQ: "Bulk RNA-seq",
-        Modalities.CITE_SEQ: "CITE-seq",
-        Modalities.MULTIPLEXED: "Multiplexed",
-        Modalities.SINGLE_CELL: "Single Cell",
-        Modalities.SPATIAL: "Spatial Data",
-    }
-
     class ModalitiesNameMapping:
         names = {
             Modalities.BULK_RNA_SEQ: "Bulk RNA-seq",

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -195,7 +195,7 @@ class Sample(CommonDataAttributes, TimestampedModel):
 
         return sorted(
             [
-                Sample.MODALITY_NAME_MAPPING[modality_name]
+                Sample.ModalitiesNameMapping.get_name(modality_name)
                 for attr_name, modality_name in attr_name_modality_mapping.items()
                 if getattr(self, attr_name)
             ]

--- a/api/scpca_portal/models/sample.py
+++ b/api/scpca_portal/models/sample.py
@@ -20,6 +20,26 @@ class Sample(CommonDataAttributes, TimestampedModel):
         get_latest_by = "updated_at"
         ordering = ["updated_at"]
 
+    MODALITY_NAME_MAPPING = {
+        Modalities.BULK_RNA_SEQ: "Bulk RNA-seq",
+        Modalities.CITE_SEQ: "CITE-seq",
+        Modalities.MULTIPLEXED: "Multiplexed",
+        Modalities.SINGLE_CELL: "Single Cell",
+        Modalities.SPATIAL: "Spatial Data",
+    }
+
+    class ModalitiesNameMapping:
+        names = {
+            Modalities.BULK_RNA_SEQ: "Bulk RNA-seq",
+            Modalities.CITE_SEQ: "CITE-seq",
+            Modalities.MULTIPLEXED: "Multiplexed",
+            Modalities.SPATIAL: "Spatial Data",
+        }
+
+        @staticmethod
+        def get_name(modality):
+            return Sample.ModalitiesNameMapping.names.get(modality)
+
     age = models.TextField()
     age_timing = models.TextField()
     demux_cell_count_estimate_sum = models.IntegerField(null=True)
@@ -175,7 +195,7 @@ class Sample(CommonDataAttributes, TimestampedModel):
 
         return sorted(
             [
-                Modalities.NAME_MAPPING[modality_name]
+                Sample.MODALITY_NAME_MAPPING[modality_name]
                 for attr_name, modality_name in attr_name_modality_mapping.items()
                 if getattr(self, attr_name)
             ]

--- a/api/scpca_portal/test/expected_values/project_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999990.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 
 from scpca_portal.enums import FileFormats, Modalities
-from scpca_portal.models import Sample
 
 
 class Project_SCPCP999990:
@@ -26,8 +25,8 @@ class Project_SCPCP999990:
         "includes_merged_anndata": True,
         "includes_xenografts": False,
         "modalities": [
-            Sample.ModalitiesNameMapping.get_name(Modalities.BULK_RNA_SEQ),
-            Sample.ModalitiesNameMapping.get_name(Modalities.SPATIAL),
+            Modalities.BULK_RNA_SEQ.label,
+            Modalities.SPATIAL.label,
         ],
         "multiplexed_sample_count": 0,
         "organisms": ["Homo sapiens"],

--- a/api/scpca_portal/test/expected_values/project_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999990.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 from scpca_portal.enums import FileFormats, Modalities
+from scpca_portal.models import Sample
 
 
 class Project_SCPCP999990:
@@ -25,8 +26,8 @@ class Project_SCPCP999990:
         "includes_merged_anndata": True,
         "includes_xenografts": False,
         "modalities": [
-            Modalities.NAME_MAPPING[Modalities.BULK_RNA_SEQ],
-            Modalities.NAME_MAPPING[Modalities.SPATIAL],
+            Sample.ModalitiesNameMapping.get_name(Modalities.BULK_RNA_SEQ),
+            Sample.ModalitiesNameMapping.get_name(Modalities.SPATIAL),
         ],
         "multiplexed_sample_count": 0,
         "organisms": ["Homo sapiens"],

--- a/api/scpca_portal/test/expected_values/project_SCPCP999991.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999991.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 
 from scpca_portal.enums import FileFormats, Modalities
-from scpca_portal.models import Sample
 
 
 class Project_SCPCP999991:
@@ -26,7 +25,7 @@ class Project_SCPCP999991:
         "includes_merged_anndata": False,
         "includes_xenografts": False,
         "modalities": [
-            Sample.ModalitiesNameMapping.get_name(Modalities.MULTIPLEXED),
+            Modalities.MULTIPLEXED.label,
         ],
         "multiplexed_sample_count": 2,
         "organisms": ["Homo sapiens"],

--- a/api/scpca_portal/test/expected_values/project_SCPCP999991.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999991.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 from scpca_portal.enums import FileFormats, Modalities
+from scpca_portal.models import Sample
 
 
 class Project_SCPCP999991:
@@ -25,7 +26,7 @@ class Project_SCPCP999991:
         "includes_merged_anndata": False,
         "includes_xenografts": False,
         "modalities": [
-            Modalities.NAME_MAPPING[Modalities.MULTIPLEXED],
+            Sample.ModalitiesNameMapping.get_name(Modalities.MULTIPLEXED),
         ],
         "multiplexed_sample_count": 2,
         "organisms": ["Homo sapiens"],

--- a/api/scpca_portal/test/expected_values/project_SCPCP999992.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999992.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 from scpca_portal.enums import FileFormats, Modalities
+from scpca_portal.models import Sample
 
 
 class Project_SCPCP999992:
@@ -24,7 +25,7 @@ class Project_SCPCP999992:
         "includes_merged_sce": True,
         "includes_merged_anndata": True,
         "includes_xenografts": False,
-        "modalities": [Modalities.NAME_MAPPING[Modalities.CITE_SEQ]],
+        "modalities": [Sample.ModalitiesNameMapping.get_name(Modalities.CITE_SEQ)],
         "multiplexed_sample_count": 0,
         "organisms": ["Homo sapiens"],
         "original_file_paths": [

--- a/api/scpca_portal/test/expected_values/project_SCPCP999992.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999992.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 
 from scpca_portal.enums import FileFormats, Modalities
-from scpca_portal.models import Sample
 
 
 class Project_SCPCP999992:
@@ -25,7 +24,7 @@ class Project_SCPCP999992:
         "includes_merged_sce": True,
         "includes_merged_anndata": True,
         "includes_xenografts": False,
-        "modalities": [Sample.ModalitiesNameMapping.get_name(Modalities.CITE_SEQ)],
+        "modalities": [Modalities.CITE_SEQ.label],
         "multiplexed_sample_count": 0,
         "organisms": ["Homo sapiens"],
         "original_file_paths": [


### PR DESCRIPTION
## Issue Number

Close #1106

## Purpose/Implementation Notes

I've updated all the classes in the `enums` folder to be subclasses of `Enum`.

Regarding the `NAME_MAPPING` constant, it was previously inside `Modalities`, but due to how `TextChoices` works, it was getting included in the `choices` property, which wasn’t ideal when referencing it. To fix this, I've moved it to the `Sample` model as an inner class, since it’s only relevant for that model. This approach keeps things simple, avoids adding extra helpers, and makes future cleanups easier if needed (as discussed in our meeting).

Let me know if you have any other suggestions or thoughts on this, thank you!

```py
In [1]: from scpca_portal.enums import Modalities

In [2]: Modalities.choices
Out[2]: 
[('BULK_RNA_SEQ', 'Bulk Rna Seq'),
 ('CITE_SEQ', 'Cite Seq'),
 ('MULTIPLEXED', 'Multiplexed'),
 ('SINGLE_CELL', 'Single Cell'),
 ('SPATIAL', 'Spatial'),
 ("{'BULK_RNA_SEQ': 'Bulk RNA-seq', 'CITE_SEQ': 'CITE-seq', 'MULTIPLEXED': 'Multiplexed', 'SPATIAL': 'Spatial Data'}",
  'Name Mapping')]
 ```

## Types of changes

What types of changes does your code introduce?
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
