### PR TITLE
1282 - Start implementation of dataset_ready email template

### DIFF
--- a/api/scpca_portal/email_templates/dataset_ready.html
+++ b/api/scpca_portal/email_templates/dataset_ready.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Your dataset is ready!</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        background-color: #f3f3f3;
+        margin: 0;
+        padding: 0;
+      }
+
+      @media only screen {
+        html {
+          min-height: 100%;
+          background: #f3f3f3;
+        }
+      }
+
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        background-color: #ffffff;
+        border-radius: 4px;
+        overflow: hidden;
+      }
+
+      .banner {
+        background-color: #145ECC;
+        color: #ffffff;
+        padding: 20px;
+        font-size: 24px;
+        font-weight: bold;
+        text-align: left;
+      }
+
+      .header-content {
+        background-color: #ffffff;
+        text-align: center;
+        padding: 30px 20px 20px;
+      }
+
+      .header-content h2 {
+        font-size: 21px;
+        margin-bottom: 10px;
+      }
+
+      .header-content p {
+        font-size: 16px;
+        margin-top: 0;
+        margin-bottom: 20px;
+      }
+
+      .button {
+        display: inline-block;
+        background-color: #003595;
+        color: white;
+        padding: 12px 24px;
+        text-decoration: none;
+        border-radius: 4px;
+      }
+
+      .divider {
+        border-top: 3px solid #F2F2F2;
+        margin: 0 20px;
+      }
+
+      .main-content {
+        padding: 30px 20px;
+      }
+
+      .footer {
+        font-size: 12px;
+        color: #666666;
+        text-align: center;
+        padding: 20px;
+        line-height: 1.4;
+      }
+
+      .footer a {
+        color: #003595;
+        text-decoration: none;
+        margin: 0 5px;
+      }
+
+
+    </style>
+  </head>
+  <body>
+    <table class="container" align="center">
+      <!-- Header banner -->
+      <tr>
+        <td class="banner">
+          ScPCA Portal
+        </td>
+      </tr>
+
+      <!-- Header content -->
+      <tr>
+        <td class="header-content">
+          <h2>Your dataset is ready for download!</h2>
+          <p>Uncompressed Size: {{ uncompressed_size }} GB</p>
+          <a href="{{ download_link }}" class="button">Get Dataset</a>
+        </td>
+      </tr>
+
+      <!-- Divider line -->
+      <tr>
+        <td>
+          <div class="divider"></div>
+        </td>
+      </tr>
+
+      <!-- Main content placeholder -->
+      <tr>
+        <td class="main-content">
+          <!-- Dataset Summary and Download File Summary go here -->
+        </td>
+      </tr>
+
+      <!-- Footer -->
+      <tr>
+        <td class="footer">
+          <p>
+            <a href="{{ terms_url }}">Terms of Use</a> and
+            <a href="{{ privacy_url }}">Privacy Policy</a><br />
+            Alex’s Lemonade Stand Foundation for Childhood Cancer<br />
+            333 E. Lancaster Ave, #414, Wynnewood, PA 19096 USA
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/api/scpca_portal/email_templates/dataset_ready.html
+++ b/api/scpca_portal/email_templates/dataset_ready.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
+  <!-- To account for mail clients which throw away the first head tag -->
+  <head>
+  </head>
   <head>
     <meta charset="UTF-8" />
     <title>Your dataset is ready!</title>


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1282.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

In this PR, a `dataset_ready` email template was added. Included in this template thusfar are the header, the link button, and the footer. The main content, which includes a Dataset Summary table and a Download File Summary table, will be added in a future PR.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->


- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A