### PR TITLE
1145 - Implement Job::terminate using the existing Job model instance

### DIFF
--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -143,8 +143,8 @@ class Job(TimestampedModel):
     def terminate(self, retry_on_termination=False):
         """
         Terminate the submitted and incompleted job via boto3, and update state.
-        Throws an error if failed to terminate the job and,
-        set critical_error to True if the job is irrecoverable.
+        Throw an error if failed to terminate the job and,
+        set critical_error to True if the job is irrecoverable (e.g., server error).
         """
 
         if self.state in [JobStates.COMPLETED, JobStates.TERMINATED]:

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -134,7 +134,7 @@ class Job(TimestampedModel):
 
         self.save()
 
-    def terminate(self, retry_on_termination=False):
+    def terminate(self, retry_on_termination=False) -> bool:
         """
         Terminate the submitted and incompleted job via boto3, and update state.
         Return True if the job is successfully terminated or already terminated, otherwise False.

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.utils.timezone import make_aware
 
 import boto3
-from botocore.exceptions import ClientError
 
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.enums import JobStates
@@ -152,16 +151,10 @@ class Job(TimestampedModel):
             self.terminated_at = make_aware(datetime.now())
 
             self.save()
-        except ClientError as error:
-            logger.exception(
-                f"Failed to terminate the job due to a ClientException:\n\t{error}",
-                job_id=self.pk,
-                batch_job_id=self.batch_job_id,
-            )
-            return False
+
         except Exception as error:
             logger.exception(
-                f"Failed to terminate the job due to a ServerException:\n\t{error}",
+                f"Failed to terminate the job due to: \n\t{error}",
                 job_id=self.pk,
                 batch_job_id=self.batch_job_id,
             )

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -136,12 +136,12 @@ class Job(TimestampedModel):
 
     def terminate(self, retry_on_termination=False) -> bool:
         """
