### PR TITLE
1217 - Improve error message for missing OriginalFile in load_metadata management command

### DIFF
--- a/api/scpca_portal/management/commands/load_metadata.py
+++ b/api/scpca_portal/management/commands/load_metadata.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from scpca_portal import common, loader
+from scpca_portal.models import OriginalFile
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -62,6 +63,11 @@ class Command(BaseCommand):
         **kwargs,
     ) -> None:
         """Loads metadata from input metadata files on s3 and creates model objects in the db."""
+        if not OriginalFile.objects.exists():
+            raise Exception(
+                "OriginalFile table is empty. Run 'sync_original_files' first to populate it."
+            )
+
         loader.prep_data_dirs()
 
         for project_metadata in loader.get_projects_metadata(scpca_project_id):

--- a/api/scpca_portal/test/management/commands/test_load_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_load_metadata.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 
 from scpca_portal import common
 from scpca_portal.models import Project
+from scpca_portal.test.factories import OriginalFileFactory
 
 
 class TestLoadMetadata(TestCase):
@@ -45,6 +46,9 @@ class TestLoadMetadata(TestCase):
         self.mock_get_projects_metadata.return_value = self.projects_metadata
         self.project = Project()
         self.mock_create_project.return_value = self.project
+
+        # Populate OriginalFile
+        OriginalFileFactory()
 
     def tearDown(self):
         for p in self.patches:

--- a/api/scpca_portal/test/management/commands/test_load_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_load_metadata.py
@@ -47,7 +47,7 @@ class TestLoadMetadata(TestCase):
         self.project = Project()
         self.mock_create_project.return_value = self.project
 
-        # Populate OriginalFile
+        # Populate OriginalFile to prevent exception when calling load_metadata
         OriginalFileFactory()
 
     def tearDown(self):


### PR DESCRIPTION
## Issue Number

Closes #1217

## Purpose/Implementation Notes

I've added a check to the `load_metadata` management command to verify that the `original_files` table has been populated. If it's empty, an error is raised with an instructive message to run the `sync_original_files` management command first.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

- Updated `test_load_metadata`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
