### PR TITLE
fix exit code on test failure

### DIFF
--- a/api/run_tests.sh
+++ b/api/run_tests.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
 
 python wait_for_postgres.py
 export AWS_DEFAULT_REGION=us-east-1


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

@avrohomgottlieb discovered that the exit code was zero when tests were failing.

This PR removes the `-e` option from the  hashbang and explicitly sets it at the top of the script which seems to actually set the option.

This PR sets 

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

updated a test to explicitly fail and checked the return code

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
