### PR TITLE
share args and backend_configs and init

### DIFF
--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -223,19 +223,20 @@ if __name__ == "__main__":
             "use_lockfile=true",
         ]
 
-    if args.destroy:
-        terraform.init()
-        terraform.destroy(args.stage, backend_configs)
-        exit(1)
-
+    # Always init first
     init_code = terraform.init(backend_configs)
 
     if init_code != 0:
         exit(init_code)
 
-    terraform_code, terraform_output = terraform.apply(
-        f"-var-file=tf_vars/{args.stage}.tfvars", taints=TAINT_ON_APPLY, env=env
-    )
+    # Shared for destroy and apply
+    var_file_arg = f"-var-file=tf_vars/{args.stage}.tfvars"
+
+    if args.destroy:
+        terraform.destroy(var_file_arg)
+        exit(1)
+
+    terraform_code, terraform_output = terraform.apply(var_file_arg, taints=TAINT_ON_APPLY, env=env)
 
     if terraform_code != 0:
         exit(terraform_code)

--- a/infrastructure/deploy_modules/terraform.py
+++ b/infrastructure/deploy_modules/terraform.py
@@ -84,13 +84,7 @@ def apply(var_file_arg, taints=[], env=os.environ.copy(), print_output=True):
     return process.returncode, merged_output
 
 
-def destroy(stage, backend_configs=[]):
-    # init terrafrom first
-    init(backend_configs)
-
-    # locally defined defaults
-    var_file_arg = f"-var-file=tf_vars/{stage}.tfvars"
-
+def destroy(var_file_arg):
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
         terraform_process = subprocess.Popen(


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- removed redundant init code
- passes in tf_file_arg variable to both destroy and apply
- only init once but for any terraform action

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
