### PR TITLE
1115 - Add test_validate_data tests to test_dataset module

### DIFF
--- a/api/scpca_portal/enums/__init__.py
+++ b/api/scpca_portal/enums/__init__.py
@@ -1,3 +1,4 @@
+from scpca_portal.enums.dataset_data_project_config import DatasetDataProjectConfig
 from scpca_portal.enums.dataset_formats import DatasetFormats
 from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.enums.job_states import JobStates

--- a/api/scpca_portal/enums/dataset_data_project_config.py
+++ b/api/scpca_portal/enums/dataset_data_project_config.py
@@ -1,0 +1,5 @@
+class DatasetDataProjectConfig:
+    MERGE_SINGLE_CELL = "merge_single_cell"
+    INCLUDES_BULK = "includes_bulk"
+    SINGLE_CELL = "SINGLE_CELL"
+    SPATIAL = "SPATIAL"

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -87,29 +87,22 @@ class DataValidator:
         ]
 
     def validate_project(self, project_id: str) -> bool:
-        is_valid = self._validate_project_id(project_id)
-        is_valid &= (
-            self._validate_merge_single_cell(project_id)
-            if self.data.get(project_id).get("merge_single_cell")
-            else True
-        )
-        is_valid &= (
-            self._validate_includes_bulk(project_id)
-            if self.data.get(project_id).get("includes_bulk")
-            else True
-        )
-        is_valid &= (
-            self._validate_single_cell(project_id)
-            if self.data.get(project_id).get(Modalities.SINGLE_CELL)
-            else True
-        )
-        is_valid &= (
-            self._validate_spatial(project_id)
-            if self.data.get(project_id).get(Modalities.SPATIAL)
-            else True
-        )
+        if not self._validate_project_id(project_id):
+            return False
 
-        return is_valid
+        if not self._validate_merge_single_cell(project_id):
+            return False
+
+        if not self._validate_includes_bulk(project_id):
+            return False
+
+        if not self._validate_single_cell(project_id):
+            return False
+
+        if not self._validate_spatial(project_id):
+            return False
+
+        return True
 
     def _validate_project_id(self, project_id):
         return self._validate_id(project_id, common.PROJECT_ID_PREFIX)
@@ -125,15 +118,27 @@ class DataValidator:
         return len(id_number) == 6 and id_number.isdigit()
 
     def _validate_merge_single_cell(self, project_id) -> bool:
-        return isinstance(self.data.get(project_id).get("merge_single_cell"), bool)
+        if "merge_single_cell" not in self.data.get(project_id, {}):
+            return True
+
+        return isinstance(self.data.get(project_id).get("merge_single_cell", {}), bool)
 
     def _validate_includes_bulk(self, project_id) -> bool:
+        if "includes_bulk" not in self.data.get(project_id, {}):
+            return True
+
         return isinstance(self.data.get(project_id).get("includes_bulk"), bool)
 
     def _validate_single_cell(self, project_id) -> bool:
+        if Modalities.SINGLE_CELL not in self.data.get(project_id, {}):
+            return True
+
         return self._validate_modality(self.data.get(project_id).get(Modalities.SINGLE_CELL))
 
     def _validate_spatial(self, project_id) -> bool:
+        if Modalities.SPATIAL not in self.data.get(project_id, {}):
+            return True
+
         return self._validate_modality(self.data.get(project_id).get(Modalities.SPATIAL))
 
     def _validate_modality(self, modality_sample_ids: List) -> bool:

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -1,8 +1,9 @@
 import uuid
+from typing import Dict
 
 from django.db import models
 
-from scpca_portal.enums import DatasetFormats
+from scpca_portal.enums import DatasetFormats, Modalities
 from scpca_portal.models import APIToken, ComputedFile
 from scpca_portal.models.base import TimestampedModel
 
@@ -59,3 +60,12 @@ class Dataset(TimestampedModel):
 
     def __str__(self):
         return f"Dataset {self.id}"
+
+
+class DataElement:
+    def __init__(self, json_element: Dict) -> None:
+        ((self.project_id, self.config),) = json_element.items()
+        self.merge_single_cell = self.config.get("merge_single_cell")
+        self.includes_bulk = self.config.get("includes_bulk")
+        self.SINGLE_CELL = self.config.get(Modalities.SINGLE_CELL)
+        self.SPATIAL = self.config.get(Modalities.SPATIAL)

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -62,9 +62,9 @@ class Dataset(TimestampedModel):
     def __str__(self):
         return f"Dataset {self.id}"
 
