### PR TITLE
1108 - Dataset OriginalFile Query

### DIFF
--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -164,19 +164,19 @@ class Dataset(TimestampedModel):
                 sample_ids__overlap=project_config["SINGLE_CELL"],
             )
 
-            single_cell = OriginalFile.downloadable_objects.filter(
-                project_id=project_id,
-                is_single_cell=True,
-                formats__contains=[self.format],
-            )
-
             if project_config["merge_single_cell"]:
-                files |= single_cell.filter(is_merged=True)
-            else:
-                files |= single_cell.filter(
-                    is_merged=False, sample_ids__overlap=project_config["SINGLE_CELL"]
+                merged_files = OriginalFile.downloadable_objects.filter(
+                    project_id=project_id, is_merged=True
                 )
-
+                files |= merged_files.filter(formats__contains=[self.format])
+                files |= merged_files.filter(is_supplementary=True)
+            else:
+                files |= OriginalFile.downloadable_objects.filter(
+                    project_id=project_id,
+                    is_single_cell=True,
+                    formats__contains=[self.format],
+                    sample_ids__overlap=project_config["SINGLE_CELL"],
+                )
             if project_config["includes_bulk"]:
                 files |= OriginalFile.downloadable_objects.filter(
                     project_id=project_id, is_bulk=True

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -1,9 +1,11 @@
+from pathlib import Path
+
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase, tag
 
 from scpca_portal import loader
-from scpca_portal.enums import Modalities
+from scpca_portal.enums import DatasetFormats, Modalities
 from scpca_portal.models import Dataset
 from scpca_portal.test import expected_values as test_data
 from scpca_portal.test.factories import DatasetFactory
@@ -276,3 +278,29 @@ class TestDataset(TestCase):
             ccdl_project_dataset.CCDL_NAME, ccdl_project_dataset.PROJECT_ID
         )
         self.assertTrue(found)
+
+    def test_original_files_property(self):
+        # SINGLE_CELL SCE
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999997"],
+                Modalities.SPATIAL: [],
+            },
+        }
+        format = DatasetFormats.SINGLE_CELL_EXPERIMENT
+        dataset = Dataset(data=data, format=format)
+        expected_files = {
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_celltype-report.html"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_filtered.rds"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_qc.html"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_processed.rds"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_unfiltered.rds"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_celltype-report.html"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_qc.html"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_unfiltered.rds"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_filtered.rds"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_processed.rds"),
+        }
+        self.assertEqual(dataset.original_file_paths, expected_files)

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -304,3 +304,173 @@ class TestDataset(TestCase):
             Path("SCPCP999990/SCPCS999997/SCPCL999997_processed.rds"),
         }
         self.assertEqual(dataset.original_file_paths, expected_files)
