### PR TITLE
1146 - Implement Job::sync_state and Job::bulk_sync_state methods using the existing Job model instance

### DIFF
--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -130,9 +130,7 @@ class Job(TimestampedModel):
         If the remote status is 'FAILED', update failure_reason if it hasn't been set already.
         """
         if submitted_jobs := cls.objects.filter(state=JobStates.SUBMITTED.name):
-            batch_job_ids = [job.batch_job_id for job in submitted_jobs]
-
-            if fetched_jobs := batch.get_jobs(batch_job_ids):
+            if fetched_jobs := batch.get_jobs(submitted_jobs):
                 # Map the fetched AWS jobs for easy lookup by batch_job_id
                 aws_jobs = {job["jobId"]: job for job in fetched_jobs}
 
@@ -203,7 +201,7 @@ class Job(TimestampedModel):
         if self.state is not JobStates.SUBMITTED.name:
             return False
 
-        if fetched_jobs := batch.get_jobs([self.batch_job_id]):
+        if fetched_jobs := batch.get_jobs([self]):
             aws_job = fetched_jobs[0]
             aws_job_status = aws_job["status"]
             is_terminated = aws_job.get("isCancelled") or aws_job.get("isTerminated")

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -126,7 +126,7 @@ class Job(TimestampedModel):
     def bulk_sync_state(cls) -> bool:
         """
         Sync all submitted job instances' states with AWS Batch job statuses.
-        Call batch.get_job_status to fetch all the corresponding remote jobs.
+        Call batch.get_jobs to fetch all the corresponding remote jobs.
         Update each job instance's state if it changes to COMPLETED, and update completed_at.
         If the remote status is 'FAILED', update failure_reason if it hasn't been set already.
         """

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -53,14 +53,14 @@ class Job(TimestampedModel):
         If FAILED with is_terminated True, return TERMINATED.
         """
         state_mapping = {
-            "SUCCEEDED": JobStates.COMPLETED,
-            "FAILED": JobStates.COMPLETED,
+            "SUCCEEDED": JobStates.COMPLETED.name,
+            "FAILED": JobStates.COMPLETED.name,
         }
 
         if is_terminated:
-            return JobStates.TERMINATED
+            return JobStates.TERMINATED.name
 
-        return state_mapping.get(batch_job_status, JobStates.SUBMITTED)
+        return state_mapping.get(batch_job_status, JobStates.SUBMITTED.name)
 
     @classmethod
     def get_project_job(cls, project_id: str, download_config_name: str, notify: bool = False):
@@ -129,7 +129,7 @@ class Job(TimestampedModel):
         Update each job instance's state if it changes to COMPLETED, and update completed_at.
         If the remote status is 'FAILED', update failure_reason if it hasn't been set already.
         """
-        if submitted_jobs := cls.objects.filter(state=JobStates.SUBMITTED):
+        if submitted_jobs := cls.objects.filter(state=JobStates.SUBMITTED.name):
             batch_job_ids = [job.batch_job_id for job in submitted_jobs]
 
             if fetched_jobs := batch.get_jobs(batch_job_ids):
@@ -200,7 +200,7 @@ class Job(TimestampedModel):
         Update instance state if it changes to COMPLETED, and update completed_at.
         If the remote status is 'FAILED', update failure_reason if it hasn't been set already.
         """
-        if self.state is not JobStates.SUBMITTED:
+        if self.state is not JobStates.SUBMITTED.name:
             return False
 
         if fetched_jobs := batch.get_jobs([self.batch_job_id]):

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -53,14 +53,14 @@ class Job(TimestampedModel):
         If FAILED with is_terminated True, return TERMINATED.
         """
         state_mapping = {
-            "SUCCEEDED": JobStates.COMPLETED.name,
-            "FAILED": JobStates.COMPLETED.name,
+            "SUCCEEDED": JobStates.COMPLETED.value,
+            "FAILED": JobStates.COMPLETED.value,
         }
 
         if is_terminated:
-            return JobStates.TERMINATED.name
+            return JobStates.TERMINATED.value
 
-        return state_mapping.get(batch_job_status, JobStates.SUBMITTED.name)
+        return state_mapping.get(batch_job_status, JobStates.SUBMITTED.value)
 
     @classmethod
     def get_project_job(cls, project_id: str, download_config_name: str, notify: bool = False):
@@ -124,12 +124,11 @@ class Job(TimestampedModel):
     @classmethod
     def bulk_sync_state(cls) -> bool:
         """
