### PR TITLE
1263 - Resolve invalid seq_unit and technology combinations in summaries_counts

### DIFF
--- a/api/scpca_portal/models/project_summary.py
+++ b/api/scpca_portal/models/project_summary.py
@@ -6,9 +6,10 @@ from scpca_portal.models.base import TimestampedModel
 class ProjectSummary(TimestampedModel):
     """One of multiple summaries of a project.
 
-    There will be one of these per combination of `diagnosis`,
-    `seq_unit`, and `technology`. `sample_count` denotes how many
-    samples in the project have those values. For example:
+    There will be one of these per project samples `diagnosis`,
+    each sample's libraries `seq_unit` and `technology`.
+    `sample_count` denotes how many samples in the project have those values.
+    For example:
         diagnosis=AML
         seq_unit=cell
         technology=10Xv2_5prime

--- a/api/scpca_portal/test/expected_values/project_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999990.py
@@ -41,8 +41,8 @@ class Project_SCPCP999990:
         "s3_input_bucket": settings.AWS_S3_INPUT_BUCKET_NAME,
         "sample_count": 4,
         "scpca_id": SCPCA_ID,
-        "seq_units": "cell, spot",
-        "technologies": "10Xv3, visium",
+        "seq_units": "bulk, cell, spot",
+        "technologies": "10Xv3, paired_end, visium",
         "title": "TBD",
         "unavailable_samples_count": 1,
     }

--- a/api/scpca_portal/test/expected_values/project_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/project_SCPCP999990.py
@@ -41,8 +41,8 @@ class Project_SCPCP999990:
         "s3_input_bucket": settings.AWS_S3_INPUT_BUCKET_NAME,
         "sample_count": 4,
         "scpca_id": SCPCA_ID,
-        "seq_units": "bulk, cell, spot",
-        "technologies": "10Xv3, paired_end, visium",
+        "seq_units": "cell, spot",
+        "technologies": "10Xv3, visium",
         "title": "TBD",
         "unavailable_samples_count": 1,
     }

--- a/api/scpca_portal/test/views/test_filter_options.py
+++ b/api/scpca_portal/test/views/test_filter_options.py
@@ -28,5 +28,5 @@ class FilterOptionsTestCase(APITestCase):
         response = response.json()
         self.assertEqual(len(response["diagnoses"]), 2)
         self.assertEqual(len(response["modalities"]), 1)  # CITE-seq only.
-        self.assertEqual(len(response["seq_units"]), 2)
-        self.assertEqual(len(response["technologies"]), 5)
+        self.assertEqual(len(response["seq_units"]), 1)
+        self.assertEqual(len(response["technologies"]), 3)


### PR DESCRIPTION
## Issue Number

Closes #1263

## Purpose/Implementation Notes

I've resolved the generation of invalid `seq_unit` and `technology` combinations for `summaries_counts`. 

Changes include:
- In `Project::update_project_aggregate_properties`, iterate through the libraries per sample to get each library's `seq_unit` and `technology` pair to:
  - populate `summaries_counts`
  - aggregate `seq_units` and `technologies` per project 
- Adjusted for the assertions for `seq_units` and `technologies` in `test.views.test_filter_options.FilterOptionsTestCase`
- Updated the docstring of the`ProjectSummary` model to reflect the changes


## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

Updated:
- `test.views.test_filter_options.FilterOptionsTestCase`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