+
+        # SINGLE_CELL ANN_DATA
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999997"],
+                Modalities.SPATIAL: [],
+            },
+        }
+        format = DatasetFormats.ANN_DATA
+        dataset = Dataset(data=data, format=format)
+        expected_files = {
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_celltype-report.html"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_qc.html"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_processed_rna.h5ad"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_unfiltered_rna.h5ad"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_filtered_rna.h5ad"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_celltype-report.html"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_processed_rna.h5ad"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_filtered_rna.h5ad"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_unfiltered_rna.h5ad"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_qc.html"),
+        }
+        self.assertEqual(dataset.original_file_paths, expected_files)
+
+        # SINGLE_CELL SCE MERGED
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": True,
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999997"],
+                Modalities.SPATIAL: [],
+            },
+        }
+        format = DatasetFormats.SINGLE_CELL_EXPERIMENT
+        dataset = Dataset(data=data, format=format)
+        expected_files = {
+            Path("SCPCP999990/merged/SCPCP999990_merged.rds"),
+            Path("SCPCP999990/merged/SCPCP999990_merged-summary-report.html"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_celltype-report.html"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_qc.html"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_celltype-report.html"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_qc.html"),
+        }
+        self.assertEqual(dataset.original_file_paths, expected_files)
+
+        # SINGLE_CELL ANN_DATA MERGED
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": True,
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999997"],
+                Modalities.SPATIAL: [],
+            },
+        }
+        format = DatasetFormats.ANN_DATA
+        dataset = Dataset(data=data, format=format)
+        expected_files = {
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_qc.html"),
+            Path("SCPCP999990/SCPCS999997/SCPCL999997_celltype-report.html"),
+            Path("SCPCP999990/merged/SCPCP999990_merged-summary-report.html"),
+            Path("SCPCP999990/merged/SCPCP999990_merged_rna.h5ad"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_qc.html"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_celltype-report.html"),
+        }
+        self.assertEqual(dataset.original_file_paths, expected_files)
+        # SPATIAL SCE
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: [],
+                Modalities.SPATIAL: ["SCPCS999991"],
+            },
+        }
+        format = DatasetFormats.SINGLE_CELL_EXPERIMENT
+        dataset = Dataset(data=data, format=format)
+        expected_files = {
+            Path(
+                "SCPCP999990/SCPCS999991/SCPCL999991_spatial/raw_feature_bc_matrix/barcodes.tsv.gz"
+            ),
+            Path("SCPCP999990/SCPCS999991/SCPCL999991_spatial/spatial/scalefactors_json.json"),
+            Path("SCPCP999990/SCPCS999991/SCPCL999991_spatial/spatial/tissue_positions_list.csv"),
+            Path(
+                "SCPCP999990/SCPCS999991/SCPCL999991_spatial/filtered_feature_bc_matrix/matrix.mtx.gz"  # noqa
+            ),
+            Path("SCPCP999990/SCPCS999991/SCPCL999991_spatial/raw_feature_bc_matrix/matrix.mtx.gz"),
+            Path(
+                "SCPCP999990/SCPCS999991/SCPCL999991_spatial/filtered_feature_bc_matrix/features.tsv.gz"  # noqa
+            ),
+            Path("SCPCP999990/SCPCS999991/SCPCL999991_spatial/SCPCL999991_metadata.json"),
+            Path(
+                "SCPCP999990/SCPCS999991/SCPCL999991_spatial/raw_feature_bc_matrix/features.tsv.gz"
+            ),
+            Path("SCPCP999990/SCPCS999991/SCPCL999991_spatial/spatial/tissue_hires_image.png"),
+            Path("SCPCP999990/SCPCS999991/SCPCL999991_spatial/spatial/tissue_lowres_image.png"),
+            Path("SCPCP999990/SCPCS999991/SCPCL999991_spatial/spatial/aligned_fiducials.jpg"),
+            Path(
+                "SCPCP999990/SCPCS999991/SCPCL999991_spatial/filtered_feature_bc_matrix/barcodes.tsv.gz"  # noqa
+            ),
+            Path(
+                "SCPCP999990/SCPCS999991/SCPCL999991_spatial/SCPCL999991_spaceranger-summary.html"
+            ),
+            Path("SCPCP999990/SCPCS999991/SCPCL999991_spatial/spatial/detected_tissue_image.jpg"),
+        }
+        self.assertEqual(dataset.original_file_paths, expected_files)
+
+        # BULK
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: [],
+                Modalities.SPATIAL: [],
+            },
+        }
+        format = DatasetFormats.SINGLE_CELL_EXPERIMENT
+        dataset = Dataset(data=data, format=format)
+        expected_files = {
+            Path("SCPCP999990/bulk/SCPCP999990_bulk_metadata.tsv"),
+            Path("SCPCP999990/bulk/SCPCP999990_bulk_quant.tsv"),
+        }
+        self.assertEqual(dataset.original_file_paths, expected_files)
+
+        # MIXED USAGE
+        data = {
+            "SCPCP999990": {
+                "merge_single_cell": False,
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: ["SCPCS999990", "SCPCS999991"],
+                Modalities.SPATIAL: ["SCPCS999997"],
+            },
+            "SCPCP999991": {
+                "merge_single_cell": False,
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: ["SCPCS999992", "SCPCS999993", "SCPCS999995"],
+                Modalities.SPATIAL: [],
+            },
+            "SCPCP999992": {
+                "merge_single_cell": True,
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: ["SCPCS999992", "SCPCS999993", "SCPCS999995"],
+                Modalities.SPATIAL: [],
+            },
+        }
+        format = DatasetFormats.SINGLE_CELL_EXPERIMENT
+        dataset = Dataset(data=data, format=format)
+        expected_files = {
+            Path("SCPCP999990/bulk/SCPCP999990_bulk_metadata.tsv"),
+            Path("SCPCP999991/SCPCS999992,SCPCS999993/SCPCL999992_filtered.rds"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_filtered.rds"),
+            Path("SCPCP999991/SCPCS999992,SCPCS999993/SCPCL999992_processed.rds"),
+            Path("SCPCP999991/SCPCS999992,SCPCS999993/SCPCL999992_qc.html"),
+            Path("SCPCP999991/SCPCS999995/SCPCL999995_unfiltered.rds"),
+            Path("SCPCP999991/SCPCS999992,SCPCS999993/SCPCL999992_celltype-report.html"),
+            Path("SCPCP999991/SCPCS999995/SCPCL999995_processed.rds"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_celltype-report.html"),
+            Path("SCPCP999991/SCPCS999995/SCPCL999995_celltype-report.html"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_processed.rds"),
+            Path("SCPCP999990/bulk/SCPCP999990_bulk_quant.tsv"),
+            Path("SCPCP999991/SCPCS999995/SCPCL999995_qc.html"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_qc.html"),
+            Path("SCPCP999991/SCPCS999992,SCPCS999993/SCPCL999992_unfiltered.rds"),
+            Path("SCPCP999990/SCPCS999990/SCPCL999990_unfiltered.rds"),
+            Path("SCPCP999992/merged/SCPCP999992_merged.rds"),
+            Path("SCPCP999991/SCPCS999995/SCPCL999995_filtered.rds"),
+            Path("SCPCP999992/merged/SCPCP999992_merged-summary-report.html"),
+        }
+        self.assertEqual(dataset.original_file_paths, expected_files)


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1108.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR introduces an OriginalFile query on the Dataset model. This query is able to grab all of a Dataset's OriginalFiles based on its data and format attributes. A `test_original_files_property` test was also added, which verifies through different configurations that the behavior of the method is as expected.




## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

- `test_original_files_property`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A
