### PR TITLE
1200 - Add terminate_batch_jobs Management Command for retrying terminated jobs

### DIFF
--- a/api/scpca_portal/management/commands/terminate_batch_jobs.py
+++ b/api/scpca_portal/management/commands/terminate_batch_jobs.py
@@ -1,0 +1,40 @@
+import logging
+from argparse import BooleanOptionalAction
+
+from django.core.management.base import BaseCommand
+
+from scpca_portal.models import Job
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
+
+
+class Command(BaseCommand):
+    help = """Terminates all submitted, incomplete jobs on AWS Batch,
+    and creates new retry jobs if the no_retry flag is set to False.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("--no-retry", action=BooleanOptionalAction, type=bool, default=True)
+
+    def handle(self, *args, **kwargs):
+        self.terminate_batch_jobs(**kwargs)
+
+    def terminate_batch_jobs(self, no_retry: bool = False, **kwargs):
+        logger.info("Terminating jobs on AWS Batch...")
+        terminated_jobs = Job.terminate_submitted()
+
+        if not no_retry:
+            logger.info("Creating new retry jobs...")
+            retry_jobs = Job.create_terminated_retry_jobs(terminated_jobs)
+
+            if retry_jobs:
+                logger.info("Successfully created new retry jobs.")
+            else:
+                logger.info("No retry jobs were created.")
+
+        if terminated_jobs:
+            logger.info("Successfully terminated jobs on AWS Batch!")
+        else:
+            logger.info("No jobs were terminated on AWS Batch.")

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -302,6 +302,7 @@ class TestJob(TestCase):
         self.assertEqual(saved_job.state, JobStates.TERMINATED)
         self.assertTrue(saved_job.retry_on_termination)
         self.assertIsInstance(saved_job.terminated_at, datetime)
+        self.assertDatasetState(saved_job.dataset, is_processing=False)
 
     @patch("scpca_portal.batch.terminate_job")
     def test_terminate_job_failure(self, mock_batch_terminate_job):


### PR DESCRIPTION
## Issue Number

Closes #1200
## Purpose/Implementation Notes

I've implemented the `terminate_batch_jobs` management command and added the corresponding test, `TestTerminateBatchJobs`. 

Additionally, I updated the `Job::create_terminated_retry_jobs` method to accept a list of terminated jobs (instead of querying internally). I also added logic to update the associated datasets in both `Job::terminate_submitted` and `Job::terminate` when submitted jobs are terminated, and adjusted the existing tests accordingly.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

Updated:
- `TestJob::test_terminate_job`
- `TestJob::test_terminate_job_failure`
- `TestJob::test_terminate_submitted`
- `TestJob::test_terminate_submitted_failure`
- `TestJob::test_terminate_submitted_no_termination`
- `TestJob::assert_dataset` (a new helper method for `job.dataset` assertions)

Newly Added:
- `TestTerminateBatchJobs`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
