### PR TITLE
Fix the legacy service error on Github workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,11 +7,11 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
-      - uses: pre-commit/action@v2.0.0
+          python-version: "3.10"
+      - uses: pre-commit/action@v3.0.1
 
   run-linters:
     name: Run linters
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -42,7 +42,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Touch .aws
         run: mkdir -p ~/.aws && touch ~/.aws/config
       - name: Set perms

--- a/api/scpca_portal/config/logging.py
+++ b/api/scpca_portal/config/logging.py
@@ -67,7 +67,7 @@ def log_runtime(logger):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            global LOG_RUNTIMES
+            global LOG_RUNTIMES  # noqa: F824
             if not LOG_RUNTIMES:
                 return func(*args, **kwargs)
 


### PR DESCRIPTION
## Issue Number

N/A

Related PR #1193

## Purpose/Implementation Notes

(resource) [actions/cache v1-v2 and actions/toolkit cache package closing down](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)

The initial error encountered when running the GitHub actions workflow in the related PR linked above:

```py
Error: getCacheEntry failed: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset
```

The following action versions were updated to address this legacy service:
- Updated `actions/checkout` to **v4** (not deprecated but update to the latest)
- Updated `pre-commit/action` to **v3.0.1** (which [uses `actions.cache@v4`](https://github.com/pre-commit/action/blob/main/action.yml))

After making these changes, the `flake8` failed due to the following line:

```py
 Flake8...................................................................Failed
- hook id: flake8
- exit code: 1

api/scpca_portal/config/logging.py:70:13: F824 `global LOG_RUNTIMES` is unused: name is never assigned in scope
```
To prevent this, I've temporarily excluded this line from the `flake8` check rather than modifying the file.

Please let me know if you have any other suggestions for resolving this issue. Thank you!

## Types of changes


<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
