### PR TITLE
add default region to local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   postgres:
     image: postgres:11.6
@@ -20,6 +18,7 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
+      - AWS_DEFAULT_REGION=us-east-1
       - DEV_HOST=http://localhost:${API_PORT}
       - LOG_RUNTIMES
     command: >


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Fixes temporary local issue while transitioning over to different credentials managment.

- sets `AWS_DEFAULT_REGION` for local API builds
- removes docker compose version

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
