### PR TITLE
dataset remove metadata files

### DIFF
--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -344,6 +344,10 @@ class Dataset(TimestampedModel):
     def original_files(self) -> Iterable[OriginalFile]:
         """Returns all of a Dataset's associated OriginalFiles."""
         files = OriginalFile.objects.none()
+
+        if self.format == DatasetFormats.METADATA:
+            return files
+
         for project_id, project_config in self.data.items():
             # add spatial files
             files |= OriginalFile.downloadable_objects.filter(


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Fixes an issue where we were including supplementary files with metadata only downloads.

Also, improves estimates file size by including the readme and metadata object sizes which now prevents us from having file size estimates of `0` bytes.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A tested locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