-        Terminate the submitted and incompleted job via boto3, and update state.
+        Terminate the submitted and incomplete job via boto3, and update state.
         Return True if the job is successfully terminated or already terminated, otherwise False.
         Throw an error if failed to terminate the job.
         """
 
-        if self.state == JobStates.COMPLETED or self.state == JobStates.TERMINATED:
+        if self.state in [JobStates.COMPLETED, JobStates.TERMINATED]:
             return self.state == JobStates.TERMINATED
 
         try:

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -211,29 +211,7 @@ class DatasetFactory(factory.django.DjangoModelFactory):
 class JobFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "scpca_portal.Job"
-        exclude = (
-            "project_id",
-            "sample_id",
-            "download_config_name",
-            "resource_flag",
-            "resource_id",
-        )
 
-    # Test-only fields (not part of the model)
-    project_id = None
-    sample_id = None
-    download_config_name = "MOCK_DOWNLOAD_CONFIG"
-    resource_flag = factory.LazyAttribute(
-        lambda obj: "--project-id" if obj.project_id else "--sample-id"
-    )
-    resource_id = factory.LazyAttribute(
-        lambda obj: obj.project_id if obj.project_id else obj.sample_id
-    )
-
-    # Required fields for creating a job (part of the model)
-    batch_job_name = factory.LazyAttribute(
-        lambda obj: f"{obj.project_id}-{obj.download_config_name}"
-    )
     batch_job_queue = settings.AWS_BATCH_JOB_QUEUE_NAME
     batch_job_definition = settings.AWS_BATCH_JOB_DEFINITION_NAME
     batch_container_overrides = factory.LazyAttribute(
@@ -242,11 +220,10 @@ class JobFactory(factory.django.DjangoModelFactory):
                 "python",
                 "manage.py",
                 "generate_computed_file",
-                obj.resource_flag,
-                obj.resource_id,
+                "--project-id" if "SCPCP" in obj.batch_job_name else "--sample-id",
+                "SCPCP000000" if "SCPCP" in obj.batch_job_name else "SCPCS000000",
                 "--download-config-name",
-                obj.download_config_name,
-                "",
+                "MOCK_DOWNLOAD_CONFIG",
             ]
         }
     )

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -2,6 +2,7 @@ from django.conf import settings
 
 import factory
 
+from scpca_portal import common
 from scpca_portal.enums import DatasetFormats, FileFormats, Modalities
 from scpca_portal.models import ComputedFile
 
@@ -220,10 +221,18 @@ class JobFactory(factory.django.DjangoModelFactory):
                 "python",
                 "manage.py",
                 "generate_computed_file",
-                "--project-id" if "SCPCP" in obj.batch_job_name else "--sample-id",
-                "SCPCP000000" if "SCPCP" in obj.batch_job_name else "SCPCS000000",
+                (
+                    "--project-id"
+                    if obj.batch_job_name.startswith(common.PROJECT_ID_PREFIX)
+                    else "--sample-id"
+                ),
+                (
+                    "SCPCP000000"
+                    if obj.batch_job_name.startswith(common.SAMPLE_ID_PREFIX)
+                    else "SCPCS000000"
+                ),
                 "--download-config-name",
-                "MOCK_DOWNLOAD_CONFIG",
+                "MOCK_DOWNLOAD_CONFIG_NAME",
             ]
         }
     )

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -228,7 +228,7 @@ class JobFactory(factory.django.DjangoModelFactory):
                 ),
                 (
                     "SCPCP000000"
-                    if obj.batch_job_name.startswith(common.SAMPLE_ID_PREFIX)
+                    if obj.batch_job_name.startswith(common.PROJECT_ID_PREFIX)
                     else "SCPCS000000"
                 ),
                 "--download-config-name",

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -4,64 +4,102 @@ from unittest.mock import patch
 from django.conf import settings
 from django.test import TestCase
 
+from botocore.exceptions import ClientError
+
 from scpca_portal.enums import JobStates
 from scpca_portal.models import Job
+from scpca_portal.test.factories import JobFactory
 
 
 class TestJob(TestCase):
     def setUp(self):
-        self.mock_job_id = "FAKE_JOB_ID"
-        self.project_id = "FAKE_PROJECT_ID"
-        self.download_config_name = "FAKE_DOWNLOAD_CONFIG"
-        self.batch_job_name = f"{self.project_id}-{self.download_config_name}"
-        self.project_job_batch_container_overrides = {
-            "command": [
-                "python",
-                "manage.py",
-                "generate_computed_file",
-                "--project-id",
-                self.project_id,
-                "--download-config-name",
-                self.download_config_name,
-                "",
-            ]
-        }
+        self.mock_project_id = "SCPCP000000"
+        self.mock_sample_id = "SCPCS000000"
+        self.mock_batch_job_id = "MOCK_JOB_ID"  # The job id via AWS Batch response
 
     @patch("scpca_portal.models.Job._batch")
     def test_submit_job(self, mock_batch_client):
-        # Set the mock return value of submit_job
-        mock_batch_client.submit_job.return_value = {"jobId": self.mock_job_id}
+        # Set up mock for submit_job
+        mock_batch_client.submit_job.return_value = {"jobId": self.mock_batch_job_id}
 
         job = Job.get_project_job(
-            project_id=self.project_id, download_config_name=self.download_config_name
+            project_id=self.mock_project_id, download_config_name="MOCK_DOWNLOAD_CONFIG"
         )
 
         # Before submission, the job instance should not have an ID
         self.assertIsNone(job.id)
 
         job.submit()
-
-        mock_batch_client.submit_job.assert_called_once_with(
-            jobName=self.batch_job_name,
-            jobQueue=settings.AWS_BATCH_JOB_QUEUE_NAME,
-            jobDefinition=settings.AWS_BATCH_JOB_DEFINITION_NAME,
-            containerOverrides=self.project_job_batch_container_overrides,
-        )
+        mock_batch_client.submit_job.assert_called_once()
 
         # After submission, the job should be updated
-        self.assertEqual(job.batch_job_id, self.mock_job_id)
+        self.assertEqual(job.batch_job_id, self.mock_batch_job_id)
         self.assertEqual(job.state, JobStates.SUBMITTED)
         self.assertIsInstance(job.submitted_at, datetime)
 
         # Make sure that the job is saved in the db with correct field values
         self.assertEqual(Job.objects.count(), 1)
         saved_job = Job.objects.first()
-        self.assertEqual(saved_job.batch_job_name, self.batch_job_name)
+        self.assertEqual(saved_job.batch_job_id, self.mock_batch_job_id)
         self.assertEqual(saved_job.batch_job_queue, settings.AWS_BATCH_JOB_QUEUE_NAME)
         self.assertEqual(saved_job.batch_job_definition, settings.AWS_BATCH_JOB_DEFINITION_NAME)
-        self.assertEqual(
-            saved_job.batch_container_overrides, self.project_job_batch_container_overrides
-        )
-        self.assertIn(self.project_id, saved_job.batch_container_overrides["command"])
+        self.assertIn("--project-id", saved_job.batch_container_overrides["command"])
+        self.assertIn(self.mock_project_id, saved_job.batch_container_overrides["command"])
         self.assertEqual(saved_job.state, JobStates.SUBMITTED)
         self.assertIsInstance(saved_job.submitted_at, datetime)
+
+    @patch("scpca_portal.models.Job._batch")
+    def test_terminate_job(self, mock_batch_client):
+        # Set up mock for terminate_job
+        mock_batch_client.terminate_job.return_value = True
+        job = JobFactory.create(
+            batch_job_id=self.mock_batch_job_id,
+            state=JobStates.SUBMITTED,
+            project_id=self.mock_project_id,  # Test-only
+        )
+
+        response = job.terminate(retry_on_termination=True)
+        mock_batch_client.terminate_job.assert_called_once()
+        self.assertTrue(response)
+
+        # After termination, the job should be saved with correct field values
+        saved_job = Job.objects.first()
+        self.assertEqual(saved_job.state, JobStates.TERMINATED)
+        self.assertTrue(saved_job.retry_on_termination)
+        self.assertIsInstance(saved_job.terminated_at, datetime)
+
+    @patch("scpca_portal.models.Job._batch")
+    def test_terminate_job_failure(self, mock_batch_client):
+        job = JobFactory.create(
+            batch_job_id=self.mock_batch_job_id,
+            state=JobStates.SUBMITTED,
+            project_id=self.mock_project_id,  # Test-only
+        )
+
+        # Set up mock for ClientException
+        mock_batch_client.terminate_job.side_effect = ClientError(
+            {"Error": {"Code": "400", "Message": "ClientException"}}, "MockTerminatingJob"
+        )
+
+        response = job.terminate(retry_on_termination=True)
+        mock_batch_client.terminate_job.assert_called()
+        self.assertFalse(response)
+
+        # The job should not be updated in the db
+        saved_job = Job.objects.first()
+        self.assertEqual(saved_job.state, JobStates.SUBMITTED)
+        self.assertFalse(saved_job.critical_error)  # Still recoverable
+        self.assertFalse(saved_job.retry_on_termination)
+
+        # Set up mock for ServerException
+        mock_batch_client.terminate_job.side_effect = Exception("ServerException")
+
+        response = job.terminate(retry_on_termination=True)
+        mock_batch_client.terminate_job.assert_called()
+        self.assertFalse(response)
+
+        # The job should be saved with correct field values
+        saved_job = Job.objects.first()
+        self.assertEqual(saved_job.state, JobStates.TERMINATED)
+        self.assertTrue(saved_job.critical_error)  # No longer recoverable
+        self.assertFalse(saved_job.retry_on_termination)

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -91,9 +91,9 @@ class TestJob(TestCase):
         # Set up mock to raise an exception
         mock_batch_client.terminate_job.side_effect = Exception("Exception")
 
-        failure = job.terminate(retry_on_termination=True)
+        success = job.terminate(retry_on_termination=True)
         mock_batch_client.terminate_job.assert_called()
-        self.assertFalse(failure)
+        self.assertFalse(success)
 
         # The job should not be updated
         saved_job = Job.objects.first()

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -12,7 +12,7 @@ from scpca_portal.test.factories import JobFactory
 class TestJob(TestCase):
     def setUp(self):
         self.mock_project_id = "SCPCP000000"
-        self.mock_download_config_name = "MOCK_DOWNLOAD_CONFIG"
+        self.mock_download_config_name = "MOCK_DOWNLOAD_CONFIG_NAME"
         self.mock_batch_job_id = "MOCK_JOB_ID"  # The job id via AWS Batch response
         self.mock_project_batch_job_name = (
             f"{self.mock_project_id}-{self.mock_download_config_name}"
@@ -62,13 +62,11 @@ class TestJob(TestCase):
         self.assertTrue(success)
 
         # After termination, the job should be saved with correct field values
-        saved_job = Job.objects.first()
+        saved_job = Job.objects.get(pk=submitted_job.pk)
         self.assertEqual(saved_job.state, JobStates.TERMINATED)
         self.assertTrue(saved_job.retry_on_termination)
         self.assertIsInstance(saved_job.terminated_at, datetime)
 
-    @patch("scpca_portal.models.Job._batch")
-    def test_terminate_job_on_terminated_job(self, mock_batch_client):
         terminated_job = JobFactory(
             batch_job_name=self.mock_project_batch_job_name,
             batch_job_id=self.mock_batch_job_id,
@@ -77,7 +75,7 @@ class TestJob(TestCase):
 
         # Should return True early for already TERMINATED jobs
         success = terminated_job.terminate(retry_on_termination=True)
-        mock_batch_client.terminate_job.assert_not_called()
+        self.assertEqual(mock_batch_client.terminate_job.call_count, 1)  # No subsequent call
         self.assertTrue(success)
 
     @patch("scpca_portal.models.Job._batch")
@@ -95,6 +93,6 @@ class TestJob(TestCase):
         mock_batch_client.terminate_job.assert_called_once()
         self.assertFalse(success)
 
-        # The job state should remain the same
-        saved_job = Job.objects.first()
+        saved_job = Job.objects.get(pk=job.pk)
+        # The job state should remain unchanged
         self.assertEqual(saved_job.state, job.state)

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -58,9 +58,9 @@ class TestJob(TestCase):
             state=JobStates.SUBMITTED,
         )
 
-        response = submitted_job.terminate(retry_on_termination=True)
+        success = submitted_job.terminate(retry_on_termination=True)
         mock_batch_client.terminate_job.assert_called()
-        self.assertTrue(response)
+        self.assertTrue(success)
 
         # After termination, the job should be saved with correct field values
         saved_job = Job.objects.first()
@@ -76,9 +76,9 @@ class TestJob(TestCase):
         )
 
         # Should return Ture for previously terminated job
-        response = terminated_job.terminate(retry_on_termination=True)
+        success = terminated_job.terminate(retry_on_termination=True)
         mock_batch_client.terminate_job.assert_called()
-        self.assertTrue(response)
+        self.assertTrue(success)
 
     @patch("scpca_portal.models.Job._batch")
     def test_terminate_job_failure(self, mock_batch_client):
@@ -91,9 +91,9 @@ class TestJob(TestCase):
         # Set up mock to raise an exception
         mock_batch_client.terminate_job.side_effect = Exception("Exception")
 
-        response = job.terminate(retry_on_termination=True)
+        failure = job.terminate(retry_on_termination=True)
         mock_batch_client.terminate_job.assert_called()
-        self.assertFalse(response)
+        self.assertFalse(failure)
 
         # The job should not be updated
         saved_job = Job.objects.first()


### PR DESCRIPTION
## Issue Number

Close #1145

## Purpose/Implementation Notes

I've implement  the `Job::terminate` method and added the corresponding test using mocks. 

Additionally, I've added the `JobFactory` class and incorporated it in the `TestJob`, as well as cleaned up the no longer used attributes in the `JobTest::setUp` method.

## Types of changes

What types of changes does your code introduce?

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

- `TestJob::test_terminate_job`
- `TestJob::test_terminate_job_failure`
- `JobFactory`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
