### PR TITLE
1321 - Add new utils methods for preparing data directory

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -1,5 +1,7 @@
 from scpca_portal.enums import JobStates, Modalities
 
+TODO_AFTER_DATASET_RELEASE = "Remove after the dataset release"
+
 CSV_MULTI_VALUE_DELIMITER = ";"
 
 TAB = "\t"

--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -1,4 +1,3 @@
-import shutil
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Any, Dict, List, Set
@@ -21,32 +20,6 @@ from scpca_portal.models import (
 )
 
 logger = get_and_configure_logger(__name__)
-
-
-def prep_data_dirs(wipe_input_dir: bool = False, wipe_output_dir: bool = True) -> None:
-    """
-    Create the input and output data dirs, if they do not yet exist.
-    Allow for options to be passed to wipe these dirs if they do exist.
-        - wipe_input_dir defaults to False because we typically want to keep input data files
-        between testing rounds to speed up our tests.
-        - wipe_output_dir defaults to True because we typically don't want to keep around
-        computed files after execution.
-    The options are given to the caller for to customize behavior for different use cases.
-    """
-    # Prepare data input directory.
-    if wipe_input_dir:
-        shutil.rmtree(settings.INPUT_DATA_PATH, ignore_errors=True)
-    settings.INPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
-
-    # Prepare data output directory.
-    if wipe_output_dir:
-        shutil.rmtree(settings.OUTPUT_DATA_PATH, ignore_errors=True)
-    settings.OUTPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
-
-
-def remove_project_input_files(project_id: str) -> None:
-    """Remove the input files located at the project_id's input directory."""
-    shutil.rmtree(settings.INPUT_DATA_PATH / project_id, ignore_errors=True)
 
 
 def get_projects_metadata(filter_on_project_ids: List[str] = []) -> List[Dict[str, Any]]:
