### PR TITLE
staging deploy compute environment

### DIFF
--- a/infrastructure/batch/compute_environment.tf
+++ b/infrastructure/batch/compute_environment.tf
@@ -26,7 +26,9 @@ resource "aws_batch_compute_environment" "scpca_portal_fargate" {
 }
 
 resource "aws_batch_compute_environment" "scpca_portal_ec2" {
-  compute_environment_name = "scpca-portal-ec2-compute-${var.user}-${var.stage}"
+  # Prefix to avoid error on deploy.
+  # ClientException: Cannot delete, found existing JobQueue relationship.
+  compute_environment_name_prefix = "scpca-portal-ec2-compute-${var.user}-${var.stage}"
 
   compute_resources {
     type = "EC2"

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -62,11 +62,11 @@ resource "aws_s3_bucket_acl" "scpca_portal_cert_bucket" {
   bucket = aws_s3_bucket.scpca_portal_cert_bucket.id
   rule {
     id = "auto-delete-after-30-days-${var.user}-${var.stage}"
+    filter {}
     status = "Enabled"
     abort_incomplete_multipart_upload {
       days_after_initiation = 1
     }
-
     expiration {
       days = 30
     }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This PR fixes 2 issues with terraform:

When redeploying the ec2 compute environment AWS and terraform encountered an error.
`ClientException: Cannot delete, found existing JobQueue relationship.`

This can be resolved by setting a `create_before_destroy` lifecycle rule on the compute environment.
However, this will cause the following error:
`ClientException: Object already exists.`

This can be resolved by using `compute_environment_name_prefix` instead of just `compute_environment_name`.

Additionally, this PR resolves a warning that was related to a change in how s3 lifecycle configurations require a filter to be defined. So an empty one was added to stop that warning.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A Many local deployments to test.

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
