### PR TITLE
1226 - Add Hashes and Uncompressed Size to Stats Property

### DIFF
--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -107,7 +107,7 @@ class Dataset(TimestampedModel):
             "current_data_hash": self.current_data_hash,
             "current_readme_hash": self.current_readme_hash,
             "current_metadata_hash": self.current_metadata_hash,
-            "is_hash_changed": self.combined_hash == self.current_combined_hash,
+            "is_hash_changed": self.combined_hash != self.current_combined_hash,
             "uncompressed_size": self.estimated_size_in_bytes,
         }
 
@@ -417,15 +417,18 @@ class Dataset(TimestampedModel):
         return hashlib.md5(readme_file_contents_bytes).hexdigest()
 
     @property
-    def combined_hash(self) -> str:
+    def combined_hash(self) -> str | None:
         """
         Combines, computes and returns the combined cached data, metadata and readme hashes.
         """
+        # Return None if hashes have not been calculated yet
+        if not (self.data_hash and self.metadata_hash and self.readme_hash):
+            return None
         concat_hash = self.data_hash + self.metadata_hash + self.readme_hash
         return hashlib.md5(concat_hash.encode("utf-8")).hexdigest()
 
     @property
-    def current_combined_hash(self) -> str:
+    def current_combined_hash(self) -> str | None:
         """
         Combines, computes and returns the combined current data, metadata and readme hashes.
         """

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -97,6 +97,20 @@ class Dataset(TimestampedModel):
     def __str__(self):
         return f"Dataset {self.id}"
 