@@ -72,6 +45,7 @@ def get_projects_metadata(filter_on_project_ids: List[str] = []) -> List[Dict[st
     return projects_metadata
 
 
+# TODO: common.TODO_AFTER_DATASET_RELEASE
 def _can_process_project(project_metadata: Dict[str, Any], submitter_whitelist: Set[str]) -> bool:
     """
     Validate that a project can be processed by assessing that:
@@ -93,6 +67,7 @@ def _can_process_project(project_metadata: Dict[str, Any], submitter_whitelist: 
     return True
 
 
+# TODO: common.TODO_AFTER_DATASET_RELEASE
 def _can_purge_project(
     project: Project,
     *,
@@ -153,6 +128,7 @@ def create_project(
     return project
 
 
+# TODO: common.TODO_AFTER_DATASET_RELEASE
 def _create_computed_file(
     computed_file: ComputedFile, update_s3: bool, clean_up_output_data: bool
 ) -> None:
@@ -172,6 +148,7 @@ def _create_computed_file(
         computed_file.save()
 
 
+# TODO: common.TODO_AFTER_DATASET_RELEASE
 def _create_computed_file_callback(future, *, update_s3: bool, clean_up_output_data: bool) -> None:
     """
     Wrap computed file saving and uploading to s3 in a way that accommodates multiprocessing.
@@ -183,6 +160,7 @@ def _create_computed_file_callback(future, *, update_s3: bool, clean_up_output_d
     connection.close()
 
 
+# TODO: common.TODO_AFTER_DATASET_RELEASE
 def generate_computed_file(
     *,
     download_config: Dict,
@@ -202,6 +180,7 @@ def generate_computed_file(
         sample.project.update_downloadable_sample_count()
 
 
+# TODO: common.TODO_AFTER_DATASET_RELEASE
 def generate_computed_files(
     project: Project,
     max_workers: int,

--- a/api/scpca_portal/management/commands/generate_computed_file.py
+++ b/api/scpca_portal/management/commands/generate_computed_file.py
@@ -3,7 +3,7 @@ from argparse import BooleanOptionalAction
 
 from django.core.management.base import BaseCommand
 
-from scpca_portal import common, loader, notifications
+from scpca_portal import common, loader, notifications, utils
 from scpca_portal.models import Project, Sample
 
 logger = logging.getLogger()
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         **kwargs,
     ) -> None:
         """Generates a project's computed files according predetermined download configurations"""
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         ids_not_mutually_exclusive = project_id and sample_id or (not project_id and not sample_id)
         if ids_not_mutually_exclusive:

--- a/api/scpca_portal/management/commands/generate_computed_file.py
+++ b/api/scpca_portal/management/commands/generate_computed_file.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         **kwargs,
     ) -> None:
         """Generates a project's computed files according predetermined download configurations"""
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         ids_not_mutually_exclusive = project_id and sample_id or (not project_id and not sample_id)
         if ids_not_mutually_exclusive:

--- a/api/scpca_portal/management/commands/generate_computed_files.py
+++ b/api/scpca_portal/management/commands/generate_computed_files.py
@@ -71,7 +71,7 @@ class Command(BaseCommand):
         **kwargs,
     ) -> None:
         """Generates a project's computed files according predetermined download configurations"""
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         project = Project.objects.filter(scpca_id=scpca_project_id).first()
 
@@ -83,4 +83,4 @@ class Command(BaseCommand):
         # Output data is deleted on a computed file level - after each file is created it's deleted.
         if clean_up_input_data:
             logger.info(f"Cleaning up '{project}' input files")
-            utils.remove_project_input_files(project.scpca_id)
+            utils.remove_project_data_dirs(project.scpca_id)

--- a/api/scpca_portal/management/commands/generate_computed_files.py
+++ b/api/scpca_portal/management/commands/generate_computed_files.py
@@ -4,7 +4,7 @@ from argparse import BooleanOptionalAction
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from scpca_portal import loader
+from scpca_portal import loader, utils
 from scpca_portal.models import Project
 
 logger = logging.getLogger()
@@ -71,7 +71,7 @@ class Command(BaseCommand):
         **kwargs,
     ) -> None:
         """Generates a project's computed files according predetermined download configurations"""
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         project = Project.objects.filter(scpca_id=scpca_project_id).first()
 
@@ -83,4 +83,4 @@ class Command(BaseCommand):
         # Output data is deleted on a computed file level - after each file is created it's deleted.
         if clean_up_input_data:
             logger.info(f"Cleaning up '{project}' input files")
-            loader.remove_project_input_files(project.scpca_id)
+            utils.remove_project_input_files(project.scpca_id)

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
         **kwargs,
     ) -> None:
         """Loads data from S3. Creates projects and loads data for them."""
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # load metadata
         for project_metadata in loader.get_projects_metadata(scpca_project_id):
@@ -103,4 +103,4 @@ class Command(BaseCommand):
 
                 if clean_up_input_data:
                     logger.info(f"Cleaning up '{project}' input files")
-                    utils.remove_project_input_files(project.scpca_id)
+                    utils.remove_project_data_dirs(project.scpca_id)

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -5,7 +5,7 @@ from typing import Set
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from scpca_portal import common, loader
+from scpca_portal import common, loader, utils
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -87,7 +87,7 @@ class Command(BaseCommand):
         **kwargs,
     ) -> None:
         """Loads data from S3. Creates projects and loads data for them."""
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # load metadata
         for project_metadata in loader.get_projects_metadata(scpca_project_id):
@@ -103,4 +103,4 @@ class Command(BaseCommand):
 
                 if clean_up_input_data:
                     logger.info(f"Cleaning up '{project}' input files")
-                    loader.remove_project_input_files(project.scpca_id)
+                    utils.remove_project_input_files(project.scpca_id)

--- a/api/scpca_portal/management/commands/load_metadata.py
+++ b/api/scpca_portal/management/commands/load_metadata.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
                 "OriginalFile table is empty. Run 'sync_original_files' first to populate it."
             )
 
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         projects_metadata_ids = set(metadata_parser.get_projects_metadata_ids())
         lockfile_project_ids = set(lockfile.get_lockfile_project_ids())
