### PR TITLE
destroy with init

### DIFF
--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -198,11 +198,7 @@ if __name__ == "__main__":
     # get environ to inject into terraform commands
     env = get_env(vars(args))
 
-    if args.destroy:
-        terraform.init()
-        terraform.destroy(args.stage, args.user)
-
-    if not args.skip_docker:
+    if not args.skip_docker or args.destroy:
         docker_code = docker.build_and_push_docker_image(
             f"{args.dockerhub_account}/scpca_portal_api",
             f"--build-arg SYSTEM_VERSION={args.system_version}",
@@ -226,6 +222,11 @@ if __name__ == "__main__":
             f"key={args.user}-{args.stage}.tfstate",
             "use_lockfile=true",
         ]
+
+    if args.destroy:
+        terraform.init()
+        terraform.destroy(args.stage, backend_configs)
+        exit(1)
 
     init_code = terraform.init(backend_configs)
 

--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
     # get environ to inject into terraform commands
     env = get_env(vars(args))
 
-    if not args.skip_docker or args.destroy:
+    if not args.skip_docker and not args.destroy:
         docker_code = docker.build_and_push_docker_image(
             f"{args.dockerhub_account}/scpca_portal_api",
             f"--build-arg SYSTEM_VERSION={args.system_version}",

--- a/infrastructure/deploy_modules/terraform.py
+++ b/infrastructure/deploy_modules/terraform.py
@@ -84,9 +84,9 @@ def apply(var_file_arg, taints=[], env=os.environ.copy(), print_output=True):
     return process.returncode, merged_output
 
 
-def destroy(stage, user):
+def destroy(stage, backend_configs=[]):
     # init terrafrom first
-    init()
+    init(backend_configs)
 
     # locally defined defaults
     var_file_arg = f"-var-file=tf_vars/{stage}.tfvars"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- When destroying an instance that doesnt have local .terraform, we need to be initialize the backend with backend_config args.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
