### PR TITLE
create before destroy

### DIFF
--- a/infrastructure/batch/compute_environment.tf
+++ b/infrastructure/batch/compute_environment.tf
@@ -14,6 +14,10 @@ resource "aws_batch_compute_environment" "scpca_portal_fargate" {
 
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   service_role = aws_iam_role.batch_service_role.arn
   type         = "MANAGED"
   depends_on   = [aws_iam_role_policy_attachment.batch_service_role]
@@ -48,6 +52,10 @@ resource "aws_batch_compute_environment" "scpca_portal_ec2" {
       version = "$Latest"
     }
 
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   service_role = aws_iam_role.batch_service_role.arn


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Encountering error with updating existing batch compute environments.
While trying to change the name of an old batch pipeline.

Error:
- `operation error Batch: DeleteComputeEnvironment`
- `ClientException: Cannot delete, found existing JobQueue relationship.`


Based on this comment: https://github.com/hashicorp/terraform-provider-aws/issues/13221#issuecomment-1692094916

This PR adds `create_before_destroy` to the batch compute environment resources in terraform.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
