### PR TITLE
1286 - Change Single Cell Merged Datatype

### DIFF
--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -183,7 +183,7 @@ class Dataset(TimestampedModel):
                 Modalities.SINGLE_CELL: (
                     list(single_cell_samples.values_list("scpca_id", flat=True))
                     if not self.ccdl_type.get("includes_merged")
-                    else ["MERGED"]
+                    else "MERGED"
                 ),
                 Modalities.SPATIAL: list(spatial_samples.values_list("scpca_id", flat=True)),
             }
@@ -329,7 +329,7 @@ class Dataset(TimestampedModel):
         return data_validator.is_valid
 
     def get_is_merged_project(self, project_id) -> bool:
-        return self.data.get(project_id, {}).get(Modalities.SINGLE_CELL.value) == ["MERGED"]
+        return self.data.get(project_id, {}).get(Modalities.SINGLE_CELL.value) == "MERGED"
 
     @property
     def original_files(self) -> Iterable[OriginalFile]:
@@ -599,7 +599,7 @@ class DataValidator:
 
     def _validate_single_cell(self, project_id) -> bool:
         if value := self.data.get(project_id, {}).get(DatasetDataProjectConfig.SINGLE_CELL):
-            if value == ["MERGED"]:
+            if value == "MERGED":
                 return True
             return self._validate_modality(value)
 

--- a/api/scpca_portal/test/expected_values/dataset_custom_single_cell_experiment.py
+++ b/api/scpca_portal/test/expected_values/dataset_custom_single_cell_experiment.py
@@ -16,7 +16,7 @@ class DatasetCustomSingleCellExperiment:
             },
             "SCPCP999992": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL: ["MERGED"],
+                Modalities.SINGLE_CELL: "MERGED",
                 Modalities.SPATIAL: [],
             },
         },

--- a/api/scpca_portal/test/expected_values/dataset_single_cell_ann_data_merged.py
+++ b/api/scpca_portal/test/expected_values/dataset_single_cell_ann_data_merged.py
@@ -7,17 +7,17 @@ class DatasetSingleCellAnndataMerged:
         "data": {
             "SCPCP999990": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             },
             "SCPCP999991": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             },
             "SCPCP999992": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             },
         },

--- a/api/scpca_portal/test/expected_values/dataset_single_cell_ann_data_merged_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/dataset_single_cell_ann_data_merged_SCPCP999990.py
@@ -8,7 +8,7 @@ class DatasetSingleCellAnndataMergedSCPCP999990:
         "data": {
             PROJECT_ID: {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             }
         },

--- a/api/scpca_portal/test/expected_values/dataset_single_cell_single_cell_experiment_merged.py
+++ b/api/scpca_portal/test/expected_values/dataset_single_cell_single_cell_experiment_merged.py
@@ -7,17 +7,17 @@ class DatasetSingleCellSingleCellExperimentMerged:
         "data": {
             "SCPCP999990": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             },
             "SCPCP999991": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             },
             "SCPCP999992": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             },
         },

--- a/api/scpca_portal/test/expected_values/dataset_single_cell_single_cell_experiment_merged_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/dataset_single_cell_single_cell_experiment_merged_SCPCP999990.py
@@ -8,7 +8,7 @@ class DatasetSingleCellSingleCellExperimentMergedSCPCP999990:
         "data": {
             PROJECT_ID: {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             }
         },

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -125,7 +125,7 @@ class TestGetFile(TestCase):
             },
             "SCPCP999992": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: ["MERGED"],
+                Modalities.SINGLE_CELL.value: "MERGED",
                 Modalities.SPATIAL.value: [],
             },
         }

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -136,7 +136,7 @@ class TestDataset(TestCase):
         data = {
             "SCPCP999990": {
                 "includes_bulk": True,
-                Modalities.SINGLE_CELL.value: "MERGED",  # should be ["MERGED"]
+                Modalities.SINGLE_CELL.value: ["MERGED"],  # should be "MERGED"
                 Modalities.SPATIAL.value: ["SCPCS999992"],
             },
         }
@@ -310,7 +310,7 @@ class TestDataset(TestCase):
         data = {
             "SCPCP999990": {
                 "includes_bulk": False,
-                Modalities.SINGLE_CELL: ["MERGED"],
+                Modalities.SINGLE_CELL: "MERGED",
                 Modalities.SPATIAL: [],
             },
         }
@@ -330,7 +330,7 @@ class TestDataset(TestCase):
         data = {
             "SCPCP999990": {
                 "includes_bulk": False,
-                Modalities.SINGLE_CELL: ["MERGED"],
+                Modalities.SINGLE_CELL: "MERGED",
                 Modalities.SPATIAL: [],
             },
         }
@@ -415,7 +415,7 @@ class TestDataset(TestCase):
             },
             "SCPCP999992": {
                 "includes_bulk": False,
-                Modalities.SINGLE_CELL: ["MERGED"],
+                Modalities.SINGLE_CELL: "MERGED",
                 Modalities.SPATIAL: [],
             },
         }


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1286.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

In this PR, the merged single cell data attribute field directive is changed from an array of `["MERGED"]` to a string value of `"MERGED"`. Changes are made to the `DataValidator` class and during dataset instance instantiation, and corroborated in expected values files for testing.


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A