### PR TITLE
Add support for sportal debug:init, debug:plan, and debug:console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ venv.bak/
 infrastructure/*.tfstate*
 infrastructure/.terraform/
 infrastructure/.terraform.lock.hcl
+infrastructure/PLAN
 .circleci/s3_tfstate/.terraform
 
 # MacOS

--- a/bin/sportal
+++ b/bin/sportal
@@ -128,6 +128,9 @@ def get_aws_env_from_profile(profile: str) -> bool:
 commands_cwd = {
     "deploy:up": Path("infrastructure"),
     "deploy:down": Path("infrastructure"),
+    "deploy:init": Path("infrastructure"),
+    "deploy:plan": Path("infrastructure"),
+    "deploy:console": Path("infrastructure"),
 }
 
 # Commands that require shell. Joined and passed as a string.
@@ -153,6 +156,9 @@ command_descriptions = {
     "api:lint:black": "Lint API python code with black.",
     "deploy:up": "Spin up a dev stack. Requires successful debug:env.",
     "deploy:down": "Tear down existing dev stack.",
+    "deploy:init": "Terraform init via the deploy command.",
+    "deploy:plan": "Terraform plan via the deploy command.",
+    "deploy:console": "Access a terraform console to help test data structures. Use --save-plan to save to infrastructure/PLAN. View with `terraform show PLAN`",
 }
 
 # All available commands and their execution.
@@ -184,6 +190,9 @@ commands = {
     "api:lint:black": ["black", "--line-length=100", "--exclude=volumes_postgres", "."],
     "deploy:up": deploy,
     "deploy:down": deploy + ["--destroy"],
+    "deploy:init": deploy + ["--init"],
+    "deploy:plan": deploy + ["--plan"],
+    "deploy:console": deploy + ["--console"],
 }
 
 

--- a/bin/sportal
+++ b/bin/sportal
@@ -158,7 +158,11 @@ command_descriptions = {
     "deploy:down": "Tear down existing dev stack.",
     "deploy:init": "Terraform init via the deploy command.",
     "deploy:plan": "Terraform plan via the deploy command.",
-    "deploy:console": "Access a terraform console to help test data structures. Use --save-plan to save to infrastructure/PLAN. View with `terraform show PLAN`",
+    "deploy:console": (
+        "Access a terraform console to help test data structures."
+        "Use --save-plan to save to infrastructure/PLAN."
+        "View with `terraform show PLAN`"
+    ),
 }
 
 # All available commands and their execution.

--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -96,7 +96,9 @@ def parse_args():
 
     # SAVE PLAN
     save_out_help_text = "Used with --plan. Saves output for next deploy."
-    parser.add_argument("--save-plan", help=save_out_help_text, action=argparse.BooleanOptionalAction)
+    parser.add_argument(
+        "--save-plan", help=save_out_help_text, action=argparse.BooleanOptionalAction
+    )
 
     # CONSOLE
     console_help_text = "Run terraform console. Skips docker builds."

--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -86,6 +86,22 @@ def parse_args():
     destroy_help_text = "Specify that you want to destroy existing stack."
     parser.add_argument("--destroy", help=destroy_help_text, action=argparse.BooleanOptionalAction)
 
+    # INIT
+    destroy_help_text = "Run terraform init. Skips docker builds."
+    parser.add_argument("--init", help=destroy_help_text, action=argparse.BooleanOptionalAction)
+
+    # PLAN
+    plan_help_text = "Run terraform plan. Skips docker builds."
+    parser.add_argument("--plan", help=plan_help_text, action=argparse.BooleanOptionalAction)
+
+    # SAVE PLAN
+    save_out_help_text = "Used with --plan. Saves output for next deploy."
+    parser.add_argument("--save-plan", help=save_out_help_text, action=argparse.BooleanOptionalAction)
+
+    # CONSOLE
+    console_help_text = "Run terraform console. Skips docker builds."
+    parser.add_argument("--console", help=console_help_text, action=argparse.BooleanOptionalAction)
+
     # SKIP DOCKER
     skip_docker_text = "Specify that you want to skip building docker container."
     parser.add_argument(
@@ -198,7 +214,9 @@ if __name__ == "__main__":
     # get environ to inject into terraform commands
     env = get_env(vars(args))
 
-    if not args.skip_docker and not args.destroy:
+    skip_docker = any([args.skip_docker, args.destroy, args.init, args.plan, args.console])
+
+    if not skip_docker:
         docker_code = docker.build_and_push_docker_image(
             f"{args.dockerhub_account}/scpca_portal_api",
             f"--build-arg SYSTEM_VERSION={args.system_version}",
@@ -226,11 +244,19 @@ if __name__ == "__main__":
     # Always init first
     init_code = terraform.init(backend_configs)
 
-    if init_code != 0:
+    if init_code != 0 or args.init:
         exit(init_code)
 
     # Shared for destroy and apply
     var_file_arg = f"-var-file=tf_vars/{args.stage}.tfvars"
+
+    if args.plan:
+        terraform.plan(var_file_arg, args.save_plan)
+        exit(1)
+
+    if args.console:
+        terraform.console(var_file_arg)
+        exit(1)
 
     if args.destroy:
         terraform.destroy(var_file_arg)

--- a/infrastructure/deploy_modules/terraform.py
+++ b/infrastructure/deploy_modules/terraform.py
@@ -47,7 +47,8 @@ def init(backend_configs=[], init_args=["-upgrade"], log_trace=False):
 
     return terraform_process.returncode
 
-def plan(var_file_arg, out = False):
+
+def plan(var_file_arg, out=False):
     """Plan changes that will be made to infrastructure.
 
     Should be called after init.
@@ -67,6 +68,7 @@ def plan(var_file_arg, out = False):
     except KeyboardInterrupt:
         terraform_process.send_signal(signal.SIGINT)
 
+
 def console(var_file_arg):
     """Enter a terraform REPL.
 
@@ -74,9 +76,7 @@ def console(var_file_arg):
     """
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
-        terraform_process = subprocess.Popen(
-            ["terraform", "console", var_file_arg, "-plan"]
-        )
+        terraform_process = subprocess.Popen(["terraform", "console", var_file_arg, "-plan"])
         terraform_process.wait()
         exit(terraform_process.returncode)
     except KeyboardInterrupt:

--- a/infrastructure/deploy_modules/terraform.py
+++ b/infrastructure/deploy_modules/terraform.py
@@ -47,6 +47,41 @@ def init(backend_configs=[], init_args=["-upgrade"], log_trace=False):
 
     return terraform_process.returncode
 
+def plan(var_file_arg, out = False):
+    """Plan changes that will be made to infrastructure.
+
+    Should be called after init.
+
+    Accepts additional argument to save the output.
+    """
+
+    command = ["terraform", "plan", var_file_arg]
+
+    if out:
+        command += ["-out=PLAN"]
+    # Make sure that Terraform is allowed to shut down gracefully.
+    try:
+        terraform_process = subprocess.Popen(command)
+        terraform_process.wait()
+        exit(terraform_process.returncode)
+    except KeyboardInterrupt:
+        terraform_process.send_signal(signal.SIGINT)
+
+def console(var_file_arg):
+    """Enter a terraform REPL.
+
+    Should be called after init.
+    """
+    # Make sure that Terraform is allowed to shut down gracefully.
+    try:
+        terraform_process = subprocess.Popen(
+            ["terraform", "console", var_file_arg, "-plan"]
+        )
+        terraform_process.wait()
+        exit(terraform_process.returncode)
+    except KeyboardInterrupt:
+        terraform_process.send_signal(signal.SIGINT)
+
 
 def output():
     process = subprocess.Popen(["terraform", "output", "-json"], stdout=subprocess.PIPE)


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Encountered an issue yesterday where I realized we were unable to utilize certain debugging techniques on the portal.

This PR expands support of sportal with the following commands:

`sportal --sso profile_name deploy:init` - useful to quickly validate terraform syntax and configuration.
`sportal --sso profile_name deploy:console` - useful to enter a REPL and debug new or existing data structures.
`sportal --sso profile_name deploy:plan` - useful to see what terraform will do without running apply / deploy:up
`sportal --sso profile_name deploy:plan --save-plan` - useful for seeing what terraform will do and saving the output. This output can be seen with `terraform show infrastructure/PLAN`. To compare against a different terraform plan.


## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A ran locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