-    @staticmethod
-    def validate_data(json_obj: Dict) -> bool:
-        data_validator = DataValidator(json_obj)
+    @property
+    def is_data_valid(self) -> bool:
+        data_validator = DataValidator(self.data)
         return data_validator.is_valid
 
 

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 from django.db import models
 
 from scpca_portal import common
-from scpca_portal.enums import DatasetFormats, Modalities
+from scpca_portal.enums import DatasetDataProjectConfig, DatasetFormats
 from scpca_portal.models import APIToken, ComputedFile
 from scpca_portal.models.base import TimestampedModel
 
@@ -118,28 +118,36 @@ class DataValidator:
         return len(id_number) == 6 and id_number.isdigit()
 
     def _validate_merge_single_cell(self, project_id) -> bool:
-        if "merge_single_cell" not in self.data.get(project_id, {}):
+        if DatasetDataProjectConfig.MERGE_SINGLE_CELL not in self.data.get(project_id, {}):
             return True
 
-        return isinstance(self.data.get(project_id).get("merge_single_cell", {}), bool)
+        return isinstance(
+            self.data.get(project_id).get(DatasetDataProjectConfig.MERGE_SINGLE_CELL, {}), bool
+        )
 
     def _validate_includes_bulk(self, project_id) -> bool:
-        if "includes_bulk" not in self.data.get(project_id, {}):
+        if DatasetDataProjectConfig.INCLUDES_BULK not in self.data.get(project_id, {}):
             return True
 
-        return isinstance(self.data.get(project_id).get("includes_bulk"), bool)
+        return isinstance(
+            self.data.get(project_id).get(DatasetDataProjectConfig.INCLUDES_BULK), bool
+        )
 
     def _validate_single_cell(self, project_id) -> bool:
-        if Modalities.SINGLE_CELL not in self.data.get(project_id, {}):
+        if DatasetDataProjectConfig.SINGLE_CELL not in self.data.get(project_id, {}):
             return True
 
-        return self._validate_modality(self.data.get(project_id).get(Modalities.SINGLE_CELL))
+        return self._validate_modality(
+            self.data.get(project_id).get(DatasetDataProjectConfig.SINGLE_CELL)
+        )
 
     def _validate_spatial(self, project_id) -> bool:
-        if Modalities.SPATIAL not in self.data.get(project_id, {}):
+        if DatasetDataProjectConfig.SPATIAL not in self.data.get(project_id, {}):
             return True
 
-        return self._validate_modality(self.data.get(project_id).get(Modalities.SPATIAL))
+        return self._validate_modality(
+            self.data.get(project_id).get(DatasetDataProjectConfig.SPATIAL)
+        )
 
     def _validate_modality(self, modality_sample_ids: List) -> bool:
         if not isinstance(modality_sample_ids, list):

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -62,6 +62,14 @@ class Dataset(TimestampedModel):
     def __str__(self):
         return f"Dataset {self.id}"
 
+    def validate_data(self, json_obj: Dict) -> bool:
+        for json_element in json_obj:
+            data_element = DataElement(json_element)
+            if not data_element.validate():
+                return False
+
+        return True
+
 
 class DataElement:
     def __init__(self, json_element: Dict) -> None:

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -62,9 +62,10 @@ class Dataset(TimestampedModel):
     def __str__(self):
         return f"Dataset {self.id}"
 
-    def validate_data(self, json_obj: Dict) -> bool:
-        for json_element in json_obj:
-            data_element = DataElement(json_element)
+    @staticmethod
+    def validate_data(json_obj: Dict) -> bool:
+        for project_id, config in json_obj.items():
+            data_element = DataElement(project_id, config)
             if not data_element.validate():
                 return False
 
@@ -72,8 +73,9 @@ class Dataset(TimestampedModel):
 
 
 class DataElement:
-    def __init__(self, json_element: Dict) -> None:
-        ((self.project_id, self.config),) = json_element.items()
+    def __init__(self, project_id: str, config: Dict) -> None:
+        self.project_id = project_id
+        self.config = config
         self.merge_single_cell = self.config.get("merge_single_cell")
         self.includes_bulk = self.config.get("includes_bulk")
         self.SINGLE_CELL = self.config.get(Modalities.SINGLE_CELL)
@@ -81,8 +83,10 @@ class DataElement:
 
     def validate(self) -> bool:
         return (
-            len(self.config.keys()) == 4
+            bool(self.project_id)
             and self._validate_project_id()
+            and bool(self.config)
+            and len(self.config.keys()) == 4
             and self._validate_merge_single_cell()
             and self._validate_includes_bulk()
             and self._validate_single_cell()

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -102,17 +102,17 @@ class DataValidator:
         return is_valid
 
     def _validate_project_id(self, project_id):
-        return self._validate_resource_id(project_id, common.PROJECT_ID_PREFIX)
+        return self._validate_id(project_id, common.PROJECT_ID_PREFIX)
 
-    def _validate_resource_id(self, resource_id: str, resource_prefix: str) -> bool:
-        if not isinstance(resource_id, str):
+    def _validate_id(self, id: str, prefix: str) -> bool:
+        if not isinstance(id, str):
             return False
 
-        if not resource_id.startswith(resource_prefix):
+        if not id.startswith(prefix):
             return False
 
-        resource_id_number = resource_id.removeprefix(resource_prefix)
-        return len(resource_id_number) == 6 and resource_id_number.isdigit()
+        id_number = id.removeprefix(prefix)
+        return len(id_number) == 6 and id_number.isdigit()
 
     def _validate_merge_single_cell(self, project_id) -> bool:
         return isinstance(self.data.get(project_id).get("merge_single_cell"), bool)
@@ -131,7 +131,7 @@ class DataValidator:
             return False
 
         for sample_id in modality_sample_ids:
-            if not self._validate_resource_id(sample_id, common.SAMPLE_ID_PREFIX):
+            if not self._validate_id(sample_id, common.SAMPLE_ID_PREFIX):
                 return False
 
         return True

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -76,6 +76,16 @@ class DataValidator:
     def is_valid(self) -> bool:
         return all(self.validate_project(project_id) for project_id in self.data.keys())
 
+    @property
+    def valid_projects(self) -> List[str]:
+        return [project_id for project_id in self.data.keys() if self.validate_project(project_id)]
+
+    @property
+    def invalid_projects(self) -> List[str]:
+        return [
+            project_id for project_id in self.data.keys() if not self.validate_project(project_id)
+        ]
+
     def validate_project(self, project_id: str) -> bool:
         is_valid = self._validate_project_id(project_id)
         is_valid &= (

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -118,36 +118,28 @@ class DataValidator:
         return len(id_number) == 6 and id_number.isdigit()
 
     def _validate_merge_single_cell(self, project_id) -> bool:
-        if DatasetDataProjectConfig.MERGE_SINGLE_CELL not in self.data.get(project_id, {}):
-            return True
+        if value := self.data.get(project_id, {}).get(DatasetDataProjectConfig.MERGE_SINGLE_CELL):
+            return isinstance(value, bool)
 
-        return isinstance(
-            self.data.get(project_id).get(DatasetDataProjectConfig.MERGE_SINGLE_CELL, {}), bool
-        )
+        return True
 
     def _validate_includes_bulk(self, project_id) -> bool:
-        if DatasetDataProjectConfig.INCLUDES_BULK not in self.data.get(project_id, {}):
-            return True
+        if value := self.data.get(project_id, {}).get(DatasetDataProjectConfig.INCLUDES_BULK):
+            return isinstance(value, bool)
 
-        return isinstance(
-            self.data.get(project_id).get(DatasetDataProjectConfig.INCLUDES_BULK), bool
-        )
+        return True
 
     def _validate_single_cell(self, project_id) -> bool:
-        if DatasetDataProjectConfig.SINGLE_CELL not in self.data.get(project_id, {}):
-            return True
+        if value := self.data.get(project_id, {}).get(DatasetDataProjectConfig.SINGLE_CELL):
+            return self._validate_modality(value)
 
-        return self._validate_modality(
-            self.data.get(project_id).get(DatasetDataProjectConfig.SINGLE_CELL)
-        )
+        return True
 
     def _validate_spatial(self, project_id) -> bool:
-        if DatasetDataProjectConfig.SPATIAL not in self.data.get(project_id, {}):
-            return True
+        if value := self.data.get(project_id, {}).get(DatasetDataProjectConfig.SPATIAL):
+            return self._validate_modality(value)
 
-        return self._validate_modality(
-            self.data.get(project_id).get(DatasetDataProjectConfig.SPATIAL)
-        )
+        return True
 
     def _validate_modality(self, modality_sample_ids: List) -> bool:
         if not isinstance(modality_sample_ids, list):

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -72,13 +72,13 @@ class TestDataset(TestCase):
         }
         self.assertTrue(Dataset.validate_data(data))
 
-        # Empty config
+        # Empty config (valid)
         data = {
             "SCPCP999990": {},
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertTrue(Dataset.validate_data(data))
 
-        # Merge single cell - missing
+        # Merge single cell - missing (valid)
         data = {
             "SCPCP999990": {
                 "includes_bulk": True,
@@ -86,9 +86,9 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertTrue(Dataset.validate_data(data))
 
-        # Merge single cell - wrong data type
+        # Merge single cell - wrong data type (invalid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": "True",
@@ -99,7 +99,7 @@ class TestDataset(TestCase):
         }
         self.assertFalse(Dataset.validate_data(data))
 
-        # Includes bulk - missing
+        # Includes bulk - missing (valid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -107,9 +107,9 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertTrue(Dataset.validate_data(data))
 
-        # Includes bulk - wrong data type
+        # Includes bulk - wrong data type (invalid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -120,7 +120,7 @@ class TestDataset(TestCase):
         }
         self.assertFalse(Dataset.validate_data(data))
 
-        # Single Cell - missing
+        # Single Cell - missing (valid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -128,9 +128,9 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertTrue(Dataset.validate_data(data))
 
-        # Single Cell - wrong data type
+        # Single Cell - wrong data type (invalid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -141,7 +141,7 @@ class TestDataset(TestCase):
         }
         self.assertFalse(Dataset.validate_data(data))
 
-        # Single Cell - wrong inner data type
+        # Single Cell - wrong inner data type (invalid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -152,7 +152,7 @@ class TestDataset(TestCase):
         }
         self.assertFalse(Dataset.validate_data(data))
 
