### PR TITLE
1117 - Implement Job::submit method

### DIFF
--- a/api/scpca_portal/config/test.py
+++ b/api/scpca_portal/config/test.py
@@ -7,7 +7,9 @@ class Test(Local):
     # AWS S3
     # Note: Data must be resynced when test bucket is updated
     AWS_S3_INPUT_BUCKET_NAME = "scpca-portal-public-test-inputs/2024-09-10"
-
+    # AWS Batch
+    AWS_BATCH_JOB_QUEUE_NAME = "MOCK_AWS_BATCH_JOB_QUEUE_NAME"
+    AWS_BATCH_JOB_DEFINITION_NAME = "MOCK_AWS_BATCH_JOB_DEFINITION_NAME"
     # Code Paths
     INPUT_DATA_PATH = Path("/home/user/code/test_data/input")
     OUTPUT_DATA_PATH = Path("/home/user/code/test_data/output")

--- a/api/scpca_portal/management/commands/dispatch_to_batch.py
+++ b/api/scpca_portal/management/commands/dispatch_to_batch.py
@@ -8,7 +8,7 @@ from django.template.defaultfilters import pluralize
 
 import boto3
 
-from scpca_portal.models import Project
+from scpca_portal.models import Job, Project
 
 batch = boto3.client(
     "batch",
@@ -38,41 +38,41 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         self.dispatch_to_batch(**kwargs)
 
-    def submit_job(
-        self,
-        *,
-        download_config_name: str,
-        project_id: str = "",
-        sample_id: str = "",
-        notify: bool = False,
-    ) -> None:
-        """
-        Submit job to AWS Batch, accordingly to the resource_id and download_config combination.
-        """
-        resource_flag = "--project-id" if project_id else "--sample-id"
-        resource_id = project_id if project_id else sample_id
-        job_name = f"{resource_id}-{download_config_name}"
-        notify_flag = "--notify" if notify else ""
+    # def submit_job(
+    #     self,
+    #     *,
+    #     download_config_name: str,
+    #     project_id: str = "",
+    #     sample_id: str = "",
+    #     notify: bool = False,
+    # ) -> None:
+    #     """
+    #     Submit job to AWS Batch, accordingly to the resource_id and download_config combination.
+    #     """
+    #     resource_flag = "--project-id" if project_id else "--sample-id"
+    #     resource_id = project_id if project_id else sample_id
+    #     job_name = f"{resource_id}-{download_config_name}"
+    #     notify_flag = "--notify" if notify else ""
 
-        response = batch.submit_job(
-            jobName=job_name,
-            jobQueue=settings.AWS_BATCH_JOB_QUEUE_NAME,
-            jobDefinition=settings.AWS_BATCH_JOB_DEFINITION_NAME,
-            containerOverrides={
-                "command": [
-                    "python",
-                    "manage.py",
-                    "generate_computed_file",
-                    resource_flag,
-                    resource_id,
-                    "--download-config-name",
-                    download_config_name,
-                    notify_flag,
-                ],
-            },
-        )
+    #     response = batch.submit_job(
+    #         jobName=job_name,
+    #         jobQueue=settings.AWS_BATCH_JOB_QUEUE_NAME,
+    #         jobDefinition=settings.AWS_BATCH_JOB_DEFINITION_NAME,
+    #         containerOverrides={
+    #             "command": [
+    #                 "python",
+    #                 "manage.py",
+    #                 "generate_computed_file",
+    #                 resource_flag,
+    #                 resource_id,
+    #                 "--download-config-name",
+    #                 download_config_name,
+    #                 notify_flag,
+    #             ],
+    #         },
+    #     )
 
-        logger.info(f'{job_name} submitted to Batch with jobId {response["jobId"]}')
+    #     logger.info(f'{job_name} submitted to Batch with jobId {response["jobId"]}')
 
     def dispatch_to_batch(self, project_id: str, regenerate_all: bool, notify: bool, **kwargs):
         """
@@ -100,19 +100,23 @@ class Command(BaseCommand):
                 ):
                     may_notify = notify
 
-                self.submit_job(
+                job = Job.get_project_job(
                     project_id=project.scpca_id,
                     download_config_name=download_config_name,
                     notify=may_notify,
                 )
+
+                job.submit()
                 job_counts["project"] += 1
 
             for sample in project.samples_to_generate:
                 for download_config_name in sample.valid_download_config_names:
-                    self.submit_job(
+                    job = Job.get_sample_job(
                         sample_id=sample.scpca_id,
                         download_config_name=download_config_name,
                     )
+
+                    job.submit()
                     job_counts["sample"] += 1
 
         total_job_count = sum(job_counts.values())

--- a/api/scpca_portal/management/commands/dispatch_to_batch.py
+++ b/api/scpca_portal/management/commands/dispatch_to_batch.py
@@ -57,14 +57,14 @@ class Command(BaseCommand):
         for project in project_list:
             project_valid_download_config_names = project.valid_download_config_names
             for download_config_name in project_valid_download_config_names:
-                last_project = (
+                is_last_job = (
                     project == project_list[-1]
                     and download_config_name == project_valid_download_config_names[-1]
                 )
                 job = Job.get_project_job(
                     project_id=project.scpca_id,
                     download_config_name=download_config_name,
-                    notify=last_project and notify,
+                    notify=is_last_job and notify,
                 )
 
                 job.submit()

--- a/api/scpca_portal/management/commands/dispatch_to_batch.py
+++ b/api/scpca_portal/management/commands/dispatch_to_batch.py
@@ -38,42 +38,6 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         self.dispatch_to_batch(**kwargs)
 
-    # def submit_job(
-    #     self,
-    #     *,
-    #     download_config_name: str,
-    #     project_id: str = "",
-    #     sample_id: str = "",
-    #     notify: bool = False,
-    # ) -> None:
-    #     """
-    #     Submit job to AWS Batch, accordingly to the resource_id and download_config combination.
-    #     """
-    #     resource_flag = "--project-id" if project_id else "--sample-id"
-    #     resource_id = project_id if project_id else sample_id
-    #     job_name = f"{resource_id}-{download_config_name}"
-    #     notify_flag = "--notify" if notify else ""
-
-    #     response = batch.submit_job(
-    #         jobName=job_name,
-    #         jobQueue=settings.AWS_BATCH_JOB_QUEUE_NAME,
-    #         jobDefinition=settings.AWS_BATCH_JOB_DEFINITION_NAME,
-    #         containerOverrides={
-    #             "command": [
-    #                 "python",
-    #                 "manage.py",
-    #                 "generate_computed_file",
-    #                 resource_flag,
-    #                 resource_id,
-    #                 "--download-config-name",
-    #                 download_config_name,
-    #                 notify_flag,
-    #             ],
-    #         },
-    #     )
-
-    #     logger.info(f'{job_name} submitted to Batch with jobId {response["jobId"]}')
-
     def dispatch_to_batch(self, project_id: str, regenerate_all: bool, notify: bool, **kwargs):
         """
         Iterate over all projects that fit the criteria of the passed flags
@@ -93,17 +57,14 @@ class Command(BaseCommand):
         for project in project_list:
             project_valid_download_config_names = project.valid_download_config_names
             for download_config_name in project_valid_download_config_names:
-                may_notify = False
-                if (
+                last_project = (
                     project == project_list[-1]
                     and download_config_name == project_valid_download_config_names[-1]
-                ):
-                    may_notify = notify
-
+                )
                 job = Job.get_project_job(
                     project_id=project.scpca_id,
                     download_config_name=download_config_name,
-                    notify=may_notify,
+                    notify=last_project and notify,
                 )
 
                 job.submit()

--- a/api/scpca_portal/test/management/commands/test_dispatch_to_batch.py
+++ b/api/scpca_portal/test/management/commands/test_dispatch_to_batch.py
@@ -4,15 +4,34 @@ from unittest.mock import patch
 from django.core.management import call_command
 from django.test import TestCase
 
+from scpca_portal.models import Job
 from scpca_portal.test.factories import ProjectFactory
 
 
 class TestDispatchToBatch(TestCase):
     def setUp(self):
+        # handle patching in setUp function
         self.dispatch_to_batch = partial(call_command, "dispatch_to_batch")
+        patch_job_submit = patch("scpca_portal.models.Job.submit")
+        patch_get_sample_job = patch("scpca_portal.models.Job.get_sample_job")
+        patch_get_project_job = patch("scpca_portal.models.Job.get_project_job")
+        # Save patches that so they can be stopped during tearDown
+        self.patches = [patch_job_submit, patch_get_sample_job, patch_get_project_job]
+        # Start patches
+        self.mock_job_submit = patch_job_submit.start()
+        self.mock_get_sample_job = patch_get_sample_job.start()
+        self.mock_get_project_job = patch_get_project_job.start()
+        # Configure necessary output values
+        self.mock_get_project_job.return_value = Job()
+        self.mock_get_sample_job.return_value = Job()
 
-    @patch("scpca_portal.management.commands.dispatch_to_batch.Command.submit_job")
-    def test_generate_all_missing_files(self, mock_submit_job):
+    def tearDown(self):
+        for p in self.patches:
+            p.stop()
+
+    def test_generate_all_missing_files(
+        self,
+    ):
         projects_with_files = [ProjectFactory() for _ in range(3)]
         for project_with_files in projects_with_files:
             self.assertTrue(project_with_files.computed_files.exists())
@@ -22,13 +41,13 @@ class TestDispatchToBatch(TestCase):
             self.assertFalse(project_no_files.computed_files.exists())
 
         self.dispatch_to_batch()
-        mock_submit_job.assert_called()
+
+        self.mock_job_submit.assert_called()
 
         submitted_project_ids = set(
-            call.kwargs.get("project_id")
-            for call in mock_submit_job.call_args_list
-            if call.kwargs.get("project_id") is not None
+            call.kwargs.get("project_id") for call in self.mock_get_project_job.call_args_list
         )
+
         self.assertEqual(len(projects_no_files), len(submitted_project_ids))
         for project_no_files in projects_no_files:
             self.assertIn(project_no_files.scpca_id, submitted_project_ids)
@@ -37,25 +56,20 @@ class TestDispatchToBatch(TestCase):
 
         sample_no_files = projects_no_files[0].samples.first()
         submitted_sample_ids = set(
-            call.kwargs.get("sample_id")
-            for call in mock_submit_job.call_args_list
-            if call.kwargs.get("sample_id") is not None
+            call.kwargs.get("sample_id") for call in self.mock_get_sample_job.call_args_list
         )
         self.assertIn(sample_no_files.scpca_id, submitted_sample_ids)
 
-    @patch("scpca_portal.management.commands.dispatch_to_batch.Command.submit_job")
-    def test_generate_missing_files_for_passed_project(self, mock_submit_job):
+    def test_generate_missing_files_for_passed_project(self):
         project = ProjectFactory(computed_file=None)
         self.assertFalse(project.computed_files.exists())
         adtl_projects = [ProjectFactory(computed_file=None) for _ in range(3)]
 
         self.dispatch_to_batch(project_id=project.scpca_id)
-        mock_submit_job.assert_called()
+        self.mock_job_submit.assert_called()
 
         submitted_project_ids = set(
-            call.kwargs.get("project_id")
-            for call in mock_submit_job.call_args_list
-            if call.kwargs.get("project_id") is not None
+            call.kwargs.get("project_id") for call in self.mock_get_project_job.call_args_list
         )
         self.assertEqual(len(submitted_project_ids), 1)
         self.assertIn(project.scpca_id, submitted_project_ids)
@@ -64,15 +78,12 @@ class TestDispatchToBatch(TestCase):
 
         sample = project.samples.first()
         submitted_sample_ids = set(
-            call.kwargs.get("sample_id")
-            for call in mock_submit_job.call_args_list
-            if call.kwargs.get("sample_id") is not None
+            call.kwargs.get("sample_id") for call in self.mock_get_sample_job.call_args_list
         )
         self.assertEqual(len(submitted_sample_ids), 1)
         self.assertIn(sample.scpca_id, submitted_sample_ids)
 
-    @patch("scpca_portal.management.commands.dispatch_to_batch.Command.submit_job")
-    def test_regenerate_all_files(self, mock_submit_job):
+    def test_regenerate_all_files(self):
         projects_with_files = [ProjectFactory() for _ in range(3)]
         for project_with_files in projects_with_files:
             self.assertTrue(project_with_files.computed_files.exists())
@@ -84,12 +95,10 @@ class TestDispatchToBatch(TestCase):
         projects = projects_with_files + projects_no_files
 
         self.dispatch_to_batch(regenerate_all=True)
-        mock_submit_job.assert_called()
+        self.mock_job_submit.assert_called()
 
         submitted_project_ids = set(
-            call.kwargs.get("project_id")
-            for call in mock_submit_job.call_args_list
-            if call.kwargs.get("project_id") is not None
+            call.kwargs.get("project_id") for call in self.mock_get_project_job.call_args_list
         )
         self.assertEqual(len(projects), len(submitted_project_ids))
         for project in projects:
@@ -97,14 +106,11 @@ class TestDispatchToBatch(TestCase):
 
         sample_no_files = projects[0].samples.first()
         submitted_sample_ids = set(
-            call.kwargs.get("sample_id")
-            for call in mock_submit_job.call_args_list
-            if call.kwargs.get("sample_id") is not None
+            call.kwargs.get("sample_id") for call in self.mock_get_sample_job.call_args_list
         )
         self.assertIn(sample_no_files.scpca_id, submitted_sample_ids)
 
-    @patch("scpca_portal.management.commands.dispatch_to_batch.Command.submit_job")
-    def test_regenerate_files_for_passed_project(self, mock_submit_job):
+    def test_regenerate_files_for_passed_project(self):
         project = ProjectFactory()
         self.assertTrue(project.computed_files.exists())
         adtl_projects = [ProjectFactory() for _ in range(3)]
@@ -112,12 +118,10 @@ class TestDispatchToBatch(TestCase):
             self.assertTrue(adtl_project.computed_files.exists())
 
         self.dispatch_to_batch(project_id=project.scpca_id, regenerate_all=True)
-        mock_submit_job.assert_called()
+        self.mock_job_submit.assert_called()
 
         submitted_project_ids = set(
-            call.kwargs.get("project_id")
-            for call in mock_submit_job.call_args_list
-            if call.kwargs.get("project_id") is not None
+            call.kwargs.get("project_id") for call in self.mock_get_project_job.call_args_list
         )
         self.assertEqual(len(submitted_project_ids), 1)
         self.assertIn(project.scpca_id, submitted_project_ids)
@@ -126,20 +130,17 @@ class TestDispatchToBatch(TestCase):
 
         sample = project.samples.first()
         submitted_sample_ids = set(
-            call.kwargs.get("sample_id")
-            for call in mock_submit_job.call_args_list
-            if call.kwargs.get("sample_id") is not None
+            call.kwargs.get("sample_id") for call in self.mock_get_sample_job.call_args_list
         )
         self.assertEqual(len(submitted_sample_ids), 1)
         self.assertIn(sample.scpca_id, submitted_sample_ids)
 
-    @patch("scpca_portal.management.commands.dispatch_to_batch.Command.submit_job")
-    def test_no_missing_computed_files(self, mock_submit_job):
+    def test_no_missing_computed_files(self):
         project = ProjectFactory()
         self.assertTrue(project.computed_files.exists())
 
         self.dispatch_to_batch()
-        mock_submit_job.assert_not_called()
+        self.mock_job_submit.assert_not_called()
 
     def test_project_missing_sample_computed_files(self):
         """

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from django.conf import settings
 from django.test import TestCase
 
 from scpca_portal.enums import JobStates
@@ -10,12 +11,20 @@ from scpca_portal.models import Job
 class TestJob(TestCase):
     def setUp(self):
         self.mock_job_id = "FAKE_JOB_ID"
-        self.resource_id = "FAKE_RESOURCE_ID"
-        self.batch_job_name = "FAKE_JOB_NAME"
-        self.batch_job_queue = "FAKE_JOB_QUEUE"
-        self.batch_job_definition = "FAKE_JOB_DEFINITION"
-        self.batch_container_overrides = {
-            "command": ["FAKE_COMMAND"],
+        self.project_id = "FAKE_PROJECT_ID"
+        self.download_config_name = "FAKE_DOWNLOAD_CONFIG"
+        self.batch_job_name = f"{self.project_id}-{self.download_config_name}"
+        self.project_job_batch_container_overrides = {
+            "command": [
+                "python",
+                "manage.py",
+                "generate_computed_file",
+                "--project-id",
+                self.project_id,
+                "--download-config-name",
+                self.download_config_name,
+                "",
+            ]
         }
 
     @patch("scpca_portal.models.Job._batch")
@@ -23,23 +32,20 @@ class TestJob(TestCase):
         # Set the mock return value of submit_job
         mock_batch_client.submit_job.return_value = {"jobId": self.mock_job_id}
 
-        job = Job.get_job(
-            batch_job_name=self.batch_job_name,
-            batch_job_queue=self.batch_job_queue,
-            batch_job_definition=self.batch_job_definition,
-            batch_container_overrides=self.batch_container_overrides,
+        job = Job.get_project_job(
+            project_id=self.project_id, download_config_name=self.download_config_name
         )
 
         # Before submission, the job instance should not have an ID
         self.assertIsNone(job.id)
 
-        job.submit(resource_id=self.resource_id)
+        job.submit()
 
         mock_batch_client.submit_job.assert_called_once_with(
             jobName=self.batch_job_name,
-            jobQueue=self.batch_job_queue,
-            jobDefinition=self.batch_job_definition,
-            containerOverrides=self.batch_container_overrides,
+            jobQueue=settings.AWS_BATCH_JOB_QUEUE_NAME,
+            jobDefinition=settings.AWS_BATCH_JOB_DEFINITION_NAME,
+            containerOverrides=self.project_job_batch_container_overrides,
         )
 
         # After submission, the job should be updated
@@ -51,9 +57,11 @@ class TestJob(TestCase):
         self.assertEqual(Job.objects.count(), 1)
         saved_job = Job.objects.first()
         self.assertEqual(saved_job.batch_job_name, self.batch_job_name)
-        self.assertEqual(saved_job.batch_job_queue, self.batch_job_queue)
-        self.assertEqual(saved_job.batch_job_definition, self.batch_job_definition)
-        self.assertEqual(saved_job.batch_container_overrides, self.batch_container_overrides)
-        self.assertIn(self.resource_id, saved_job.batch_container_overrides["command"])
+        self.assertEqual(saved_job.batch_job_queue, settings.AWS_BATCH_JOB_QUEUE_NAME)
+        self.assertEqual(saved_job.batch_job_definition, settings.AWS_BATCH_JOB_DEFINITION_NAME)
+        self.assertEqual(
+            saved_job.batch_container_overrides, self.project_job_batch_container_overrides
+        )
+        self.assertIn(self.project_id, saved_job.batch_container_overrides["command"])
         self.assertEqual(saved_job.state, JobStates.SUBMITTED)
         self.assertIsInstance(saved_job.submitted_at, datetime)

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from scpca_portal.enums import JobStates
+from scpca_portal.models import Job
+
+
+class TestJob(TestCase):
+    def setUp(self):
+        self.mock_job_id = "FAKE_JOB_ID"
+        self.resource_id = "FAKE_RESOURCE_ID"
+        self.batch_job_name = "FAKE_JOB_NAME"
+        self.batch_job_queue = "FAKE_JOB_QUEUE"
+        self.batch_job_definition = "FAKE_JOB_DEFINITION"
+        self.batch_container_overrides = {
+            "command": ["FAKE_COMMAND"],
+        }
+
+    @patch("scpca_portal.models.Job._batch")
+    def test_submit_job(self, mock_batch_client):
+        # Set the mock return value of submit_job
+        mock_batch_client.submit_job.return_value = {"jobId": self.mock_job_id}
+
+        job = Job.get_job(
+            batch_job_name=self.batch_job_name,
+            batch_job_queue=self.batch_job_queue,
+            batch_job_definition=self.batch_job_definition,
+            batch_container_overrides=self.batch_container_overrides,
+        )
+
+        # Before submission, the job instance should not have an ID
+        self.assertIsNone(job.id)
+
+        job.submit(resource_id=self.resource_id)
+
+        mock_batch_client.submit_job.assert_called_once_with(
+            jobName=self.batch_job_name,
+            jobQueue=self.batch_job_queue,
+            jobDefinition=self.batch_job_definition,
+            containerOverrides=self.batch_container_overrides,
+        )
+
+        # After submission, the job should be updated
+        self.assertEqual(job.batch_job_id, self.mock_job_id)
+        self.assertEqual(job.state, JobStates.SUBMITTED)
+        self.assertIsInstance(job.submitted_at, datetime)
+
+        # Make sure that the job is saved in the db with correct field values
+        self.assertEqual(Job.objects.count(), 1)
+        saved_job = Job.objects.first()
+        self.assertEqual(saved_job.batch_job_name, self.batch_job_name)
+        self.assertEqual(saved_job.batch_job_queue, self.batch_job_queue)
+        self.assertEqual(saved_job.batch_job_definition, self.batch_job_definition)
+        self.assertEqual(saved_job.batch_container_overrides, self.batch_container_overrides)
+        self.assertIn(self.resource_id, saved_job.batch_container_overrides["command"])
+        self.assertEqual(saved_job.state, JobStates.SUBMITTED)
+        self.assertIsInstance(saved_job.submitted_at, datetime)


### PR DESCRIPTION
## Issue Number

Closes #1117 
 
## Purpose/Implementation Notes

I've implemented the `Job::submit` method and added the corresponding test. 

Changes include: 
- Added a factory class method `get_job` 
- Included `django.utils.timezone.make_aware` in the test to prevent the the runtime warning below (matching the `sync_original_files` implementation)
  - `RuntimeWarning: DateTimeField Job.submitted_at received a naive datetime `

**NOTE:** I encountered an issue when attempting to mock `datetime.datetime.now`. As a workaround, I checked the instance type of `submitted_at` after the job submission. Please let me know your thoughts. Thank you, David!

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

`test_job::test_submit_job`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