-        Sync all submitted job instances' states with AWS Batch job statuses.
-        Call batch.get_jobs to fetch all the corresponding remote jobs.
+        Sync all submitted job instances' states with the remote AWS Batch job statuses.
         Update each job instance's state if it changes to COMPLETED, and update completed_at.
         If the remote status is 'FAILED', update failure_reason if it hasn't been set already.
         """
-        if submitted_jobs := cls.objects.filter(state=JobStates.SUBMITTED.name):
+        if submitted_jobs := cls.objects.filter(state=JobStates.SUBMITTED.value):
             if fetched_jobs := batch.get_jobs(submitted_jobs):
                 # Map the fetched AWS jobs for easy lookup by batch_job_id
                 aws_jobs = {job["jobId"]: job for job in fetched_jobs}
@@ -198,7 +197,7 @@ class Job(TimestampedModel):
         Update instance state if it changes to COMPLETED, and update completed_at.
         If the remote status is 'FAILED', update failure_reason if it hasn't been set already.
         """
-        if self.state is not JobStates.SUBMITTED.name:
+        if self.state is not JobStates.SUBMITTED.value:
             return False
 
         if fetched_jobs := batch.get_jobs([self]):

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -48,7 +48,7 @@ class Job(TimestampedModel):
         return f"Job {self.id} - {self.state}"
 
     @staticmethod
-    def update_job_state(job, aws_job) -> tuple[Self, bool]:
+    def update_job_state(job: Self, aws_job: dict) -> tuple[Self, bool]:
         """
         Map the AWS Batch job status to the corresponding instance job state.
         Update the instance state and timestamps if the state changes.

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -192,8 +192,7 @@ class Job(TimestampedModel):
 
     def sync_state(self) -> bool:
         """