-        # Single Cell - invalid sample id
+        # Single Cell - invalid sample id (invalid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -163,7 +163,7 @@ class TestDataset(TestCase):
         }
         self.assertFalse(Dataset.validate_data(data))
 
-        # Spatial - missing
+        # Spatial - missing (valid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -171,9 +171,9 @@ class TestDataset(TestCase):
                 Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertTrue(Dataset.validate_data(data))
 
-        # Spatial - wrong data type
+        # Spatial - wrong data type (invalid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -184,7 +184,7 @@ class TestDataset(TestCase):
         }
         self.assertFalse(Dataset.validate_data(data))
 
-        # Spatial - wrong inner data type
+        # Spatial - wrong inner data type (invalid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -195,7 +195,7 @@ class TestDataset(TestCase):
         }
         self.assertFalse(Dataset.validate_data(data))
 
-        # Spatial - invalid sample id
+        # Spatial - invalid sample id (invalid)
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -58,3 +58,150 @@ class TestDataset(TestCase):
             },
         }
         self.assertFalse(Dataset.validate_data(data))
+
+    @tag("validate_data")
+    def test_validate_data_config(self):
+        # Valid config
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertTrue(Dataset.validate_data(data))
+
+        # Empty config
+        data = {
+            "SCPCP999990": {},
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Merge single cell - missing
+        data = {
+            "SCPCP999990": {
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Merge single cell - wrong data type
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": "True",
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Includes bulk - missing
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Includes bulk - wrong data type
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": "True",
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Single Cell - missing
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Single Cell - wrong data type
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: "SCPCS999990",
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Single Cell - wrong inner data type
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: [1, 2, 3],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Single Cell - invalid sample id
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["sample_id"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Spatial - missing
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Spatial - wrong data type
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: "SCPCS999992",
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Spatial - wrong inner data type
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: [1, 2, 3],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Spatial - invalid sample id
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["sample_id"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -1,5 +1,6 @@
-from django.test import TestCase
+from django.test import TestCase, tag
 
+from scpca_portal.enums import Modalities
 from scpca_portal.models import Dataset
 from scpca_portal.test.factories import DatasetFactory
 
@@ -11,3 +12,49 @@ class TestDataset(TestCase):
 
         returned_dataset = Dataset.objects.filter(pk=dataset.id).first()
         self.assertEqual(returned_dataset, dataset)
+
+    @tag("validate_data")
+    def test_validate_data_project_id(self):
+        # Valid project id
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertTrue(Dataset.validate_data(data))
+
+        # Incorrect project ids
+        data = {
+            "project_id": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Lack of SCPCP prefix
+        data = {
+            "SCPCA999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))
+
+        # Incorrect number of digits
+        data = {
+            "SCPCP9999900": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999992"],
+            },
+        }
+        self.assertFalse(Dataset.validate_data(data))

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -13,8 +13,8 @@ class TestDataset(TestCase):
         returned_dataset = Dataset.objects.filter(pk=dataset.id).first()
         self.assertEqual(returned_dataset, dataset)
 
-    @tag("validate_data")
-    def test_validate_data_project_id(self):
+    @tag("is_data_valid")
+    def test_is_data_valid_project_id(self):
         # Valid project id
         data = {
             "SCPCP999990": {
@@ -59,8 +59,8 @@ class TestDataset(TestCase):
         }
         self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
-    @tag("validate_data")
-    def test_validate_data_config(self):
+    @tag("is_data_valid")
+    def test_is_data_valid_config(self):
         # Valid config
         data = {
             "SCPCP999990": {

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -24,7 +24,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertTrue(Dataset.validate_data(data))
+        self.assertTrue(DatasetFactory(data=data).is_data_valid)
 
         # Incorrect project ids
         data = {
@@ -35,7 +35,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Lack of SCPCP prefix
         data = {
@@ -46,7 +46,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Incorrect number of digits
         data = {
@@ -57,7 +57,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
     @tag("validate_data")
     def test_validate_data_config(self):
@@ -70,13 +70,13 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertTrue(Dataset.validate_data(data))
+        self.assertTrue(DatasetFactory(data=data).is_data_valid)
 
         # Empty config (valid)
         data = {
             "SCPCP999990": {},
         }
-        self.assertTrue(Dataset.validate_data(data))
+        self.assertTrue(DatasetFactory(data=data).is_data_valid)
 
         # Merge single cell - missing (valid)
         data = {
@@ -86,7 +86,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertTrue(Dataset.validate_data(data))
+        self.assertTrue(DatasetFactory(data=data).is_data_valid)
 
         # Merge single cell - wrong data type (invalid)
         data = {
@@ -97,7 +97,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Includes bulk - missing (valid)
         data = {
@@ -107,7 +107,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertTrue(Dataset.validate_data(data))
+        self.assertTrue(DatasetFactory(data=data).is_data_valid)
 
         # Includes bulk - wrong data type (invalid)
         data = {
@@ -118,7 +118,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Single Cell - missing (valid)
         data = {
@@ -128,7 +128,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertTrue(Dataset.validate_data(data))
+        self.assertTrue(DatasetFactory(data=data).is_data_valid)
 
         # Single Cell - wrong data type (invalid)
         data = {
@@ -139,7 +139,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Single Cell - wrong inner data type (invalid)
         data = {
@@ -150,7 +150,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Single Cell - invalid sample id (invalid)
         data = {
@@ -161,7 +161,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["SCPCS999992"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Spatial - missing (valid)
         data = {
@@ -171,7 +171,7 @@ class TestDataset(TestCase):
                 Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
             },
         }
-        self.assertTrue(Dataset.validate_data(data))
+        self.assertTrue(DatasetFactory(data=data).is_data_valid)
 
         # Spatial - wrong data type (invalid)
         data = {
@@ -182,7 +182,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: "SCPCS999992",
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Spatial - wrong inner data type (invalid)
         data = {
@@ -193,7 +193,7 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: [1, 2, 3],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)
 
         # Spatial - invalid sample id (invalid)
         data = {
@@ -204,4 +204,4 @@ class TestDataset(TestCase):
                 Modalities.SPATIAL: ["sample_id"],
             },
         }
-        self.assertFalse(Dataset.validate_data(data))
+        self.assertFalse(DatasetFactory(data=data).is_data_valid)


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1115

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR introduced a `is_data_valid` property method, which leverages the `DataValidator` class to determine if the Dataset data attribute is properly build. The Dataset data attribute must contain a dictionary with keys being project_ids and values being config dictionaries which contain options and samples to draw from when querying for Original Files during Computed File generation.

A few tests were added to validate the project_id keys and config values confirm to the desired structure.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

- test_dataset::test_is_data_valid_project_id
- test_dataset::test_is_data_valid_config

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works


## Screenshots

N/A