+    @property
+    def uncompressed_size(self) -> str:
+        pass
+
+    @property
+    def stats(self) -> Dict:
+        return {
+            "current_data_hash": self.current_data_hash,
+            "current_readme_hash": self.current_readme_hash,
+            "current_metadata_hash": self.current_metadata_hash,
+            "is_hash_changed": self.combined_hash == self.current_combined_hash,
+            "uncompressed_size": self.uncompressed_size,
+        }
+
     @classmethod
     def get_or_find_ccdl_dataset(
         cls, ccdl_name: CCDLDatasetNames, project_id: str | None = None

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -10,7 +10,7 @@ from django.utils.timezone import make_aware
 
 from typing_extensions import Self
 
-from scpca_portal import ccdl_datasets, common, metadata_file, readme_file
+from scpca_portal import ccdl_datasets, common, metadata_file, readme_file, utils
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.enums import (
     CCDLDatasetNames,
@@ -99,8 +99,8 @@ class Dataset(TimestampedModel):
 
     @property
     def uncompressed_size(self) -> str:
-        file_size_sum = sum(of.size_in_bytes for of in self.original_files)
-        return f"{file_size_sum}GB"
+        file_size_in_bytes = sum(of.size_in_bytes for of in self.original_files)
+        return f"{utils.convert_bytes_to_gb(file_size_in_bytes):.2f}GB"
 
     @property
     def stats(self) -> Dict:

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -10,7 +10,7 @@ from django.utils.timezone import make_aware
 
 from typing_extensions import Self
 
-from scpca_portal import ccdl_datasets, common, metadata_file, readme_file, utils
+from scpca_portal import ccdl_datasets, common, metadata_file, readme_file
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.enums import (
     CCDLDatasetNames,
@@ -98,9 +98,8 @@ class Dataset(TimestampedModel):
         return f"Dataset {self.id}"
 
     @property
-    def uncompressed_size(self) -> str:
-        file_size_in_bytes = sum(of.size_in_bytes for of in self.original_files)
-        return f"{utils.convert_bytes_to_gb(file_size_in_bytes):.2f}GB"
+    def estimated_size_in_bytes(self) -> int:
+        return self.original_files.aggregate(models.Sum("size_in_bytes")).get("size_in_bytes__sum")
 
     @property
     def stats(self) -> Dict:
@@ -109,7 +108,7 @@ class Dataset(TimestampedModel):
             "current_readme_hash": self.current_readme_hash,
             "current_metadata_hash": self.current_metadata_hash,
             "is_hash_changed": self.combined_hash == self.current_combined_hash,
-            "uncompressed_size": self.uncompressed_size,
+            "uncompressed_size": self.estimated_size_in_bytes,
         }
 
     @classmethod

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -99,7 +99,8 @@ class Dataset(TimestampedModel):
 
     @property
     def uncompressed_size(self) -> str:
-        pass
+        file_size_sum = sum(of.size_in_bytes for of in self.original_files)
+        return f"{file_size_sum}GB"
 
     @property
     def stats(self) -> Dict:

--- a/api/scpca_portal/serializers.py
+++ b/api/scpca_portal/serializers.py
@@ -198,6 +198,7 @@ class DatasetSerializer(serializers.ModelSerializer):
             "email",
             "start",
             "format",
+            "stats",
             "data_hash",
             "metadata_hash",
             "readme_hash",
@@ -234,6 +235,7 @@ class DatasetCreateSerializer(serializers.ModelSerializer):
             "format",
             "start",
             "id",
+            "stats",
             "data_hash",
             "metadata_hash",
             "readme_hash",
@@ -257,6 +259,7 @@ class DatasetCreateSerializer(serializers.ModelSerializer):
         )
         read_only_fields = (
             "id",
+            "stats",
             "data_hash",
             "metadata_hash",
             "readme_hash",
@@ -289,6 +292,7 @@ class DatasetUpdateSerializer(serializers.ModelSerializer):
             "start",
             "id",
             "format",
+            "stats",
             "data_hash",
             "metadata_hash",
             "readme_hash",
@@ -313,6 +317,7 @@ class DatasetUpdateSerializer(serializers.ModelSerializer):
         read_only_fields = (
             "id",
             "format",
+            "stats",
             "data_hash",
             "metadata_hash",
             "readme_hash",

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase, tag
 
-from scpca_portal import loader, utils
+from scpca_portal import loader
 from scpca_portal.enums import CCDLDatasetNames, DatasetFormats, Modalities
 from scpca_portal.models import Dataset, OriginalFile
 from scpca_portal.test import expected_values as test_data
@@ -533,7 +533,7 @@ class TestDataset(TestCase):
         expected_readme_hash = "93ce0b3571f15cd41db81d9e25dcb873"
         self.assertEqual(dataset.current_readme_hash, expected_readme_hash)
 
-    def test_uncompressed_size(self):
+    def estimated_size_in_bytes(self):
         data = {
             "SCPCP999990": {
                 "merge_single_cell": False,
@@ -565,7 +565,4 @@ class TestDataset(TestCase):
 
             expected_file_size += original_file.size_in_bytes
 
-        expected_file_size_in_gb_formatted = (
-            f"{utils.convert_bytes_to_gb(expected_file_size):.2f}GB"
-        )
-        self.assertEqual(dataset.uncompressed_size, expected_file_size_in_gb_formatted)
+        self.assertEqual(dataset.estimated_size_in_bytes, expected_file_size)

--- a/api/scpca_portal/test/utils/test_helpers.py
+++ b/api/scpca_portal/test/utils/test_helpers.py
@@ -235,3 +235,9 @@ class TestPathReplace(TestCase):
         expected_folder_count = 3
         actual_folder_count = str(new_path).count(new_value)
         self.assertEqual(actual_folder_count, expected_folder_count)
+
+
+class TestConvertBytesToGB(TestCase):
+    def test_conversion_successful(self):
+        size_in_bytes = 1234567890
+        self.assertEqual(utils.convert_bytes_to_gb(size_in_bytes), 1.23456789)

--- a/api/scpca_portal/test/views/test_dataset.py
+++ b/api/scpca_portal/test/views/test_dataset.py
@@ -88,3 +88,17 @@ class DatasetsTestCase(APITestCase):
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_stats_property_keys(self):
+        url = reverse("datasets-detail", args=[self.ccdl_dataset.id])
+        response = self.client.get(url)
+        stats_property = response.json().get("stats")
+        stats_property_fields = {
+            "current_data_hash",
+            "current_readme_hash",
+            "current_metadata_hash",
+            "is_hash_changed",
+            "uncompressed_size",
+        }
+        for field in stats_property_fields:
+            self.assertIn(field, stats_property)

--- a/api/scpca_portal/utils/helpers.py
+++ b/api/scpca_portal/utils/helpers.py
@@ -150,3 +150,8 @@ def find_first_contained(value: Any, containers: Iterable[Iterable[Any]]) -> Ite
 def path_replace(path: Path, old_value: str, new_value: str) -> Path:
     """Return path with all occurrences of old_value replaced with new_value."""
     return Path(str(path).replace(old_value, new_value))
+
+
+def convert_bytes_to_gb(size_in_bytes: int) -> float:
+    """Return a number in bytes its equivalent value in gigabytes."""
+    return size_in_bytes / 1000000000


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1226

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR begins the implementation of the stats property. 

Five fields have been added in this PR:
- `current_data_hash`
- `current_readme_hash`
- `current_metadata_hash`
- `is_hash_changed`
- `uncompressed_size`

The remaining fields will be added in subsequent PRs.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- New feature (non-breaking change which adds functionality)

## Functional tests

- `test_dataset::test_uncompressed_size`
- `test_utils::TestConvertBytesToGB::test_converstion_successful`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots