### PR TITLE
1157 - Add Dataset Project Card with Storybook

### DIFF
--- a/client/.storybook/stories/DatasetProjectCard.stories.js
+++ b/client/.storybook/stories/DatasetProjectCard.stories.js
@@ -6,70 +6,74 @@ import { DatasetProjectCard } from 'components/DatasetProjectCard'
 // NOTE: Mock data ("data" data structure copied from the current BE test)
 const datasets = [
     {
-        id: 'UUID-1',
-        data: {
+      id: 'UUID-1',
+      format: 'SINGLE_CELL_EXPERIMENT',
+      data: {
         SCPCP999991: {
-            merge_single_cell: true,
-            includes_bulk: true,
-            SINGLE_CELL: ['SCPCS000001', 'SCPCS000002', 'SCPCS000003', 'SCPCS000004'],
-            SPATIAL: ['SCPCS000001', 'SCPCS000005', 'SCPCS000006']
-        }
+          merge_single_cell: true,
+          includes_bulk: true,
+          SINGLE_CELL: [
+            'SCPCS000001',
+            'SCPCS000002',
+            'SCPCS000003',
+            'SCPCS000004'
+          ],
+          SPATIAL: ['SCPCS000001', 'SCPCS000005', 'SCPCS000006']
         },
-        diagnoses_counts:
-        'pilocytic astrocytoma (10), ganglioglioma/ATRT (10), ganglioglioma (9), low grade glioma (1)',
-        format: 'SINGLE_CELL_EXPERIMENT',
-        downloadable_sample_count: 6,
-        title:
-        'Single-Cell Profiling of Acute Myeloid Leukemia for High-Resolution Chemo-immunotherapy Target Discovery'
-    },
-    {
-        id: 'UUID-2',
-        data: {
         SCPCP999992: {
-            merge_single_cell: true,
-            includes_bulk: false,
-            SINGLE_CELL: ['SCPCS000001', 'SCPCS000002'],
-            SPATIAL: []
-        }
+          merge_single_cell: true,
+          includes_bulk: false,
+          SINGLE_CELL: ['SCPCS000001'],
+          SPATIAL: []
         },
-        diagnoses_counts:
-        'Ependymoma (1), Ganglioglioma (5), Ganglioglioma/ATRT (1)',
-        format: 'ANN_DATA',
-        downloadable_sample_count: 2,
-        title:
-        'Single cell RNA sequencing of pediatric low-grade gliomas'
-    },
-    {
-        id: 'UUID-3',
-        data: {
-        SCPCP999992: {
-            merge_single_cell: false,
-            includes_bulk: true,
-            SINGLE_CELL: ['SCPCS000001', 'SCPCS000002', 'SCPCS000003'],
-            SPATIAL: ['SCPCS000001', 'SCPCS000002', 'SCPCS000003',  'SCPCS000004']
-        }
-        },
-        diagnoses_counts: 'Neuroblastoma (40)',
-        format:'SINGLE_CELL_EXPERIMENT',
-        downloadable_sample_count: 3,
-        title: 'Profiling the transcriptional heterogeneity of diverse pediatric solid tumors - Neuroblastoma'
-    },
-    {
-        id: 'UUID-4',
-        data: {
         SCPCP999993: {
-            merge_single_cell: false,
-            includes_bulk: false,
-            SINGLE_CELL: ['SCPCS000002', 'SCPCS000003', 'SCPCS000004'],
-            SPATIAL: []
-        }
+          merge_single_cell: false,
+          includes_bulk: true,
+          SINGLE_CELL: ['SCPCS000001', 'SCPCS000002', 'SCPCS000003'],
+          SPATIAL: ['SCPCS000001', 'SCPCS000002', 'SCPCS000003', 'SCPCS000004']
         },
-        diagnoses_counts: 'Osteosarcoma (28)',
-        format: 'ANN_DATA',
-        downloadable_sample_count: 3,
-        title: 'A Single Cell Atlas of Pediatric Sarcoma'
+        SCPCP999994: {
+          merge_single_cell: false,
+          includes_bulk: false,
+          SINGLE_CELL: ['SCPCS000002', 'SCPCS000003', 'SCPCS000004'],
+          SPATIAL: []
+        }
+      },
+      stats: {
+        projects: {
+          // each of the project cards here
+          SCPCP999991: {
+            diagnoses_counts:
+              'pilocytic astrocytoma (10), ganglioglioma/ATRT (10), ganglioglioma (9), low grade glioma (1)',
+            samples_difference_count: 5,
+            downloadable_sample_count: 6,
+            title:
+              'Single-Cell Profiling of Acute Myeloid Leukemia for High-Resolution Chemo-immunotherapy Target Discovery'
+          },
+          SCPCP999992: {
+            diagnoses_counts:
+              'Ependymoma (1), Ganglioglioma (5), Ganglioglioma/ATRT (1)',
+            samples_difference_count: 0,
+            downloadable_sample_count: 1,
+            title: 'Single cell RNA sequencing of pediatric low-grade gliomas'
+          },
+          SCPCP999993: {
+            diagnoses_counts: 'Neuroblastoma (40)',
+            samples_difference_count: 1,
+            downloadable_sample_count: 3,
+            title:
+              'Profiling the transcriptional heterogeneity of diverse pediatric solid tumors - Neuroblastoma'
+          },
+          SCPCP999994: {
+            diagnoses_counts: 'Osteosarcoma (28)',
+            samples_difference_count: 0,
+            downloadable_sample_count: 3,
+            title: 'A Single Cell Atlas of Pediatric Sarcoma'
+          }
+        }
+      }
     }
-]
+  ]
 
 export default {
   title: 'Components/DatasetProjectCard',
@@ -78,10 +82,12 @@ export default {
 
 export const Default = (args) =>  (
     <>
-     {datasets.map((dataset)=> (
-        <Box key={dataset.id} width='900px'>
-            <DatasetProjectCard dataset={dataset} {...args}  />
+     {datasets.map((d) =>
+        Object.keys(d.stats.projects).map((id) => (
+        <Box key={d.id} width='900px'>
+            <DatasetProjectCard dataset={d} projectId={id} {...args}  />
         </Box>
-     ))}
+     ))
+    )}
     </>
 )

--- a/client/.storybook/stories/DatasetProjectCard.stories.js
+++ b/client/.storybook/stories/DatasetProjectCard.stories.js
@@ -1,0 +1,87 @@
+import React from 'react'
+import 'regenerator-runtime/runtime'
+import { Box} from 'grommet'
+import { DatasetProjectCard } from 'components/DatasetProjectCard'
+
+// NOTE: Mock data ("data" data structure copied from the current BE test)
+const datasets = [
+    {
+        id: 'UUID-1',
+        data: {
+        SCPCP999991: {
+            merge_single_cell: true,
+            includes_bulk: true,
+            SINGLE_CELL: ['SCPCS000001', 'SCPCS000002', 'SCPCS000003', 'SCPCS000004'],
+            SPATIAL: ['SCPCS000001', 'SCPCS000005', 'SCPCS000006']
+        }
+        },
+        diagnoses_counts:
+        'pilocytic astrocytoma (10), ganglioglioma/ATRT (10), ganglioglioma (9), low grade glioma (1)',
+        format: 'SINGLE_CELL_EXPERIMENT',
+        downloadable_sample_count: 6,
+        title:
+        'Single-Cell Profiling of Acute Myeloid Leukemia for High-Resolution Chemo-immunotherapy Target Discovery'
+    },
+    {
+        id: 'UUID-2',
+        data: {
+        SCPCP999992: {
+            merge_single_cell: true,
+            includes_bulk: false,
+            SINGLE_CELL: ['SCPCS000001', 'SCPCS000002'],
+            SPATIAL: []
+        }
+        },
+        diagnoses_counts:
+        'Ependymoma (1), Ganglioglioma (5), Ganglioglioma/ATRT (1)',
+        format: 'ANN_DATA',
+        downloadable_sample_count: 2,
+        title:
+        'Single cell RNA sequencing of pediatric low-grade gliomas'
+    },
+    {
+        id: 'UUID-3',
+        data: {
+        SCPCP999992: {
+            merge_single_cell: false,
+            includes_bulk: true,
+            SINGLE_CELL: ['SCPCS000001', 'SCPCS000002', 'SCPCS000003'],
+            SPATIAL: ['SCPCS000001', 'SCPCS000002', 'SCPCS000003',  'SCPCS000004']
+        }
+        },
+        diagnoses_counts: 'Neuroblastoma (40)',
+        format:'SINGLE_CELL_EXPERIMENT',
+        downloadable_sample_count: 3,
+        title: 'Profiling the transcriptional heterogeneity of diverse pediatric solid tumors - Neuroblastoma'
+    },
+    {
+        id: 'UUID-4',
+        data: {
+        SCPCP999993: {
+            merge_single_cell: false,
+            includes_bulk: false,
+            SINGLE_CELL: ['SCPCS000002', 'SCPCS000003', 'SCPCS000004'],
+            SPATIAL: []
+        }
+        },
+        diagnoses_counts: 'Osteosarcoma (28)',
+        format: 'ANN_DATA',
+        downloadable_sample_count: 3,
+        title: 'A Single Cell Atlas of Pediatric Sarcoma'
+    }
+]
+
+export default {
+  title: 'Components/DatasetProjectCard',
+  args: { datasets }
+}
+
+export const Default = (args) =>  (
+    <>
+     {datasets.map((dataset)=> (
+        <Box key={dataset.id} width='900px'>
+            <DatasetProjectCard dataset={dataset} {...args}  />
+        </Box>
+     ))}
+    </>
+)

--- a/client/src/components/Badge.js
+++ b/client/src/components/Badge.js
@@ -12,7 +12,7 @@ const badges = {
   Samples
 }
 
-export const Badge = ({ badge, label, className }) => {
+export const Badge = ({ badge, label, className, children }) => {
   const BadgeSVG = badges[badge]
   return (
     <Box direction="row" align="center" className={className}>
@@ -20,6 +20,7 @@ export const Badge = ({ badge, label, className }) => {
         <BadgeSVG role="presentation" aria-hidden="true" focusable="false" />
       </Box>
       <Paragraph margin={{ left: 'small' }}>{label}</Paragraph>
+      {children}
     </Box>
   )
 }

--- a/client/src/components/DatasetProjectCard.js
+++ b/client/src/components/DatasetProjectCard.js
@@ -7,15 +7,6 @@ import { Link } from 'components/Link'
 import { WarningText } from 'components/WarningText'
 import { getReadable } from 'helpers/getReadable'
 
-// NOTE: Temporarily defined within this component (the existing project card's header component is in a separate file)
-const DatasetHeader = ({ title }) => (
-  <Link href="#demo">
-    <Text weight="bold" color="brand" size="large">
-      {title}
-    </Text>
-  </Link>
-)
-
 const Label = ({ label }) => <Text weight="bold">{label}</Text>
 
 // NOTE: This component accepts 'dataset' and 'projectId' props but it's subject to change
@@ -38,8 +29,6 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
   const isSamplesDifference = samplesDifferenceCount > 0
 
   const modalities = ['SINGLE_CELL', 'SPATIAL']
-  const options = ['merge_single_cell', 'includes_bulk']
-  const hasNoOptions = options.filter((o) => projectData[o]).length === 0
 
   const downloadOptions = [
     {
@@ -61,17 +50,22 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
     },
     {
       title: 'Other Options',
-      value: (
-        <Box key={projectId}>
-          {includesBulk && (
-            <Text>Include all bulk RNA-seq data in the project</Text>
-          )}
-          {mergedSingleCell && (
-            <Text>Merge single-cell samples into 1 object</Text>
-          )}
-          {hasNoOptions && <Text>Not Specified</Text>}
-        </Box>
-      )
+      value: () => {
+        const options = ['merge_single_cell', 'includes_bulk']
+        const hasNoOptions = options.filter((o) => projectData[o]).length === 0
+
+        return (
+          <Box>
+            {includesBulk && (
+              <Text>Include all bulk RNA-seq data in the project</Text>
+            )}
+            {mergedSingleCell && (
+              <Text>Merge single-cell samples into 1 object</Text>
+            )}
+            {hasNoOptions && <Text>Not Specified</Text>}
+          </Box>
+        )
+      }
     }
   ]
 
@@ -82,7 +76,11 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
         margin={{ bottom: '24px' }}
         pad={{ bottom: '24px' }}
       >
-        <DatasetHeader linked title={projectStats.title} />
+        <Link href="#demo">
+          <Text weight="bold" color="brand" size="large">
+            {projectStats.title}
+          </Text>
+        </Link>
       </Box>
       <Box margin={{ bottom: '24px' }}>
         <Badge badge="Samples">
@@ -106,13 +104,7 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
           {downloadOptions.map((d) => (
             <Box key={d.title} flex={{ grow: 1 }}>
               <Label label={d.title} />
-              {d.value ? (
-                <Text>{d.value}</Text>
-              ) : (
-                <Text italic color="black-tint-30">
-                  Not Specified
-                </Text>
-              )}
+              <Text>{d.value}</Text>
             </Box>
           ))}
         </Box>

--- a/client/src/components/DatasetProjectCard.js
+++ b/client/src/components/DatasetProjectCard.js
@@ -29,45 +29,8 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
   const isSamplesDifference = samplesDifferenceCount > 0
 
   const modalities = ['SINGLE_CELL', 'SPATIAL']
-
-  const downloadOptions = [
-    {
-      title: 'Data Format',
-      value: getReadable(dataset.format)
-    },
-    {
-      title: 'Modality',
-      value: modalities.map((modality) => {
-        const totalSamples = projectData[modality].length
-        return (
-          <Box key={modality}>
-            <Text>
-              {totalSamples > 0 && `${getReadable(modality)} (${totalSamples})`}
-            </Text>
-          </Box>
-        )
-      })
-    },
-    {
-      title: 'Other Options',
-      value: () => {
-        const options = ['merge_single_cell', 'includes_bulk']
-        const hasNoOptions = options.filter((o) => projectData[o]).length === 0
-
-        return (
-          <Box>
-            {includesBulk && (
-              <Text>Include all bulk RNA-seq data in the project</Text>
-            )}
-            {mergedSingleCell && (
-              <Text>Merge single-cell samples into 1 object</Text>
-            )}
-            {hasNoOptions && <Text>Not Specified</Text>}
-          </Box>
-        )
-      }
-    }
-  ]
+  const options = ['merge_single_cell', 'includes_bulk']
+  const hasNoOptions = options.filter((o) => projectData[o]).length === 0
 
   return (
     <Box elevation="medium" pad="24px" width="full">
@@ -101,12 +64,31 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
           direction={responsive('column', 'row')}
           margin={{ bottom: '24px' }}
         >
-          {downloadOptions.map((d) => (
-            <Box key={d.title} flex={{ grow: 1 }}>
-              <Label label={d.title} />
-              <Text>{d.value}</Text>
+          <Box flex={{ grow: 1 }}>
+            <Label label="Data Format" />
+            <Text>{getReadable(dataset.format)}</Text>
+          </Box>
+          <Box flex={{ grow: 1 }}>
+            <Label label="Modality" />
+            {modalities.map((modality) => (
+              <Text key={modality}>
+                {projectData[modality].length > 0 &&
+                  `${getReadable(modality)} (${projectData[modality].length})`}
+              </Text>
+            ))}
+          </Box>
+          <Box flex={{ grow: 1 }}>
+            <Label label="Other Options" />
+            <Box>
+              {includesBulk && (
+                <Text>Include all bulk RNA-seq data in the project</Text>
+              )}
+              {mergedSingleCell && (
+                <Text>Merge single-cell samples into 1 object</Text>
+              )}
+              {hasNoOptions && <Text>Not Specified</Text>}
             </Box>
-          ))}
+          </Box>
         </Box>
       </Box>
       <Box

--- a/client/src/components/DatasetProjectCard.js
+++ b/client/src/components/DatasetProjectCard.js
@@ -28,12 +28,18 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
     stats: { projects }
   } = dataset
 
+  const projectData = data[projectId]
   const { merge_single_cell: mergedSingleCell, includes_bulk: includesBulk } =
-    data[projectId]
-  const hasNoOptions = !mergedSingleCell && !includesBulk
-  const downloadableSamples = projects[projectId].downloadable_sample_count
-  const samplesDifferenceCount = projects[projectId].samples_difference_count
+    projectData
+
+  const projectStats = projects[projectId]
+  const downloadableSamples = projectStats.downloadable_sample_count
+  const samplesDifferenceCount = projectStats.samples_difference_count
   const isSamplesDifference = samplesDifferenceCount > 0
+
+  const modalities = ['SINGLE_CELL', 'SPATIAL']
+  const options = ['merge_single_cell', 'includes_bulk']
+  const hasNoOptions = options.filter((o) => projectData[o]).length === 0
 
   const downloadOptions = [
     {
@@ -42,8 +48,8 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
     },
     {
       title: 'Modality',
-      value: ['SINGLE_CELL', 'SPATIAL'].map((modality) => {
-        const totalSamples = data[projectId][modality].length
+      value: modalities.map((modality) => {
+        const totalSamples = projectData[modality].length
         return (
           <Box key={modality}>
             <Text>
@@ -55,9 +61,7 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
     },
     {
       title: 'Other Options',
-      value: hasNoOptions ? (
-        <Text>Not Specified</Text>
-      ) : (
+      value: (
         <Box key={projectId}>
           {includesBulk && (
             <Text>Include all bulk RNA-seq data in the project</Text>
@@ -65,6 +69,7 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
           {mergedSingleCell && (
             <Text>Merge single-cell samples into 1 object</Text>
           )}
+          {hasNoOptions && <Text>Not Specified</Text>}
         </Box>
       )
     }
@@ -77,7 +82,7 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
         margin={{ bottom: '24px' }}
         pad={{ bottom: '24px' }}
       >
-        <DatasetHeader linked title={projects[projectId].title} />
+        <DatasetHeader linked title={projectStats.title} />
       </Box>
       <Box margin={{ bottom: '24px' }}>
         <Badge badge="Samples">
@@ -89,7 +94,7 @@ export const DatasetProjectCard = ({ dataset, projectId }) => {
       <Box>
         <Box margin={{ bottom: '24px' }}>
           <Label label="Diagnosis" />
-          <Text>{projects[projectId].diagnoses_counts}</Text>
+          <Text>{projectStats.diagnoses_counts}</Text>
         </Box>
         <Box margin={{ bottom: 'xsmall' }}>
           <Label label="Download Options" />

--- a/client/src/components/DatasetProjectCard.js
+++ b/client/src/components/DatasetProjectCard.js
@@ -1,0 +1,165 @@
+import React from 'react'
+import { Box, Text } from 'grommet'
+import { useResponsive } from 'hooks/useResponsive'
+import { Badge } from 'components/Badge'
+import { Button } from 'components/Button'
+import { Link } from 'components/Link'
+import { WarningText } from 'components/WarningText'
+import { getReadable } from 'helpers/getReadable'
+import { uniqueArray } from 'helpers/uniqueArray'
+
+// NOTE: Temporarily defined within this component (the existing project card's header component is in a separate file)
+const DatasetHeader = ({ dataset, linked = false }) => (
+  <>
+    {linked ? (
+      <Link href="#demo">
+        <Text weight="bold" color="brand" size="large">
+          {dataset.title}
+        </Text>
+      </Link>
+    ) : (
+      <Text weight="bold" color="brand" size="large">
+        {dataset.title}
+      </Text>
+    )}
+  </>
+)
+
+const Label = ({ label }) => <Text weight="bold">{label}</Text>
+
+// NOTE: This component accepts 'dataset' prop but it's subject to change
+// Currently mock data is used via Storybook for development
+export const DatasetProjectCard = ({ dataset }) => {
+  const { responsive } = useResponsive()
+  const projectIds = Object.keys(dataset.data)
+  const modalities = ['SINGLE_CELL', 'SPATIAL']
+  const downloadOptions = [
+    {
+      title: 'Data Format',
+      value: getReadable(dataset.format)
+    },
+    {
+      title: 'Modality',
+      value: modalities.map((modality) => {
+        const totalSamples = projectIds.reduce((acc, projectId) => {
+          return acc + dataset.data[projectId][modality].length
+        }, 0)
+
+        return (
+          <Box key={modality}>
+            <Text>
+              {totalSamples > 0 && `${getReadable(modality)} (${totalSamples})`}
+            </Text>
+          </Box>
+        )
+      })
+    },
+    {
+      title: 'Other Options',
+      value: projectIds.map((projectId) => {
+        const {
+          includes_bulk: includesBulk,
+          merge_single_cell: mergedSingleCell
+        } = dataset.data[projectId]
+        const hasNoOptions = !includesBulk && !mergedSingleCell
+
+        return (
+          <Box key={projectId}>
+            {includesBulk && (
+              <Text>Include all bulk RNA-seq data in the project</Text>
+            )}
+            {mergedSingleCell && (
+              <Text>Merge single-cell samples into 1 object</Text>
+            )}
+            {hasNoOptions && <Text>Not Specified</Text>}
+          </Box>
+        )
+      })
+    }
+  ]
+
+  const samplesDifferenceCount = projectIds.reduce((acc, projectId) => {
+    const { SINGLE_CELL, SPATIAL } = dataset.data[projectId]
+    const singleCellSamples = uniqueArray(SINGLE_CELL)
+    const spatialSamples = uniqueArray(SPATIAL)
+
+    if (singleCellSamples.length === 0 || spatialSamples.length === 0) {
+      return 0
+    }
+
+    const difference = [
+      ...singleCellSamples.filter((sample) => !spatialSamples.includes(sample)),
+      ...spatialSamples.filter((id) => !singleCellSamples.includes(id))
+    ]
+    return acc + difference.length
+  }, 0)
+
+  const isSamplesDifference = samplesDifferenceCount > 0
+
+  return (
+    <Box elevation="medium" pad="24px" width="full">
+      <Box
+        border={{ side: 'bottom' }}
+        margin={{ bottom: '24px' }}
+        pad={{ bottom: '24px' }}
+      >
+        <DatasetHeader linked dataset={dataset} />
+      </Box>
+      <Box margin={{ bottom: '24px' }}>
+        <Badge badge="Samples">
+          <Text size="21px" weight="bold">
+            {dataset.downloadable_sample_count} Samples
+          </Text>
+        </Badge>
+      </Box>
+      <Box>
+        <Box margin={{ bottom: '24px' }}>
+          <Label label="Diagnosis" />
+          <Text>{dataset.diagnoses_counts}</Text>
+        </Box>
+        <Box margin={{ bottom: 'xsmall' }}>
+          <Label label="Download Options" />
+        </Box>
+        <Box
+          direction={responsive('column', 'row')}
+          margin={{ bottom: '24px' }}
+        >
+          {downloadOptions.map((d) => (
+            <Box key={d.title} flex={{ grow: 1 }}>
+              <Label label={d.title} />
+              {d.value ? (
+                <Text>{d.value}</Text>
+              ) : (
+                <Text italic color="black-tint-30">
+                  Not Specified
+                </Text>
+              )}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+      <Box
+        align={responsive('start', 'center')}
+        direction={responsive('column', 'row')}
+        gap="large"
+      >
+        <Button
+          label="View/Edit Samples"
+          aria-label="View/Edit Samples"
+          href="#demo"
+        />
+        {isSamplesDifference && (
+          <WarningText iconMargin="0" iconSize="24px" margin="0">
+            <Text>
+              Selected modalities may not be available for{' '}
+              {samplesDifferenceCount} sample
+              {samplesDifferenceCount > 1 ? 's' : ''}.
+            </Text>
+          </WarningText>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+export default DatasetProjectCard

--- a/client/src/components/WarningText.js
+++ b/client/src/components/WarningText.js
@@ -25,8 +25,8 @@ export const WarningText = ({
       <Paragraph>
         {text} {lineBreak && <br />}
         {link && <Link label={linkLabel} href={link} newTab={newTab} />}
-        {children}
       </Paragraph>
+      {children}
     </Box>
   )
 }

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -4,11 +4,5 @@
   "github": {
     "autoAlias" : false,
     "silent" : true
-  },
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "yarn run build-storybook",
-  "devCommand": "yarn run storybook",
-  "installCommand": "yarn install",
-  "framework": null,
-  "outputDirectory": "./storybook-static"
+  }
 }

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -4,5 +4,11 @@
   "github": {
     "autoAlias" : false,
     "silent" : true
-  }
+  },
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "yarn run build-storybook",
+  "devCommand": "yarn run storybook",
+  "installCommand": "yarn install",
+  "framework": null,
+  "outputDirectory": "./storybook-static"
 }


### PR DESCRIPTION
## Issue Number

Closes #1157

## Purpose/Implementation Notes

Please see the latest Storybook [here](https://scpca-portal-963irvr6j-ccdl.vercel.app/?path=/story/components-datasetprojectcard--default).

I've implemented the `DatasetProjectCard` component and add the corresponding story with mock data in Storybook.

Other change include:
- Minor updates to the following components:
  - Added a `children` prop to `Badge` 
  - Moved the `children` prop outside of `Paragraph` in `WarningText` 

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