@@ -116,4 +116,4 @@ class Command(BaseCommand):
             ):
                 if clean_up_input_data:
                     logger.info(f"Cleaning up '{project}' input files")
-                    utils.remove_project_input_files(project.scpca_id)
+                    utils.remove_project_data_dirs(project.scpca_id)

--- a/api/scpca_portal/management/commands/load_metadata.py
+++ b/api/scpca_portal/management/commands/load_metadata.py
@@ -5,7 +5,7 @@ from typing import Set
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from scpca_portal import common, loader, lockfile, metadata_parser
+from scpca_portal import common, loader, lockfile, metadata_parser, utils
 from scpca_portal.models import OriginalFile, Project
 
 logger = logging.getLogger()
@@ -85,7 +85,7 @@ class Command(BaseCommand):
                 "OriginalFile table is empty. Run 'sync_original_files' first to populate it."
             )
 
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         projects_metadata_ids = set(metadata_parser.get_projects_metadata_ids())
         lockfile_project_ids = set(lockfile.get_lockfile_project_ids())
@@ -116,4 +116,4 @@ class Command(BaseCommand):
             ):
                 if clean_up_input_data:
                     logger.info(f"Cleaning up '{project}' input files")
-                    loader.remove_project_input_files(project.scpca_id)
+                    utils.remove_project_input_files(project.scpca_id)

--- a/api/scpca_portal/management/commands/process_dataset.py
+++ b/api/scpca_portal/management/commands/process_dataset.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         self.process_dataset(**kwargs)
 
     def process_dataset(self, job_id: str, **kwargs) -> None:
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         job = Job.objects.filter(id=job_id).first()
         if not job:

--- a/api/scpca_portal/management/commands/process_dataset.py
+++ b/api/scpca_portal/management/commands/process_dataset.py
@@ -4,7 +4,7 @@ from argparse import BooleanOptionalAction
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from scpca_portal import loader, notifications
+from scpca_portal import notifications, utils
 from scpca_portal.enums import JobStates
 from scpca_portal.models import Job
 
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         self.process_dataset(**kwargs)
 
     def process_dataset(self, job_id: str, **kwargs) -> None:
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         job = Job.objects.filter(id=job_id).first()
         if not job:

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -23,26 +23,26 @@ class TestLoadData(TestCase):
         self.submitter_whitelist = common.SUBMITTER_WHITELIST
 
         # Handle patching in setUp function
-        prep_data_dirs_patch = patch("scpca_portal.utils.prep_data_dirs")
+        create_data_dirs_patch = patch("scpca_portal.utils.create_data_dirs")
         get_projects_metadata_patch = patch("scpca_portal.loader.get_projects_metadata")
         create_project_patch = patch("scpca_portal.loader.create_project")
         generate_computed_files_patch = patch("scpca_portal.loader.generate_computed_files")
-        remove_project_input_files_patch = patch("scpca_portal.utils.remove_project_input_files")
+        remove_project_data_dirs_patch = patch("scpca_portal.utils.remove_project_data_dirs")
 
         # Start patches
-        self.mock_prep_data_dirs = prep_data_dirs_patch.start()
+        self.mock_create_data_dirs = create_data_dirs_patch.start()
         self.mock_get_projects_metadata = get_projects_metadata_patch.start()
         self.mock_create_project = create_project_patch.start()
         self.mock_generate_computed_files = generate_computed_files_patch.start()
-        self.mock_remove_project_input_files = remove_project_input_files_patch.start()
+        self.mock_remove_project_data_dirs = remove_project_data_dirs_patch.start()
 
         # Save patches that so they can be stopped during tearDown
         self.patches = [
-            prep_data_dirs_patch,
+            create_data_dirs_patch,
             get_projects_metadata_patch,
             create_project_patch,
             generate_computed_files_patch,
-            remove_project_input_files_patch,
+            remove_project_data_dirs_patch,
         ]
 
         # Configure necessary output values
