### PR TITLE
1177 - Add Portal Wide Download Card with Storybook

### DIFF
--- a/client/.storybook/stories/DatasetPortalWideDownloadCard.stories.js
+++ b/client/.storybook/stories/DatasetPortalWideDownloadCard.stories.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { Grid } from 'grommet'
+import { useResponsive } from 'hooks/useResponsive'
+import { DatasetPortalWideDownloadCard } from 'components/DatasetPortalWideDownloadCard'
+
+
+const datasets = [
+    {
+        id: 1,
+        format: 'SINGLE_CELL_EXPERIMENT',
+        modality: 'SINGLE_CELL',
+        has_bulk_rna_seq: true,
+        has_cite_seq_data: true,
+        includes_merged: true,
+        metadata_only: false,
+        size_in_bytes: 429496729600
+    },
+    {
+        id: 2,
+        format: 'ANN_DATA',
+        modality: 'SINGLE_CELL',
+        has_bulk_rna_seq: true,
+        has_cite_seq_data: true,
+        includes_merged: true,
+        metadata_only: false,
+        size_in_bytes: 966367641600
+    },
+    {
+        id: 3,
+        format: 'SINGLE_CELL_EXPERIMENT',
+        modality: 'SPATIAL',
+        has_bulk_rna_seq: true,
+        has_cite_seq_data: false,
+        includes_merged: false,
+        metadata_only: false,
+        size_in_bytes: 429496729600
+    }
+]
+
+const portalMetadataDataset = {
+    id: 1,
+    format: null,
+    modality: null,
+    has_bulk_rna_seq: false,
+    has_cite_seq_data: false,
+    includes_merged: false,
+    metadata_only: true,
+    size_in_bytes: 608270
+  }
+
+
+export default {
+  title: 'Components/DatasetPortalWideDownloadCard',
+  args: {datasets, portalMetadataDataset}
+}
+
+export const DataFormat = (args) => {
+    const { responsive } = useResponsive()
+    return (
+    <Grid columns={responsive( '100%' , '420px')} gap="xxlarge">
+        { datasets.map((d) =>
+            <DatasetPortalWideDownloadCard key={d.id} dataset={d} {...args} />
+        )}
+    </Grid>)
+}
+
+export const PortalMetadata = (args) => (
+    <DatasetPortalWideDownloadCard dataset={portalMetadataDataset} {...args}   />
+)

--- a/client/.storybook/stories/DatasetPortalWideDownloadCard.stories.js
+++ b/client/.storybook/stories/DatasetPortalWideDownloadCard.stories.js
@@ -54,7 +54,7 @@ export default {
   args: {datasets, portalMetadataDataset}
 }
 