-        Sync the submitted job state with the AWS Batch job status.
-        Call batch.get_jobs to fetch the corresponding remote job.
+        Sync the submitted job state with the remote AWS Batch job status.
         Update instance state if it changes to COMPLETED, and update completed_at.
         If the remote status is 'FAILED', update failure_reason if it hasn't been set already.
         """

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -213,6 +213,8 @@ class JobFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "scpca_portal.Job"
 
+    batch_job_id = factory.Sequence(lambda n: f"MOCK_JOB_ID_{str(n).zfill(3)}")
+    batch_job_name = "SCPCP000000-MOCK_DOWNLOAD_CONFIG_NAME"
     batch_job_queue = settings.AWS_BATCH_JOB_QUEUE_NAME
     batch_job_definition = settings.AWS_BATCH_JOB_DEFINITION_NAME
     batch_container_overrides = factory.LazyAttribute(
@@ -236,33 +238,3 @@ class JobFactory(factory.django.DjangoModelFactory):
             ]
         }
     )
-
-    @classmethod
-    def get_mock_jobs(cls, list_of_jobs=None, num_unsaved_jobs=False):
-        """Helper to create job instances using JobFactory
-        If list_of_jobs, generate saved jobs for the given list.
-        If num_unsaved_jobs, generate the spefified number of unsaved jobs.
-        """
-        mock_batch_job_name = "MOCK_BATCH_JOB_NAME"
-
-        if num_unsaved_jobs:
-            return [cls.build(batch_job_name=mock_batch_job_name) for _ in range(num_unsaved_jobs)]
-        else:
-            return [cls(batch_job_name=mock_batch_job_name, **job) for job in list_of_jobs]
-
-    @classmethod
-    def get_mock_aws_batch_jobs(self, list_of_jobs, terminated_job=None):
-        """Helper to generate AWS Batch jobs for mocked method return value."""
-
-        if terminated_job:
-            list_of_jobs.append(terminated_job)
-
-        return [
-            {
-                "jobId": job["jobId"],
-                "status": job["status"],
-                "statusReason": f"Job {job['status']}",
-                "isTerminated": terminated_job and job["jobId"] == terminated_job["jobId"],
-            }
-            for job in list_of_jobs
-        ]

--- a/api/scpca_portal/test/factories.py
+++ b/api/scpca_portal/test/factories.py
@@ -236,3 +236,33 @@ class JobFactory(factory.django.DjangoModelFactory):
             ]
         }
     )
+
+    @classmethod
+    def get_mock_jobs(cls, list_of_jobs=None, num_unsaved_jobs=False):
+        """Helper to create job instances using JobFactory
+        If list_of_jobs, generate saved jobs for the given list.
+        If num_unsaved_jobs, generate the spefified number of unsaved jobs.
+        """
+        mock_batch_job_name = "MOCK_BATCH_JOB_NAME"
+
+        if num_unsaved_jobs:
+            return [cls.build(batch_job_name=mock_batch_job_name) for _ in range(num_unsaved_jobs)]
+        else:
+            return [cls(batch_job_name=mock_batch_job_name, **job) for job in list_of_jobs]
+
+    @classmethod
+    def get_mock_aws_batch_jobs(self, list_of_jobs, terminated_job=None):
+        """Helper to generate AWS Batch jobs for mocked method return value."""
+
+        if terminated_job:
+            list_of_jobs.append(terminated_job)
+
+        return [
+            {
+                "jobId": job["jobId"],
+                "status": job["status"],
+                "statusReason": f"Job {job['status']}",
+                "isTerminated": terminated_job and job["jobId"] == terminated_job["jobId"],
+            }
+            for job in list_of_jobs
+        ]

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -158,7 +158,7 @@ class TestJob(TestCase):
 
     @patch("scpca_portal.batch.get_jobs")
     def test_bulk_sync_state(self, mock_batch_get_jobs):
-        # Set up mock for get_jobs with all AWS Batch job statues
+        # Set up mock for get_jobs with all AWS Batch job statuses
         mock_batch_get_jobs.return_value = self.bulk_create_mock_aws_batch_jobs(
             [
                 {"jobId": f"{self.mock_batch_job_id}-{i}", "status": status}
@@ -182,7 +182,7 @@ class TestJob(TestCase):
         # Job with state change should be updated and saved with correct field values
         for saved_job in Job.objects.all():
             if saved_job.state != JobStates.SUBMITTED:
-                # Job state should be updated to COMPLETED
+                # Job state should be COMPLETED
                 self.assertEqual(saved_job.state, JobStates.COMPLETED)
                 self.assertIn(saved_job.failure_reason, [None, "Job FAILED"])
                 self.assertIsInstance(saved_job.completed_at, datetime)

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -18,6 +18,35 @@ class TestJob(TestCase):
             f"{self.mock_project_id}-{self.mock_download_config_name}"
         )
         self.mock_dataset = DatasetFactory()
+        self.aws_batch_job_status = [  # AWS Batch job statuses
+            "SUBMITTED",
+            "PENDING",
+            "RUNNABLE",
+            "STARTING",
+            "RUNNING",
+            "SUCCEEDED",
+            "FAILED",
+        ]
+
+    def bulk_create_mock_jobs(self, list_of_jobs):
+        """Helper to create job instances using JobFactory."""
+        for job in list_of_jobs:
+            JobFactory(
+                batch_job_name=self.mock_project_batch_job_name,
+                batch_job_id=job["batch_job_id"],
+                state=job["state"],
+            )
+
+    def bulk_create_mock_aws_batch_jobs(self, list_of_jobs):
+        """Helper to generate AWS Batch jobs for mocked method return value."""
+        return [
+            {
+                "jobId": job["jobId"],
+                "status": job["status"],
+                "statusReason": f"Job {job['status']}",
+            }
+            for job in list_of_jobs
+        ]
 
     @patch("scpca_portal.batch.submit_job")
     def test_submit_job(self, mock_batch_submit_job):
@@ -65,6 +94,129 @@ class TestJob(TestCase):
         # The job state should remain default and unsaved
         self.assertEqual(Job.objects.count(), 0)
         self.assertEqual(job.state, JobStates.CREATED)
+
+    @patch("scpca_portal.batch.get_job")
+    def test_sync_state(self, mock_batch_get_job):
+        # Job state is not SUBMITTED
+        completed_job = JobFactory(
+            batch_job_name=self.mock_project_batch_job_name,
+            batch_job_id=self.mock_batch_job_id,
+            state=JobStates.COMPLETED,
+        )
+
+        # Should return False early without calling get_job
+        success = completed_job.sync_state()
+        mock_batch_get_job.assert_not_called()
+        self.assertFalse(success)
+
+        # Job is in SUBMITTED state
+        submitted_job = JobFactory(
+            batch_job_name=self.mock_project_batch_job_name,
+            batch_job_id=self.mock_batch_job_id,
+            state=JobStates.SUBMITTED,
+        )
+
+        # Set up mock for failed get_job call
+        mock_batch_get_job.return_value = False
+
+        success = submitted_job.sync_state()
+        mock_batch_get_job.assert_called()
+        self.assertFalse(success)
+
+        # The job should remain unchanged and unsaved
+        saved_job = Job.objects.get(pk=submitted_job.pk)
+        self.assertEqual(saved_job, submitted_job)
+
+        # Set up mock for get_job for RUNNING (with no state change)
+        mock_batch_get_job.return_value = {
+            "status": "RUNNING",
+            "statusReason": "Job RUNNING",
+        }
+
+        success = submitted_job.sync_state()
+        mock_batch_get_job.assert_called()
+        self.assertTrue(success)
+
+        # The job should remain unchanged and unsaved
+        saved_job = Job.objects.get(pk=submitted_job.pk)
+        self.assertEqual(saved_job, submitted_job)
+
+        # Set up mock for get_job with FAILED (with state change)
+        mock_batch_get_job.return_value = {
+            "status": "FAILED",
+            "statusReason": "Job FAILED",
+        }
+
+        success = submitted_job.sync_state()
+        mock_batch_get_job.assert_called()
+        self.assertTrue(success)
+
+        # Job should be updated and saved with correct field values
+        saved_job = Job.objects.get(pk=submitted_job.pk)
+        self.assertEqual(saved_job.state, JobStates.COMPLETED)
+        self.assertEqual(saved_job.failure_reason, mock_batch_get_job.return_value["statusReason"])
+
+    @patch("scpca_portal.batch.get_jobs")
+    def test_bulk_sync_state(self, mock_batch_get_jobs):
+        # Set up mock for get_jobs with all AWS Batch job statues
+        mock_batch_get_jobs.return_value = self.bulk_create_mock_aws_batch_jobs(
+            [
+                {"jobId": f"{self.mock_batch_job_id}-{i}", "status": status}
+                for i, status in enumerate(
+                    self.aws_batch_job_status,
+                )
+            ]
+        )
+        # Jobs with SUBMITTED state
+        self.bulk_create_mock_jobs(
+            [
+                {"batch_job_id": f"{self.mock_batch_job_id}-{i}", "state": JobStates.SUBMITTED}
+                for i in range(0, 7)
+            ]
+        )
+
+        success = Job.bulk_sync_state()
+        mock_batch_get_jobs.assert_called_once()
+        self.assertTrue(success)
+
+        # Job with state change should be updated and saved with correct field values
+        for saved_job in Job.objects.all():
+            if saved_job.state != JobStates.SUBMITTED:
+                # Job state should be updated to COMPLETED
+                self.assertEqual(saved_job.state, JobStates.COMPLETED)
+                self.assertIn(saved_job.failure_reason, [None, "Job FAILED"])
+                self.assertIsInstance(saved_job.completed_at, datetime)
+            else:
+                self.assertEqual(saved_job.state, JobStates.SUBMITTED)
+                self.assertIsNone(saved_job.failure_reason)
+                self.assertIsNone(saved_job.completed_at)
+
+    @patch("scpca_portal.batch.get_jobs")
+    def test_bulk_sync_state_no_matching_batch_job_found(self, mock_batch_get_jobs):
+        # Set up mock for get_jobs with no matched AWS job found
+        mock_batch_get_jobs.return_value = self.bulk_create_mock_aws_batch_jobs(
+            [
+                {"jobId": f"{self.mock_batch_job_id}-{i}", "status": status}
+                for i, status in enumerate(["PENDING", "FAILED"])
+            ]
+        )
+        self.bulk_create_mock_jobs(
+            [
+                {"batch_job_id": f"{self.mock_batch_job_id}-{i}", "state": JobStates.SUBMITTED}
+                for i in range(1, 4)
+            ]
+        )
+
+        # A missing batch job should not interrupt the remaining jobs
+        success = Job.bulk_sync_state()
+        mock_batch_get_jobs.assert_called()
+        self.assertTrue(success)
+
+        # Job with state change should be updated and saved with correct field values
+        saved_job = Job.objects.filter(batch_job_id=f"{self.mock_batch_job_id}-{1}").first()
+        self.assertEqual(saved_job.state, JobStates.COMPLETED)
+        self.assertEqual(saved_job.failure_reason, "Job FAILED")
+        self.assertIsInstance(saved_job.completed_at, datetime)
 
     @patch("scpca_portal.batch.terminate_job")
     def test_terminate_job(self, mock_batch_terminate_job):

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -106,7 +106,7 @@ class TestJob(TestCase):
         completed_job = JobFactory(
             batch_job_name=self.mock_project_batch_job_name,
             batch_job_id=self.mock_batch_job_id,
-            state=JobStates.COMPLETED,
+            state=JobStates.COMPLETED.name,
         )
 
         # Should return False early without calling get_jobs
@@ -118,7 +118,7 @@ class TestJob(TestCase):
         submitted_job = JobFactory(
             batch_job_name=self.mock_project_batch_job_name,
             batch_job_id=self.mock_batch_job_id,
-            state=JobStates.SUBMITTED,
+            state=JobStates.SUBMITTED.name,
         )
 
         # Set up mock for failed get_jobs call
@@ -163,12 +163,12 @@ class TestJob(TestCase):
 
         # Job should be updated and saved with correct field values
         saved_job = Job.objects.get(pk=submitted_job.pk)
-        self.assertEqual(saved_job.state, JobStates.TERMINATED)
+        self.assertEqual(saved_job.state, JobStates.TERMINATED.name)
         self.assertIsInstance(saved_job.terminated_at, datetime)
         self.assertIsNone(saved_job.failure_reason)
 
         # Set up mock for get_jobs with FAILED
-        submitted_job.state = JobStates.SUBMITTED
+        submitted_job.state = JobStates.SUBMITTED.name
         mock_batch_get_jobs.return_value = [
             {
                 "status": "FAILED",
@@ -182,7 +182,7 @@ class TestJob(TestCase):
 
         # Job should be updated and saved with correct field values
         saved_job = Job.objects.get(pk=submitted_job.pk)
-        self.assertEqual(saved_job.state, JobStates.COMPLETED)
+        self.assertEqual(saved_job.state, JobStates.COMPLETED.name)
         self.assertEqual(saved_job.failure_reason, "Job FAILED")
         self.assertIsInstance(saved_job.completed_at, datetime)
 
@@ -200,7 +200,7 @@ class TestJob(TestCase):
         )
         self.bulk_create_mock_jobs(
             [
-                {"batch_job_id": f"{self.mock_batch_job_id}-{i}", "state": JobStates.SUBMITTED}
+                {"batch_job_id": f"{self.mock_batch_job_id}-{i}", "state": JobStates.SUBMITTED.name}
                 for i in range(0, 8)
             ]
         )
@@ -211,15 +211,15 @@ class TestJob(TestCase):
 
         # Job with state change should be updated and saved with correct field values
         for saved_job in Job.objects.all():
-            if saved_job.state == JobStates.TERMINATED:
+            if saved_job.state == JobStates.TERMINATED.name:
                 self.assertIsNone(saved_job.failure_reason)
                 self.assertIsInstance(saved_job.terminated_at, datetime)
-            elif saved_job.state == JobStates.COMPLETED:
-                self.assertEqual(saved_job.state, JobStates.COMPLETED)
+            elif saved_job.state == JobStates.COMPLETED.name:
+                self.assertEqual(saved_job.state, JobStates.COMPLETED.name)
                 self.assertIn(saved_job.failure_reason, [None, "Job FAILED"])
                 self.assertIsInstance(saved_job.completed_at, datetime)
             else:
-                self.assertEqual(saved_job.state, JobStates.SUBMITTED)
+                self.assertEqual(saved_job.state, JobStates.SUBMITTED.name)
                 self.assertIsNone(saved_job.failure_reason)
                 self.assertIsNone(saved_job.completed_at)
                 self.assertIsNone(saved_job.terminated_at)
@@ -235,7 +235,7 @@ class TestJob(TestCase):
         )
         self.bulk_create_mock_jobs(
             [
-                {"batch_job_id": f"{self.mock_batch_job_id}-{i}", "state": JobStates.SUBMITTED}
+                {"batch_job_id": f"{self.mock_batch_job_id}-{i}", "state": JobStates.SUBMITTED.name}
                 for i in range(1, 4)
             ]
         )
@@ -247,7 +247,7 @@ class TestJob(TestCase):
 
         # Job with state change should be updated and saved with correct field values
         saved_job = Job.objects.filter(batch_job_id=f"{self.mock_batch_job_id}-{1}").first()
-        self.assertEqual(saved_job.state, JobStates.COMPLETED)
+        self.assertEqual(saved_job.state, JobStates.COMPLETED.name)
         self.assertEqual(saved_job.failure_reason, "Job FAILED")
         self.assertIsInstance(saved_job.completed_at, datetime)
 

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -97,7 +97,7 @@ class TestJob(TestCase):
 
         success = submitted_job.sync_state()
         mock_batch_get_jobs.assert_called()
-        self.assertTrue(success)  # Synced but no update in the db
+        self.assertFalse(success)  # Synced but no update in the db
 
         # The job should remain unchanged and unsaved
         saved_job = Job.objects.get(pk=submitted_job.pk)

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -215,7 +215,6 @@ class TestJob(TestCase):
                 self.assertIsNone(saved_job.failure_reason)
                 self.assertIsInstance(saved_job.terminated_at, datetime)
             elif saved_job.state == JobStates.COMPLETED:
-                # Job state should be COMPLETED
                 self.assertEqual(saved_job.state, JobStates.COMPLETED)
                 self.assertIn(saved_job.failure_reason, [None, "Job FAILED"])
                 self.assertIsInstance(saved_job.completed_at, datetime)

--- a/api/scpca_portal/utils/helpers.py
+++ b/api/scpca_portal/utils/helpers.py
@@ -4,7 +4,7 @@ import inspect
 from collections import namedtuple
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Set, Tuple
+from typing import Any, Callable, Dict, Generator, Iterable, List, Set, Tuple
 
 from scpca_portal import common
 from scpca_portal.config.logging import get_and_configure_logger
@@ -40,6 +40,14 @@ def join_workflow_versions(workflow_versions: Set) -> str:
     """Returns list of sorted unique workflow versions."""
 
     return ", ".join(sorted(set(workflow_versions)))
+
+
+def get_chunk_list(list: List[Any], size: int) -> Generator[List[Any], None, None]:
+    """
+    Yields chunks of the given list with the specified size.
+    """
+    for i in range(0, len(list), size):
+        yield list[i : i + size]
 
 
 def get_today_string(format: str = "%Y-%m-%d") -> str:


### PR DESCRIPTION
## Issue Number

Closes #1146

## Purpose/Implementation Notes

I've implemented the `Job::sync_state` instance method and `Job::bulk_sync_state` class method, and added the corresponding tests.

Other changes include:
- Added the `get_jobs` method to the `batch` module.
- Added `utils.get_chunk_list` for `boto3.describe_jobs` job ID size limit per request (I've used the solution from [Stack overflow: Split a list into equally-sized chunks](https://stackoverflow.com/a/312464), as using generators seems to be a commonly used approach. Please let me know if you have any other suggestions!)
- Defined `batch_job_id` using `factory.Sequence` and the default `batch_job_name` in `JobFactory`, and cleaned up `setUp` and no longer required arguments in `TestJob`

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

- `TestJob::test_sync_state`
- `TestJob::test_bulk_sync_state`
- `TestJob::test_bulk_sync_state_no_matching_batch_job_found`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