@@ -56,7 +56,7 @@ class TestLoadData(TestCase):
             p.stop()
 
     def assertMethodsCalled(self):
-        self.mock_prep_data_dirs.assert_called()
+        self.mock_create_data_dirs.assert_called()
         self.mock_get_projects_metadata.assert_called()
         self.mock_create_project.assert_called()
         self.mock_generate_computed_files.assert_called()
@@ -89,11 +89,11 @@ class TestLoadData(TestCase):
     def test_clean_up_input_data(self):
         self.load_data()
         self.assertMethodsCalled()
-        self.mock_remove_project_input_files.assert_not_called()
+        self.mock_remove_project_data_dirs.assert_not_called()
 
         clean_up_input_data = True
         self.load_data(clean_up_input_data=clean_up_input_data)
-        self.mock_remove_project_input_files.assert_called_once()
+        self.mock_remove_project_data_dirs.assert_called_once()
 
     def test_clean_up_output_data(self):
         self.load_data()
@@ -206,18 +206,18 @@ class TestLoadData(TestCase):
         self.mock_get_projects_metadata.return_value = []
         self.load_data()
 
-        self.mock_prep_data_dirs.assert_called_once()
+        self.mock_create_data_dirs.assert_called_once()
         self.mock_get_projects_metadata.assert_called_once()
         self.mock_create_project.assert_not_called()
         self.mock_generate_computed_files.assert_not_called()
-        self.mock_remove_project_input_files.assert_not_called()
+        self.mock_remove_project_data_dirs.assert_not_called()
 
     def test_create_project_failure(self):
         self.mock_create_project.return_value = None
         self.load_data()
 
-        self.mock_prep_data_dirs.assert_called_once()
+        self.mock_create_data_dirs.assert_called_once()
         self.mock_get_projects_metadata.assert_called_once()
         self.mock_create_project.assert_called_once()
         self.mock_generate_computed_files.assert_not_called()
-        self.mock_remove_project_input_files.assert_not_called()
+        self.mock_remove_project_data_dirs.assert_not_called()

--- a/api/scpca_portal/test/management/commands/test_load_data.py
+++ b/api/scpca_portal/test/management/commands/test_load_data.py
@@ -23,11 +23,11 @@ class TestLoadData(TestCase):
         self.submitter_whitelist = common.SUBMITTER_WHITELIST
 
         # Handle patching in setUp function
-        prep_data_dirs_patch = patch("scpca_portal.loader.prep_data_dirs")
+        prep_data_dirs_patch = patch("scpca_portal.utils.prep_data_dirs")
         get_projects_metadata_patch = patch("scpca_portal.loader.get_projects_metadata")
         create_project_patch = patch("scpca_portal.loader.create_project")
         generate_computed_files_patch = patch("scpca_portal.loader.generate_computed_files")
-        remove_project_input_files_patch = patch("scpca_portal.loader.remove_project_input_files")
+        remove_project_input_files_patch = patch("scpca_portal.utils.remove_project_input_files")
 
         # Start patches
         self.mock_prep_data_dirs = prep_data_dirs_patch.start()

--- a/api/scpca_portal/test/management/commands/test_load_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_load_metadata.py
@@ -23,26 +23,26 @@ class TestLoadMetadata(TestCase):
         self.submitter_whitelist = common.SUBMITTER_WHITELIST
 
         # Handle patching in setUp function
-        prep_data_dirs_patch = patch("scpca_portal.utils.prep_data_dirs")
+        create_data_dirs_patch = patch("scpca_portal.utils.create_data_dirs")
         get_lockfile_project_ids = patch("scpca_portal.lockfile.get_lockfile_project_ids")
         get_projects_metadata_patch = patch("scpca_portal.loader.get_projects_metadata")
         create_project_patch = patch("scpca_portal.loader.create_project")