-export const DataFormat = (args) => {
+export const ProjectsDownload= (args) => {
     const { responsive } = useResponsive()
     return (
     <Grid columns={responsive( '100%' , '420px')} gap="xxlarge">
@@ -64,6 +64,6 @@ export const DataFormat = (args) => {
     </Grid>)
 }
 
-export const PortalMetadata = (args) => (
+export const PortalMetadataDownload = (args) => (
     <DatasetPortalWideDownloadCard dataset={portalMetadataDataset} {...args}   />
 )

--- a/client/src/components/DatasetPortalWideDownloadCard.js
+++ b/client/src/components/DatasetPortalWideDownloadCard.js
@@ -43,9 +43,7 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
       >
         <Link href="#demo">
           <Text weight="bold" color="brand" size="large">
-            {metadataOnly
-              ? 'Sample Metadata Download'
-              : getReadable(dataset.format)}{' '}
+            {metadataOnly ? 'Sample Metadata' : getReadable(dataset.format)}{' '}
             Download
           </Text>
         </Link>

--- a/client/src/components/DatasetPortalWideDownloadCard.js
+++ b/client/src/components/DatasetPortalWideDownloadCard.js
@@ -4,7 +4,6 @@ import { useResponsive } from 'hooks/useResponsive'
 import { Button } from 'components/Button'
 import { CopyLinkButton } from 'components/CopyLinkButton'
 import { HelpLink } from 'components/HelpLink'
-import { Link } from 'components/Link'
 import { config } from 'config'
 import { formatBytes } from 'helpers/formatBytes'
 import { getReadable, getReadableFiles } from 'helpers/getReadable'
@@ -32,8 +31,11 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
     ...['has_cite_seq_data', 'has_bulk_rna_seq'].filter((key) => dataset[key])
   ].map((key) => getReadableFiles(key))
 
-  const cardTitle =
+  const projectsTitlePrefix =
     modality === 'SPATIAL' ? getReadable(modality) : getReadable(format)
+  const cardTitle = `${
+    metadataOnly ? 'Sample Metadata' : projectsTitlePrefix
+  } Download`
 
   const [mergeObject, setMergeObject] = useState(false)
   const handleChangeMergedObject = () => setMergeObject(!mergeObject)
@@ -45,11 +47,9 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
         margin={{ bottom: '24px' }}
         pad={{ bottom: 'medium' }}
       >
-        <Link href="#demo">
-          <Text weight="bold" color="brand" size="large">
-            {metadataOnly ? 'Sample Metadata' : cardTitle} Download
-          </Text>
-        </Link>
+        <Text color="brand" size="large" weight="bold">
+          {cardTitle}
+        </Text>
       </Box>
       <Box justify="between" height="100%">
         <>
@@ -73,8 +73,8 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
           {includeMerged && (
             <Box direction="row" margin={{ bottom: '24px' }}>
               <CheckBox
-                checked={mergeObject}
                 label="Merge samples into one object per project"
+                checked={mergeObject}
                 onChange={handleChangeMergedObject}
               />
               <HelpLink link={config.links.when_downloading_merged_objects} />
@@ -97,7 +97,7 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
               gap="24px"
               margin={{ bottom: 'small' }}
             >
-              <Button primary aria-label="Download" label="Download" />
+              <Button label="Download" aria-label="Download" primary />
               {!metadataOnly && <CopyLinkButton computedFile={{}} />}
             </Box>
           </Box>

--- a/client/src/components/DatasetPortalWideDownloadCard.js
+++ b/client/src/components/DatasetPortalWideDownloadCard.js
@@ -21,6 +21,7 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
   const { responsive } = useResponsive()
 
   const {
+    format,
     modality,
     includes_merged: includeMerged,
     metadata_only: metadataOnly
@@ -30,6 +31,9 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
     modality,
     ...['has_cite_seq_data', 'has_bulk_rna_seq'].filter((key) => dataset[key])
   ].map((key) => getReadableFiles(key))
+
+  const cardTitle =
+    modality === 'SPATIAL' ? getReadable(modality) : getReadable(format)
 
   const [mergeObject, setMergeObject] = useState(false)
   const handleChangeMergedObject = () => setMergeObject(!mergeObject)
@@ -43,8 +47,7 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
       >
         <Link href="#demo">
           <Text weight="bold" color="brand" size="large">
-            {metadataOnly ? 'Sample Metadata' : getReadable(dataset.format)}{' '}
-            Download
+            {metadataOnly ? 'Sample Metadata' : cardTitle} Download
           </Text>
         </Link>
       </Box>

--- a/client/src/components/DatasetPortalWideDownloadCard.js
+++ b/client/src/components/DatasetPortalWideDownloadCard.js
@@ -48,51 +48,55 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
           </Text>
         </Link>
       </Box>
-      <Box
-        as="ul"
-        margin={{ top: '0', bottom: 'large' }}
-        pad={{ left: 'large' }}
-        style={{ listStyle: 'disc' }}
-      >
-        {metadataOnly ? (
-          <Li>Sample metadata from all projects</Li>
-        ) : (
-          <>
-            {fileItems.map((item) => (
-              <Li key={item}>{item}</Li>
-            ))}
-            <Li>Project and Sample Metadata</Li>
-          </>
-        )}
-      </Box>
-      {includeMerged && (
-        <Box direction="row" margin={{ bottom: '24px' }}>
-          <CheckBox
-            checked={mergeObject}
-            label="Merge samples into one object per project"
-            onChange={handleChangeMergedObject}
-          />
-          <HelpLink link={config.links.when_downloading_merged_objects} />
-        </Box>
-      )}
-      <Box
-        align={responsive('start', 'center')}
-        direction={responsive('column', 'row')}
-        gap="large"
-      >
-        <Box direction="column">
-          {!metadataOnly && (
-            <Text margin={{ bottom: 'small' }} weight="bold">
-              Size: {formatBytes(dataset.size_in_bytes)}
-            </Text>
-          )}
+      <Box justify="between" height="100%">
+        <>
           <Box
-            direction={responsive('column', 'row')}
-            gap="24px"
-            margin={{ bottom: 'small' }}
+            as="ul"
+            margin={{ top: '0', bottom: 'large' }}
+            pad={{ left: 'large' }}
+            style={{ listStyle: 'disc' }}
           >
-            <Button primary aria-label="Download" label="Download" />
-            {!metadataOnly && <CopyLinkButton computedFile={{}} />}
+            {metadataOnly ? (
+              <Li>Sample metadata from all projects</Li>
+            ) : (
+              <>
+                {fileItems.map((item) => (
+                  <Li key={item}>{item}</Li>
+                ))}
+                <Li>Project and Sample Metadata</Li>
+              </>
+            )}
+          </Box>
+          {includeMerged && (
+            <Box direction="row" margin={{ bottom: '24px' }}>
+              <CheckBox
+                checked={mergeObject}
+                label="Merge samples into one object per project"
+                onChange={handleChangeMergedObject}
+              />
+              <HelpLink link={config.links.when_downloading_merged_objects} />
+            </Box>
+          )}
+        </>
+        <Box
+          align={responsive('start', 'center')}
+          direction={responsive('column', 'row')}
+          gap="large"
+        >
+          <Box direction="column">
+            {!metadataOnly && (
+              <Text margin={{ bottom: 'small' }} weight="bold">
+                Size: {formatBytes(dataset.size_in_bytes)}
+              </Text>
+            )}
+            <Box
+              direction={responsive('column', 'row')}
+              gap="24px"
+              margin={{ bottom: 'small' }}
+            >
+              <Button primary aria-label="Download" label="Download" />
+              {!metadataOnly && <CopyLinkButton computedFile={{}} />}
+            </Box>
           </Box>
         </Box>
       </Box>

--- a/client/src/components/DatasetPortalWideDownloadCard.js
+++ b/client/src/components/DatasetPortalWideDownloadCard.js
@@ -43,7 +43,10 @@ export const DatasetPortalWideDownloadCard = ({ dataset }) => {
       >
         <Link href="#demo">
           <Text weight="bold" color="brand" size="large">
-            {getReadable(dataset.format)} Download
+            {metadataOnly
+              ? 'Sample Metadata Download'
+              : getReadable(dataset.format)}{' '}
+            Download
           </Text>
         </Link>
       </Box>

--- a/client/src/components/DatasetPortalWideDownloadCard.js
+++ b/client/src/components/DatasetPortalWideDownloadCard.js
@@ -1,0 +1,102 @@
+import React, { useState } from 'react'
+import { Box, CheckBox, Text } from 'grommet'
+import { useResponsive } from 'hooks/useResponsive'
+import { Button } from 'components/Button'
+import { CopyLinkButton } from 'components/CopyLinkButton'
+import { HelpLink } from 'components/HelpLink'
+import { Link } from 'components/Link'
+import { config } from 'config'
+import { formatBytes } from 'helpers/formatBytes'
+import { getReadable, getReadableFiles } from 'helpers/getReadable'
+
+const Li = ({ children }) => (
+  <Box as="li" style={{ display: 'list-item' }}>
+    {children}
+  </Box>
+)
+
+// NOTE: This component temporaily accepts 'dataset' but it's subject to change
+// Currently mock data is used via Storybook for development
+export const DatasetPortalWideDownloadCard = ({ dataset }) => {
+  const { responsive } = useResponsive()
+
+  const {
+    modality,
+    includes_merged: includeMerged,
+    metadata_only: metadataOnly
+  } = dataset
+
+  const fileItems = [
+    modality,
+    ...['has_cite_seq_data', 'has_bulk_rna_seq'].filter((key) => dataset[key])
+  ].map((key) => getReadableFiles(key))
+
+  const [mergeObject, setMergeObject] = useState(false)
+  const handleChangeMergedObject = () => setMergeObject(!mergeObject)
+
+  return (
+    <Box elevation="medium" pad="24px" width="full">
+      <Box
+        border={{ side: 'bottom' }}
+        margin={{ bottom: '24px' }}
+        pad={{ bottom: 'medium' }}
+      >
+        <Link href="#demo">
+          <Text weight="bold" color="brand" size="large">
+            {getReadable(dataset.format)} Download
+          </Text>
+        </Link>
+      </Box>
+      <Box
+        as="ul"
+        margin={{ top: '0', bottom: 'large' }}
+        pad={{ left: 'large' }}
+        style={{ listStyle: 'disc' }}
+      >
+        {metadataOnly ? (
+          <Li>Sample metadata from all projects</Li>
+        ) : (
+          <>
+            {fileItems.map((item) => (
+              <Li key={item}>{item}</Li>
+            ))}
+            <Li>Project and Sample Metadata</Li>
+          </>
+        )}
+      </Box>
+      {includeMerged && (
+        <Box direction="row" margin={{ bottom: '24px' }}>
+          <CheckBox
+            checked={mergeObject}
+            label="Merge samples into one object per project"
+            onChange={handleChangeMergedObject}
+          />
+          <HelpLink link={config.links.when_downloading_merged_objects} />
+        </Box>
+      )}
+      <Box
+        align={responsive('start', 'center')}
+        direction={responsive('column', 'row')}
+        gap="large"
+      >
+        <Box direction="column">
+          {!metadataOnly && (
+            <Text margin={{ bottom: 'small' }} weight="bold">
+              Size: {formatBytes(dataset.size_in_bytes)}
+            </Text>
+          )}
+          <Box
+            direction={responsive('column', 'row')}
+            gap="24px"
+            margin={{ bottom: 'small' }}
+          >
+            <Button primary aria-label="Download" label="Download" />
+            {!metadataOnly && <CopyLinkButton computedFile={{}} />}
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default DatasetPortalWideDownloadCard

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -4,11 +4,5 @@
   "github": {
     "autoAlias" : false,
     "silent" : true
-  },
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "yarn run build-storybook",
-  "devCommand": "yarn run storybook",
-  "installCommand": "yarn install",
-  "framework": null,
-  "outputDirectory": "./storybook-static"
+  }
 }


### PR DESCRIPTION
## Issue Number

Closes #1177

## Purpose/Implementation Notes

Please see the latest Storybook [here](https://scpca-portal-86ggp2vro-ccdl.vercel.app/?path=/story/components-datasetportalwidedownloadcard--projects-download).

I've implemented the `DatasetPortalWideDownloadCard` component and the corresponding Story using mock data.

There are two views added to the `DatasetPortalWideDownloadCard`story on Storybook:
- `Data Format` for the packaged projects download
- `Portal Metadata` for the portal-wide metadata download

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
