### PR TITLE
fix job get project sample job

### DIFF
--- a/api/scpca_portal/batch.py
+++ b/api/scpca_portal/batch.py
@@ -30,7 +30,7 @@ def submit_job(job) -> str | None:
         )
     except Exception as error:
         logger.exception(
-            f"Failed to terminate the job due to: \n\t{error}",
+            f"Failed to submit the job due to: \n\t{error}",
             job_id=job.pk,
             batch_job_id=job.batch_job_id,
         )

--- a/api/scpca_portal/management/commands/dispatch_to_batch.py
+++ b/api/scpca_portal/management/commands/dispatch_to_batch.py
@@ -2,18 +2,11 @@ import logging
 from argparse import BooleanOptionalAction
 from collections import Counter
 
-from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template.defaultfilters import pluralize
 
-import boto3
-
 from scpca_portal.models import Job, Project
 
-batch = boto3.client(
-    "batch",
-    region_name=settings.AWS_REGION,
-)
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler())

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -117,24 +117,25 @@ class Job(TimestampedModel):
         """
 
         batch_job_name = f"{project_id}-{download_config_name}"
-        notify_flag = "--notify" if notify else ""
+
+        command = [
+            "python",
+            "manage.py",
+            "generate_computed_file",
+            "--project-id",
+            project_id,
+            "--download-config-name",
+            download_config_name,
+        ]
+
+        if notify:
+            command.extend(["--notify"])
 
         return cls(
             batch_job_name=batch_job_name,
             batch_job_queue=settings.AWS_BATCH_JOB_QUEUE_NAME,
             batch_job_definition=settings.AWS_BATCH_JOB_DEFINITION_NAME,
-            batch_container_overrides={
-                "command": [
-                    "python",
-                    "manage.py",
-                    "generate_computed_file",
-                    "--project-id",
-                    project_id,
-                    "--download-config-name",
-                    download_config_name,
-                    notify_flag,
-                ],
-            },
+            batch_container_overrides={"command": command},
         )
 
     @classmethod
@@ -149,23 +150,26 @@ class Job(TimestampedModel):
         """
 
         batch_job_name = f"{sample_id}-{download_config_name}"
-        notify_flag = "--notify" if notify else ""
+
+        command = [
+            "python",
+            "manage.py",
+            "generate_computed_file",
+            "--sample-id",
+            sample_id,
+            "--download-config-name",
+            download_config_name,
+        ]
+
+        if notify:
+            command.extend("--notify")
 
         return cls(
             batch_job_name=batch_job_name,
             batch_job_queue=settings.AWS_BATCH_JOB_QUEUE_NAME,
             batch_job_definition=settings.AWS_BATCH_JOB_DEFINITION_NAME,
             batch_container_overrides={
-                "command": [
-                    "python",
-                    "manage.py",
-                    "generate_computed_file",
-                    "--sample-id",
-                    sample_id,
-                    "--download-config-name",
-                    download_config_name,
-                    notify_flag,
-                ],
+                "command": command,
             },
         )
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Jobs weren't able to be dispatched because of an extra empty string in the `batch.submit_job` `containerOverrides` `command` argument which AWS threw a fit over. This PR does the following.

- adds `--notify`  by extending the command list
- removes extraneous batch client from `dispatch_to_batch` management command
- fixes a copy paste typo from the submit job output when an error happens

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Dev Stack

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/a
