### PR TITLE
1178 - Add Download My Dataset for CCDL Dataset Downloading Modal Body with Storybook

### DIFF
--- a/client/.storybook/stories/DatasetDownloadStarted.stories.js
+++ b/client/.storybook/stories/DatasetDownloadStarted.stories.js
@@ -74,7 +74,7 @@ const TempMordal = ({ dataset, children }) => {
           label={cardTitle}
           onClick={handleClick}
         />
-        <Modal title={cardTitle} titleNoBreakline='nowrap' showing={showing} setShowing={setShowing}>
+        <Modal title={cardTitle} showing={showing} setShowing={setShowing}>
           <ModalBody>
             <Grid columns={['auto']} pad={{ bottom: 'medium' }}>
               <Box pad={{ top: 'small' }}>

--- a/client/.storybook/stories/DatasetDownloadStarted.stories.js
+++ b/client/.storybook/stories/DatasetDownloadStarted.stories.js
@@ -1,0 +1,101 @@
+import React, { useState } from 'react'
+import { Box, Grid } from 'grommet'
+import { Button } from 'components/Button'
+import { DatasetDownloadStarted } from 'components/DatasetDownloadStarted'
+import { Modal, ModalBody } from 'components/Modal'
+import { getReadable } from 'helpers/getReadable'
+
+const datasets = [
+    {
+        id: 1,
+        format: 'SINGLE_CELL_EXPERIMENT',
+        modality: 'SINGLE_CELL',
+        has_bulk_rna_seq: true,
+        has_cite_seq_data: true,
+        includes_merged: true,
+        metadata_only: false,
+        size_in_bytes: 429496729600
+    },
+    {
+        id: 2,
+        format: 'ANN_DATA',
+        modality: 'SINGLE_CELL',
+        has_bulk_rna_seq: true,
+        has_cite_seq_data: true,
+        includes_merged: true,
+        metadata_only: false,
+        size_in_bytes: 966367641600
+    },
+    {
+        id: 3,
+        format: 'SINGLE_CELL_EXPERIMENT',
+        modality: 'SPATIAL',
+        has_bulk_rna_seq: true,
+        has_cite_seq_data: false,
+        includes_merged: false,
+        metadata_only: false,
+        size_in_bytes: 429496729600
+    }
+]
+
+const portalMetadataDataset = {
+    id: 1,
+    format: null,
+    modality: null,
+    has_bulk_rna_seq: false,
+    has_cite_seq_data: false,
+    includes_merged: false,
+    metadata_only: true,
+    size_in_bytes: 608270
+  }
+
+export default {
+  title: 'Components/DatasetDownloadStarted',
+  args: {datasets, portalMetadataDataset}
+}
+
+const TempMordal = ({ dataset, children }) => {
+    const { format, modality, metadata_only: metadataOnly } = dataset
+    const cardTitle = `Downloading Portal-wide ${
+        metadataOnly ? 'Sample Metadata' :
+             `as ${modality === 'SPATIAL'  ? getReadable(modality) : getReadable(format)}`
+    }`
+    const [showing, setShowing] = useState(false)
+    const handleClick = () => {
+      setShowing(true)
+    }
+
+    return (
+      <Box margin="xlarge" align="start">
+        <Button
+          aria-label={cardTitle}
+          flex="grow"
+          primary
+          label={cardTitle}
+          onClick={handleClick}
+        />
+        <Modal title={cardTitle} titleNoBreakline='nowrap' showing={showing} setShowing={setShowing}>
+          <ModalBody>
+            <Grid columns={['auto']} pad={{ bottom: 'medium' }}>
+              <Box pad={{ top: 'small' }}>
+                {children}
+              </Box>
+            </Grid>
+          </ModalBody>
+        </Modal>
+      </Box>
+    )
+  }
+
+
+export const Default = (args) => (
+    <>
+      <TempMordal dataset={portalMetadataDataset} {...args}>
+        <DatasetDownloadStarted dataset={portalMetadataDataset} {...args} />
+      </TempMordal>
+      { datasets.map((d) =>
+        <TempMordal dataset={d} {...args}>
+            <DatasetDownloadStarted dataset={d} {...args} />
+        </TempMordal>
+      )}
+    </>)

--- a/client/src/components/DatasetDownloadStarted.js
+++ b/client/src/components/DatasetDownloadStarted.js
@@ -1,0 +1,92 @@
+import React from 'react'
+import { Box, Grid, Paragraph, Text } from 'grommet'
+import { Button } from 'components/Button'
+import { Link } from 'components/Link'
+import { formatBytes } from 'helpers/formatBytes'
+import { getReadable, getReadableFiles } from 'helpers/getReadable'
+import DownloadSVG from '../images/download-folder.svg'
+
+const Li = ({ children }) => (
+  <Box as="li" style={{ display: 'list-item' }}>
+    {children}
+  </Box>
+)
+
+// This component temporarily accepts 'dataset' but it's subject to change
+// Using mock data with storybook
+// Modal body to show when downloading CCDL dataset
+export const DatasetDownloadStarted = ({ dataset }) => {
+  const {
+    format,
+    modality,
+    includes_merged: includeMerged,
+    metadata_only: metadataOnly
+  } = dataset
+  const fileItems = [
+    modality,
+    ...['has_cite_seq_data', 'has_bulk_rna_seq'].filter((key) => dataset[key])
+  ].map((key) => getReadableFiles(key))
+
+  const startedText = metadataOnly ? (
+    'This download contains all of the sample metadata from every project in ScPCA Portal.'
+  ) : (
+    <Text weight="bold">Data Format: {getReadable(format)}</Text>
+  )
+
+  return (
+    <Grid columns={['2/3', '1/3']} align="center" gap="large">
+      <Box>
+        <Paragraph margin="0">Your download should have started.</Paragraph>
+        <Paragraph margin={{ vertical: metadataOnly ? 'small' : '0' }}>
+          {startedText}
+        </Paragraph>
+        <Paragraph>The download consists of the following items:</Paragraph>
+        <Box
+          as="ul"
+          margin={{ top: '0' }}
+          pad={{ left: 'large' }}
+          style={{ listStyle: 'disc' }}
+        >
+          {metadataOnly ? (
+            <Li>Sample metadata from all projects</Li>
+          ) : (
+            <>
+              {fileItems.map((item) => (
+                <Li key={item}>{item}</Li>
+              ))}
+              <Li>Project and Sample Metadata</Li>
+            </>
+          )}
+        </Box>
+        {includeMerged && (
+          <Paragraph margin="0">
+            Samples are merged into 1 object per project
+          </Paragraph>
+        )}
+        {!metadataOnly && (
+          <Paragraph>
+            <Text margin={{ bottom: 'small' }} weight="bold">
+              Size: {formatBytes(dataset.size_in_bytes)}
+            </Text>
+          </Paragraph>
+        )}
+        <Paragraph margin={{ bottom: 'small', top: '0' }}>
+          Learn more about what you can expect in your download file{' '}
+          <Link label="here" href="#demo" />.
+        </Paragraph>
+        <Box align="start">
+          <Paragraph style={{ fontStyle: 'italic' }}>
+            If your download has not started, please ensure that pop-ups are not
+            blocked and try again using the button below:
+          </Paragraph>
+          <Button label="Try Again" aria-label="Try Again" />
+        </Box>
+      </Box>
+      <Box pad="medium">
+        <DownloadSVG width="100%" height="auto" />
+      </Box>
+    </Grid>
+  )
+}
+
+export default DatasetDownloadStarted

--- a/client/src/components/Modal.js
+++ b/client/src/components/Modal.js
@@ -6,7 +6,6 @@ import { useResponsive } from 'hooks/useResponsive'
 
 export const Modal = ({
   title,
-  titleNoBreakline = 'normal',
   showing,
   setShowing,
   nondismissable,
@@ -73,10 +72,7 @@ export const Modal = ({
                     pad={{ bottom: 'medium' }}
                     margin={{ bottom: '24px' }}
                   >
-                    <Text
-                      size="xlarge"
-                      style={{ whiteSpace: titleNoBreakline }}
-                    >
+                    <Text size="xlarge" style={{ whiteSpace: 'nowrap' }}>
                       {title}
                     </Text>
                   </Box>

--- a/client/src/components/Modal.js
+++ b/client/src/components/Modal.js
@@ -6,6 +6,7 @@ import { useResponsive } from 'hooks/useResponsive'
 
 export const Modal = ({
   title,
+  titleNoBreakline = 'normal',
   showing,
   setShowing,
   nondismissable,
@@ -72,7 +73,12 @@ export const Modal = ({
                     pad={{ bottom: 'medium' }}
                     margin={{ bottom: '24px' }}
                   >
-                    <Text size="xlarge">{title} </Text>
+                    <Text
+                      size="xlarge"
+                      style={{ whiteSpace: titleNoBreakline }}
+                    >
+                      {title}
+                    </Text>
                   </Box>
                 )}
                 {children}

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -4,11 +4,5 @@
   "github": {
     "autoAlias" : false,
     "silent" : true
-  },
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "yarn run build-storybook",
-  "devCommand": "yarn run storybook",
-  "installCommand": "yarn install",
-  "framework": null,
-  "outputDirectory": "./storybook-static"
+  }
 }

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -4,5 +4,11 @@
   "github": {
     "autoAlias" : false,
     "silent" : true
-  }
+  },
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "yarn run build-storybook",
+  "devCommand": "yarn run storybook",
+  "installCommand": "yarn install",
+  "framework": null,
+  "outputDirectory": "./storybook-static"
 }


### PR DESCRIPTION
## Issue Number

Closes #1178

## Purpose/Implementation Notes

Please see the latest Storybook [here](https://scpca-portal-kuphb1fs3-ccdl.vercel.app/?path=/story/components-datasetdownloadstarted--default).

I've implemented the `DatasetDownloadStarted` component and the corresponding Story using mock data.

Other changes include:
- Added a `titleNoBreakline` prop to the `Modal` component to prevent the modal `title` from wrapping

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
