### PR TITLE
1285 - Add format bytes utils function

### DIFF
--- a/api/scpca_portal/test/utils/test_helpers.py
+++ b/api/scpca_portal/test/utils/test_helpers.py
@@ -237,15 +237,7 @@ class TestPathReplace(TestCase):
         self.assertEqual(actual_folder_count, expected_folder_count)
 
 
-class TestByteConversions(TestCase):
-    def test_convert_bytes_to_gb(self):
-        size_in_bytes = 1234567890
-        self.assertEqual(utils.convert_bytes_to_gb(size_in_bytes), 1.23456789)
-
-    def test_convert_gb_to_bytes(self):
-        size_in_bytes = 1.23456789
-        self.assertEqual(utils.convert_bytes_to_gb(size_in_bytes), 1234567890)
-
+class TestByteConversion(TestCase):
     def test_format_bytes(self):
         # assert round down formatted property
         size_in_bytes = 1234567890

--- a/api/scpca_portal/test/utils/test_helpers.py
+++ b/api/scpca_portal/test/utils/test_helpers.py
@@ -239,10 +239,23 @@ class TestPathReplace(TestCase):
 
 class TestByteConversion(TestCase):
     def test_format_bytes(self):
-        # assert round down formatted property
+        # assert gb formatted correctly
         size_in_bytes = 1234567890
-        self.assertEqual(utils.format_bytes(size_in_bytes), "1.23 GB")
+        self.assertEqual(utils.format_bytes(size_in_bytes), "1.15 GB")
 
-        # assert round up formatted properly
-        size_in_bytes = 9876543210
-        self.assertEqual(utils.format_bytes(size_in_bytes), "9.88 GB")
+        # assert mb formatted correctly
+        size_in_bytes = 12345678
+        self.assertEqual(utils.format_bytes(size_in_bytes), "11.77 MB")
+
+        # assert kb formatted correctly
+        size_in_bytes = 123456
+        self.assertEqual(utils.format_bytes(size_in_bytes), "120.56 KB")
+
+        # assert bytes formatted correctly
+        size_in_bytes = 123
+        self.assertEqual(utils.format_bytes(size_in_bytes), "123 Bytes")
+
+        # assert invalid size_in_bytes throws exception
+        size_in_bytes = -10
+        with self.assertRaises(ValueError):
+            utils.format_bytes(size_in_bytes)

--- a/api/scpca_portal/test/utils/test_helpers.py
+++ b/api/scpca_portal/test/utils/test_helpers.py
@@ -245,3 +245,12 @@ class TestByteConversions(TestCase):
     def test_convert_gb_to_bytes(self):
         size_in_bytes = 1.23456789
         self.assertEqual(utils.convert_bytes_to_gb(size_in_bytes), 1234567890)
+
+    def test_format_bytes(self):
+        # assert round down formatted property
+        size_in_bytes = 1234567890
+        self.assertEqual(utils.format_bytes(size_in_bytes), "1.23 GB")
+
+        # assert round up formatted properly
+        size_in_bytes = 9876543210
+        self.assertEqual(utils.format_bytes(size_in_bytes), "9.88 GB")

--- a/api/scpca_portal/utils/helpers.py
+++ b/api/scpca_portal/utils/helpers.py
@@ -156,13 +156,3 @@ def format_bytes(size_in_bytes: int) -> str:
     """Return a formatted string of the passed value converted from bytes to gb."""
     converted_value = float(size_in_bytes / 1000000000)
     return f"{round(converted_value, 2)} GB"
-
-
-def convert_bytes_to_gb(size_in_bytes: int | float) -> float:
-    """Return the converted value in gb for a number originally in bytes."""
-    return size_in_bytes / 1000000000
-
-
-def convert_gb_to_bytes(size_in_gb: int | float) -> int:
-    """Return the converted value in bytes for a number originally in gigabytes."""
-    return int(size_in_gb * 1000000000)

--- a/api/scpca_portal/utils/helpers.py
+++ b/api/scpca_portal/utils/helpers.py
@@ -1,6 +1,7 @@
 """Misc utils."""
 
 import inspect
+import math
 from collections import namedtuple
 from datetime import datetime
 from pathlib import Path
@@ -153,6 +154,18 @@ def path_replace(path: Path, old_value: str, new_value: str) -> Path:
 
 
 def format_bytes(size_in_bytes: int) -> str:
-    """Return a formatted string of the passed value converted from bytes to gb."""
-    converted_value = float(size_in_bytes / 1000000000)
-    return f"{round(converted_value, 2)} GB"
+    """
+    Return a formatted string of the passed value converted from bytes to a more appropriate size.
+    """
+    # This function was inspired by https://stackoverflow.com/a/18650828/763705.
+
+    if size_in_bytes < 0:
+        raise ValueError("size in bytes must be a positive number.")
+
+    k = 1024
+    if size_in_bytes < k:
+        return f"{size_in_bytes} Bytes"
+
+    sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+    i = math.floor(math.log(size_in_bytes) / math.log(k))
+    return f"{size_in_bytes / k**i:.2f} {sizes[i]}"

--- a/api/scpca_portal/utils/helpers.py
+++ b/api/scpca_portal/utils/helpers.py
@@ -152,6 +152,12 @@ def path_replace(path: Path, old_value: str, new_value: str) -> Path:
     return Path(str(path).replace(old_value, new_value))
 
 
+def format_bytes(size_in_bytes: int) -> str:
+    """Return a formatted string of the passed value converted from bytes to gb."""
+    converted_value = float(size_in_bytes / 1000000000)
+    return f"{round(converted_value, 2)} GB"
+
+
 def convert_bytes_to_gb(size_in_bytes: int | float) -> float:
     """Return the converted value in gb for a number originally in bytes."""
     return size_in_bytes / 1000000000


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1285.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

In this PR, a `format_bytes` utils function was added. We wanted this method in order to be able to convert the int value off of `ComputedFile::size_in_bytes` to a formatted string rounded to two decimal places. 

Old byte conversion utils functions were removed as well.


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

- `test_format_bytes`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A