-        remove_project_input_files_patch = patch("scpca_portal.utils.remove_project_input_files")
+        remove_project_data_dirs_patch = patch("scpca_portal.utils.remove_project_data_dirs")
 
         # Start patches
-        self.mock_prep_data_dirs = prep_data_dirs_patch.start()
+        self.mock_create_data_dirs = create_data_dirs_patch.start()
         self.mock_get_lockfile_project_ids = get_lockfile_project_ids.start()
         self.mock_get_projects_metadata = get_projects_metadata_patch.start()
         self.mock_create_project = create_project_patch.start()
-        self.mock_remove_project_input_files = remove_project_input_files_patch.start()
+        self.mock_remove_project_data_dirs = remove_project_data_dirs_patch.start()
 
         # Save patches that so they can be stopped during tearDown
         self.patches = [
-            prep_data_dirs_patch,
+            create_data_dirs_patch,
             get_lockfile_project_ids,
             get_projects_metadata_patch,
             create_project_patch,
-            remove_project_input_files_patch,
+            remove_project_data_dirs_patch,
         ]
 
         # Configure necessary output values
@@ -60,7 +60,7 @@ class TestLoadMetadata(TestCase):
             p.stop()
 
     def assertMethodsCalled(self):
-        self.mock_prep_data_dirs.assert_called()
+        self.mock_create_data_dirs.assert_called()
         self.mock_get_projects_metadata.assert_called()
         self.mock_create_project.assert_called()
 
@@ -90,11 +90,11 @@ class TestLoadMetadata(TestCase):
     def test_clean_up_input_data(self):
         self.load_metadata()
         self.assertMethodsCalled()
-        self.mock_remove_project_input_files.assert_not_called()
+        self.mock_remove_project_data_dirs.assert_not_called()
 
         clean_up_input_data = True
         self.load_metadata(clean_up_input_data=clean_up_input_data)
-        self.mock_remove_project_input_files.assert_called_once()
+        self.mock_remove_project_data_dirs.assert_called_once()
 
     def test_reload_existing(self):
         self.load_metadata()
@@ -192,16 +192,16 @@ class TestLoadMetadata(TestCase):
         self.mock_get_projects_metadata.return_value = []
         self.load_metadata()
 
-        self.mock_prep_data_dirs.assert_called_once()
+        self.mock_create_data_dirs.assert_called_once()
         self.mock_get_projects_metadata.assert_called_once()
         self.mock_create_project.assert_not_called()
-        self.mock_remove_project_input_files.assert_not_called()
+        self.mock_remove_project_data_dirs.assert_not_called()
 
     def test_create_project_failure(self):
         self.mock_create_project.return_value = None
         self.load_metadata()
 
-        self.mock_prep_data_dirs.assert_called_once()
+        self.mock_create_data_dirs.assert_called_once()
         self.mock_get_projects_metadata.assert_called_once()
         self.mock_create_project.assert_called_once()
-        self.mock_remove_project_input_files.assert_not_called()
+        self.mock_remove_project_data_dirs.assert_not_called()

--- a/api/scpca_portal/test/management/commands/test_load_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_load_metadata.py
@@ -23,11 +23,11 @@ class TestLoadMetadata(TestCase):
         self.submitter_whitelist = common.SUBMITTER_WHITELIST
 
         # Handle patching in setUp function
-        prep_data_dirs_patch = patch("scpca_portal.loader.prep_data_dirs")
+        prep_data_dirs_patch = patch("scpca_portal.utils.prep_data_dirs")
         get_lockfile_project_ids = patch("scpca_portal.lockfile.get_lockfile_project_ids")
         get_projects_metadata_patch = patch("scpca_portal.loader.get_projects_metadata")
         create_project_patch = patch("scpca_portal.loader.create_project")
