### PR TITLE
deploy docker stdin password

### DIFF
--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -36,11 +36,6 @@ jobs:
         with:
           terraform_version: 1.11.4
 
-      - name: Destroy Legacy
-        run: cd infrastructure && python3 deploy.py -s staging -u deployer -a ccdlstaging -v $(git rev-parse HEAD) --destroy
-        env:
-          SENTRY_ENV: staging-api
-
       - name: Deploy
         run: cd infrastructure && python3 deploy.py -s staging -u deployer -a ccdlstaging -v $(git rev-parse HEAD) --project
         env:


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- Removes Destroy Legacy (successfully taken down already)
- `subprocess.check_call` needs `shell=True` to take password via stdin / pipe

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A Local login worked via sportal

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
