### PR TITLE
Remove dataset endpoint for prod envs

### DIFF
--- a/api/scpca_portal/urls.py
+++ b/api/scpca_portal/urls.py
@@ -48,12 +48,15 @@ router = ExtendedDefaultRouter()
 router.trailing_slash = "/?"
 
 router.register(r"computed-files", ComputedFileViewSet, basename="computed-files")
-router.register(r"datasets", DatasetViewSet, basename="datasets")
 router.register(r"projects", ProjectViewSet, basename="projects")
 router.register(r"samples", SampleViewSet, basename="samples")
 router.register(r"tokens", APITokenViewSet, basename="tokens")
 router.register(r"project-options", FilterOptionsViewSet, basename="project-options")
 router.register(r"stats", StatsViewSet, basename="stats")
+
+# Datasets are not ready for prime time yet.
+if not settings.PRODUCTION:
+    router.register(r"datasets", DatasetViewSet, basename="datasets")
 
 urlpatterns = [
     path(


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We dont want to expose the dataset endpoint on prod yet.

This change will remove it on staging and dev environments as well. If you need access to it in a dev environment just comment it out until we have a better mechanism in place that only removes it on the deployer production environment.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