-        remove_project_input_files_patch = patch("scpca_portal.loader.remove_project_input_files")
+        remove_project_input_files_patch = patch("scpca_portal.utils.remove_project_input_files")
 
         # Start patches
         self.mock_prep_data_dirs = prep_data_dirs_patch.start()

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
-from scpca_portal import loader
+from scpca_portal import loader, utils
 from scpca_portal.enums import CCDLDatasetNames, DatasetFormats, Modalities
 from scpca_portal.models import ComputedFile, Dataset
 from scpca_portal.test import expected_values as test_data
@@ -81,7 +81,7 @@ class TestGetFile(TestCase):
             ComputedFile.get_sample_file(self.sample, invalid_download_config)
 
     def test_get_ccdl_dataset_file(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         ccdl_name = CCDLDatasetNames.SINGLE_CELL_SINGLE_CELL_EXPERIMENT.value
         project_id = "SCPCP999990"

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -81,7 +81,7 @@ class TestGetFile(TestCase):
             ComputedFile.get_sample_file(self.sample, invalid_download_config)
 
     def test_get_ccdl_dataset_file(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         ccdl_name = CCDLDatasetNames.SINGLE_CELL_SINGLE_CELL_EXPERIMENT.value
         project_id = "SCPCP999990"

--- a/api/scpca_portal/test/test_loader.py
+++ b/api/scpca_portal/test/test_loader.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TransactionTestCase
 
-from scpca_portal import loader
+from scpca_portal import loader, utils
 from scpca_portal.models import ComputedFile, Project
 from scpca_portal.test import expected_values as test_data
 
@@ -89,7 +89,7 @@ class TestLoader(TransactionTestCase):
         self.assertEqual(original_file_libraries, expected_libraries)
 
     def test_create_project_SCPCP999990(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         returned_project = self.create_project(
             self.get_project_metadata(test_data.Project_SCPCP999990.SCPCA_ID)
@@ -259,7 +259,7 @@ class TestLoader(TransactionTestCase):
         self.assertObjectProperties(publication, test_data.Project_SCPCP999990.Publication2.VALUES)
 
     def test_create_project_SCPCP999991(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         returned_project = self.create_project(
             self.get_project_metadata(test_data.Project_SCPCP999991.SCPCA_ID)
@@ -398,7 +398,7 @@ class TestLoader(TransactionTestCase):
         self.assertObjectProperties(publication, test_data.Project_SCPCP999991.Publication2.VALUES)
 
     def test_create_project_SCPCP999992(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         returned_project = self.create_project(
             self.get_project_metadata(test_data.Project_SCPCP999992.SCPCA_ID)
@@ -524,7 +524,7 @@ class TestLoader(TransactionTestCase):
         self.assertObjectProperties(publication, test_data.Project_SCPCP999992.Publication2.VALUES)
 
     def test_project_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -568,7 +568,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MULTIPLEXED(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -621,7 +621,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MERGED(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -669,7 +669,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SINGLE_CELL_ANN_DATA(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -717,7 +717,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SINGLE_CELL_ANN_DATA_MERGED(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -769,7 +769,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SPATIAL_SINGLE_CELL_EXPERIMENT(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -821,7 +821,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_ALL_METADATA(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Project.ALL_METADATA.PROJECT_ID
@@ -866,7 +866,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_sample_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SINGLE_CELL_SCE.PROJECT_ID
@@ -921,7 +921,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_sample_generate_computed_files_SINGLE_CELL_ANN_DATA(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SINGLE_CELL_ANN_DATA.PROJECT_ID
@@ -978,7 +978,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_sample_generate_computed_files_SPATIAL_SINGLE_CELL_EXPERIMENT(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SPATIAL_SCE.PROJECT_ID
@@ -1031,7 +1031,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_multiplexed_sample_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT(self):
-        loader.prep_data_dirs()
+        utils.prep_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.PROJECT_ID

--- a/api/scpca_portal/test/test_loader.py
+++ b/api/scpca_portal/test/test_loader.py
@@ -89,7 +89,7 @@ class TestLoader(TransactionTestCase):
         self.assertEqual(original_file_libraries, expected_libraries)
 
     def test_create_project_SCPCP999990(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         returned_project = self.create_project(
             self.get_project_metadata(test_data.Project_SCPCP999990.SCPCA_ID)
@@ -259,7 +259,7 @@ class TestLoader(TransactionTestCase):
         self.assertObjectProperties(publication, test_data.Project_SCPCP999990.Publication2.VALUES)
 
     def test_create_project_SCPCP999991(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         returned_project = self.create_project(
             self.get_project_metadata(test_data.Project_SCPCP999991.SCPCA_ID)
@@ -398,7 +398,7 @@ class TestLoader(TransactionTestCase):
         self.assertObjectProperties(publication, test_data.Project_SCPCP999991.Publication2.VALUES)
 
     def test_create_project_SCPCP999992(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         returned_project = self.create_project(
             self.get_project_metadata(test_data.Project_SCPCP999992.SCPCA_ID)
@@ -524,7 +524,7 @@ class TestLoader(TransactionTestCase):
         self.assertObjectProperties(publication, test_data.Project_SCPCP999992.Publication2.VALUES)
 
     def test_project_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -568,7 +568,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MULTIPLEXED(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -621,7 +621,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT_MERGED(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -669,7 +669,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SINGLE_CELL_ANN_DATA(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -717,7 +717,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SINGLE_CELL_ANN_DATA_MERGED(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -769,7 +769,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_SPATIAL_SINGLE_CELL_EXPERIMENT(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
@@ -821,7 +821,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_project_generate_computed_files_ALL_METADATA(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Project.ALL_METADATA.PROJECT_ID
@@ -866,7 +866,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_sample_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SINGLE_CELL_SCE.PROJECT_ID
@@ -921,7 +921,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_sample_generate_computed_files_SINGLE_CELL_ANN_DATA(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SINGLE_CELL_ANN_DATA.PROJECT_ID
@@ -978,7 +978,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_sample_generate_computed_files_SPATIAL_SINGLE_CELL_EXPERIMENT(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SPATIAL_SCE.PROJECT_ID
@@ -1031,7 +1031,7 @@ class TestLoader(TransactionTestCase):
         )
 
     def test_multiplexed_sample_generate_computed_files_SINGLE_CELL_SINGLE_CELL_EXPERIMENT(self):
-        utils.prep_data_dirs()
+        utils.create_data_dirs()
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.PROJECT_ID

--- a/api/scpca_portal/utils/helpers.py
+++ b/api/scpca_portal/utils/helpers.py
@@ -16,30 +16,59 @@ from scpca_portal.config.logging import get_and_configure_logger
 logger = get_and_configure_logger(__name__)
 
 
-def prep_data_dirs(wipe_input_dir: bool = False, wipe_output_dir: bool = True) -> None:
+def create_data_dirs(
+    wipe_input_dir: bool = False,
+    wipe_output_dir: bool = True,
+    input_dir=settings.INPUT_DATA_PATH,
+    output_dir=settings.OUTPUT_DATA_PATH,
+):
     """
-    Create the input and output data dirs, if they do not yet exist.
-    Allow for options to be passed to wipe these dirs if they do exist.
-        - wipe_input_dir defaults to False because we typically want to keep input data files
+    Creates the input and output data dirs.
+    Wipes these dirs first based on the given wipe flags:
+     - wipe_input_dir defaults to False because we typically want to keep input data files
         between testing rounds to speed up our tests.
-        - wipe_output_dir defaults to True because we typically don't want to keep around
+      - wipe_output_dir defaults to True because we typically don't want to keep around
         computed files after execution.
-    The options are given to the caller for to customize behavior for different use cases.
+    Calls can adjust the dafault behavior as necessary.
     """
-    # Prepare data input directory.
+    remove_data_dirs(
+        wipe_input_dir=wipe_input_dir,
+        wipe_output_dir=wipe_output_dir,
+        input_dir=input_dir,
+        output_dir=output_dir,
+    )
+    input_dir.mkdir(exist_ok=True, parents=True)
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+
+def remove_data_dirs(
+    wipe_input_dir: bool = True,
+    wipe_output_dir: bool = True,
+    input_dir=settings.INPUT_DATA_PATH,
+    output_dir=settings.OUTPUT_DATA_PATH,
+):
+    """
+    Removs the input and outout data dirs based on the given wipe flags.
+    """
     if wipe_input_dir:
-        shutil.rmtree(settings.INPUT_DATA_PATH, ignore_errors=True)
-    settings.INPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
-
-    # Prepare data output directory.
+        shutil.rmtree(input_dir, ignore_errors=True)
     if wipe_output_dir:
-        shutil.rmtree(settings.OUTPUT_DATA_PATH, ignore_errors=True)
-    settings.OUTPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
+        shutil.rmtree(output_dir, ignore_errors=True)
 
 
-def remove_project_input_files(project_id: str) -> None:
-    """Remove the input files located at the project_id's input directory."""
-    shutil.rmtree(settings.INPUT_DATA_PATH / project_id, ignore_errors=True)
+def remove_project_data_dirs(
+    project_id: str, wipe_input_dir: bool = True, wipe_output_dir: bool = False
+):
+    """
+    Remove the input files located at the project_id's input directory.
+    By default, it only wipes the input dir.
+    """
+    remove_data_dirs(
+        wipe_input_dir,
+        wipe_output_dir,
+        input_dir=settings.INPUT_DATA_PATH / project_id,
+        output_dir=settings.OUTPUT_DATA_PATH / project_id,
+    )
 
 
 def boolean_from_string(value: str) -> bool:

--- a/api/scpca_portal/utils/helpers.py
+++ b/api/scpca_portal/utils/helpers.py
@@ -2,15 +2,44 @@
 
 import inspect
 import math
+import shutil
 from collections import namedtuple
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Iterable, List, Set, Tuple
 
+from django.conf import settings
+
 from scpca_portal import common
 from scpca_portal.config.logging import get_and_configure_logger
 
 logger = get_and_configure_logger(__name__)
+
+
+def prep_data_dirs(wipe_input_dir: bool = False, wipe_output_dir: bool = True) -> None:
+    """
+    Create the input and output data dirs, if they do not yet exist.
+    Allow for options to be passed to wipe these dirs if they do exist.
+        - wipe_input_dir defaults to False because we typically want to keep input data files
+        between testing rounds to speed up our tests.
+        - wipe_output_dir defaults to True because we typically don't want to keep around
+        computed files after execution.
+    The options are given to the caller for to customize behavior for different use cases.
+    """
+    # Prepare data input directory.
+    if wipe_input_dir:
+        shutil.rmtree(settings.INPUT_DATA_PATH, ignore_errors=True)
+    settings.INPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
+
+    # Prepare data output directory.
+    if wipe_output_dir:
+        shutil.rmtree(settings.OUTPUT_DATA_PATH, ignore_errors=True)
+    settings.OUTPUT_DATA_PATH.mkdir(exist_ok=True, parents=True)
+
+
+def remove_project_input_files(project_id: str) -> None:
+    """Remove the input files located at the project_id's input directory."""
+    shutil.rmtree(settings.INPUT_DATA_PATH / project_id, ignore_errors=True)
 
 
 def boolean_from_string(value: str) -> bool:


### PR DESCRIPTION
## Issue Number

Close #1321

## Purpose/Implementation Notes

Changes include:
- Replaced the `prep_data_dirs` and `remove_project_input_files` utility functions with more generic ones:
   - `create_data_dirs`
   - `remove_data_dirs`
   - `remove_project_data_dirs`
- Updated all references in the corresponding tests

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

- Updated all references in the corresponding tests to reflect the changes

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
