### PR TITLE
1322 - Add new Job.apply_state instance method for instance-level sync flow

### DIFF
--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -2,6 +2,9 @@ from scpca_portal.enums import JobStates, Modalities
 
 TODO_AFTER_DATASET_RELEASE = "Remove after the dataset release"
 TODO_AFTER_BULK_REFACTOR = "Remove after bulk state sync flow refactor"
+TODO_REMOVE_OBSOLETE = (
+    "Remove obsolete code blocks related to old sync state flows throughout the codebase"
+)
 
 CSV_MULTI_VALUE_DELIMITER = ";"
 

--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -1,11 +1,5 @@
 from scpca_portal.enums import JobStates, Modalities
 
-TODO_AFTER_DATASET_RELEASE = "Remove after the dataset release"
-TODO_AFTER_BULK_REFACTOR = "Remove after bulk state sync flow refactor"
-TODO_REMOVE_OBSOLETE = (
-    "Remove obsolete code blocks related to old sync state flows throughout the codebase"
-)
-
 CSV_MULTI_VALUE_DELIMITER = ";"
 
 TAB = "\t"

--- a/api/scpca_portal/common.py
+++ b/api/scpca_portal/common.py
@@ -1,5 +1,8 @@
 from scpca_portal.enums import JobStates, Modalities
 
+TODO_AFTER_DATASET_RELEASE = "Remove after the dataset release"
+TODO_AFTER_BULK_REFACTOR = "Remove after bulk state sync flow refactor"
+
 CSV_MULTI_VALUE_DELIMITER = ";"
 
 TAB = "\t"

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -200,7 +200,7 @@ class Dataset(TimestampedModel):
 
         return data
 
-    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    # TODO: Remove after bulk state sync flow refactor
     def update_from_last_job(self, save: bool = True) -> None:
         """
         Updates the dataset's state based on the latest job.
@@ -253,7 +253,7 @@ class Dataset(TimestampedModel):
         if hasattr(self, f"{state_str}_reason"):
             setattr(self, f"{state_str}_reason", getattr(job, reason_attr))
 
-    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    # TODO: Remove after bulk state sync flow refactor
     def on_job_pending(self, job) -> Self:
         """
         Marks the dataset as pending based on the last job.
@@ -261,7 +261,7 @@ class Dataset(TimestampedModel):
         self.apply_job_state(job)
         return self
 
-    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    # TODO: Remove after bulk state sync flow refactor
     def on_job_processing(self, job) -> Self:
         """
         Marks the dataset as processing based on the last job.
@@ -269,7 +269,7 @@ class Dataset(TimestampedModel):
         self.apply_job_state(job)
         return self
 
-    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    # TODO: Remove after bulk state sync flow refactor
     def on_job_succeeded(self, job) -> Self:
         """
         Marks the dataset as succeeded based on the last job.
@@ -277,7 +277,7 @@ class Dataset(TimestampedModel):
         self.apply_job_state(job)
         return self
 
-    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    # TODO: Remove after bulk state sync flow refactor
     def on_job_failed(self, job) -> Self:
         """
         Marks the dataset as failed with the failure reason based on the last job.
@@ -285,7 +285,7 @@ class Dataset(TimestampedModel):
         self.apply_job_state(job)
         return self
 
-    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    # TODO: Remove after bulk state sync flow refactor
     def on_job_terminated(self, job) -> Self:
         """
         Marks the dataset as terminated with the terminated reason based on the last job.

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -200,6 +200,7 @@ class Dataset(TimestampedModel):
 
         return data
 
+    # TODO: common.TODO_AFTER_BULK_REFACTOR
     def update_from_last_job(self, save: bool = True) -> None:
         """
         Updates the dataset's state based on the latest job.
@@ -210,22 +211,22 @@ class Dataset(TimestampedModel):
 
         match last_job.state:
             case JobStates.PENDING:
-                self.on_job_pending()
+                self.on_job_pending(last_job)
             case JobStates.PROCESSING:
-                self.on_job_processing()
+                self.on_job_processing(last_job)
             case JobStates.SUCCEEDED:
-                self.on_job_succeeded()
+                self.on_job_succeeded(last_job)
             case JobStates.FAILED:
-                self.on_job_failed()
+                self.on_job_failed(last_job)
             case JobStates.TERMINATED:
-                self.on_job_terminated()
+                self.on_job_terminated(last_job)
 
         if save:
             self.save()
 
-    def apply_job_state(self) -> None:
+    def apply_job_state(self, job) -> None:
         """
-        Sets the dataset state (flag, reason, timestamps) based on the last job state.
+        Sets the dataset state (flag, reason, timestamps) based on the given job.
         Resets states before applying changes.
         """
         # Resets all state flags and reasons
@@ -243,49 +244,53 @@ class Dataset(TimestampedModel):
         for state in reset_states:
             setattr(self, f"{state.lower()}_at", None)
 
-        # Sets the current states
-        last_job = self.jobs.order_by("-pending_at").first()
-        state_str = last_job.state.lower()
+        # Sets new states based on the given job
+        state_str = job.state.lower()
         reason_attr = f"{state_str}_reason"
 
         setattr(self, f"is_{state_str}", True)
         setattr(self, f"{state_str}_at", make_aware(datetime.now()))
         if hasattr(self, f"{state_str}_reason"):
-            setattr(self, f"{state_str}_reason", getattr(last_job, reason_attr))
+            setattr(self, f"{state_str}_reason", getattr(job, reason_attr))
 
-    def on_job_pending(self) -> Self:
+    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    def on_job_pending(self, job) -> Self:
         """
         Marks the dataset as pending based on the last job.
         """
-        self.apply_job_state()
+        self.apply_job_state(job)
         return self
 
-    def on_job_processing(self) -> Self:
+    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    def on_job_processing(self, job) -> Self:
         """
         Marks the dataset as processing based on the last job.
         """
-        self.apply_job_state()
+        self.apply_job_state(job)
         return self
 
-    def on_job_succeeded(self) -> Self:
+    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    def on_job_succeeded(self, job) -> Self:
         """
         Marks the dataset as succeeded based on the last job.
         """
-        self.apply_job_state()
+        self.apply_job_state(job)
         return self
 
-    def on_job_failed(self) -> Self:
+    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    def on_job_failed(self, job) -> Self:
         """
         Marks the dataset as failed with the failure reason based on the last job.
         """
-        self.apply_job_state()
+        self.apply_job_state(job)
         return self
 
-    def on_job_terminated(self) -> Self:
+    # TODO: common.TODO_AFTER_BULK_REFACTOR
+    def on_job_terminated(self, job) -> Self:
         """
         Marks the dataset as terminated with the terminated reason based on the last job.
         """
-        self.apply_job_state()
+        self.apply_job_state(job)
         return self
 
     @property

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -305,7 +305,7 @@ class Job(TimestampedModel):
         self.dataset.apply_job_state(self)  # Sync the dataset state
         return True
 
-    # TODO: common.TODO_REMOVE_OBSOLETE
+    # TODO: Remove obsolete code blocks related to old sync state flows
     def update_state_at(self, save: bool = True) -> None:
         """
         Updates timestamp fields, *_at, based on the latest job state.
@@ -369,7 +369,7 @@ class Job(TimestampedModel):
         changed = self.apply_state(JobStates.PROCESSING)
         if changed:
             self.save()
-            if self.dataset:  # TODD: common.TODO_AFTER_DATASET_RELEASE
+            if self.dataset:  # TODO: Remove after the dataset release
                 self.dataset.save()
 
         return True
@@ -397,7 +397,7 @@ class Job(TimestampedModel):
         changed = self.apply_state(new_state, reason)
         if changed:
             self.save()
-            if self.dataset:  # TODD: common.TODO_AFTER_DATASET_RELEASE
+            if self.dataset:  # TODO: Remove after the dataset release
                 self.dataset.save()
 
         return True
@@ -418,7 +418,7 @@ class Job(TimestampedModel):
         changed = self.apply_state(JobStates.TERMINATED, reason)
         if changed:
             self.save()
-            if self.dataset:  # TODD: common.TODO_AFTER_DATASET_RELEASE
+            if self.dataset:  # TODO: Remove after the dataset release
                 self.dataset.save()
 
         return True
@@ -449,7 +449,7 @@ class Job(TimestampedModel):
         new_job.apply_state(JobStates.PENDING)
         if save:
             new_job.save()
-            if new_job.dataset:  # TODD: common.TODO_AFTER_DATASET_RELEASE
+            if new_job.dataset:  # TODO: Remove after the dataset release
                 new_job.dataset.save()
 
         return new_job

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -366,8 +366,8 @@ class Job(TimestampedModel):
             return False
 
         self.batch_job_id = job_id
-        changed = self.apply_state(JobStates.PROCESSING)
-        if changed:
+
+        if self.apply_state(JobStates.PROCESSING):
             self.save()
             if self.dataset:  # TODO: Remove after the dataset release
                 self.dataset.save()
@@ -394,8 +394,7 @@ class Job(TimestampedModel):
         if new_state == self.state:
             return False
 
-        changed = self.apply_state(new_state, reason)
-        if changed:
+        if self.apply_state(new_state, reason):
             self.save()
             if self.dataset:  # TODO: Remove after the dataset release
                 self.dataset.save()
@@ -415,8 +414,7 @@ class Job(TimestampedModel):
         if not batch.terminate_job(self):
             return False
 
-        changed = self.apply_state(JobStates.TERMINATED, reason)
-        if changed:
+        if self.apply_state(JobStates.TERMINATED, reason):
             self.save()
             if self.dataset:  # TODO: Remove after the dataset release
                 self.dataset.save()

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -180,7 +180,7 @@ class Job(TimestampedModel):
         retry_jobs = []
 
         for job in jobs:
-            retry_jobs.append(job.get_retry_job())
+            retry_jobs.append(job.get_retry_job(save=False))
 
         cls.bulk_update_state(jobs)
         cls.objects.bulk_create(retry_jobs)
@@ -287,6 +287,24 @@ class Job(TimestampedModel):
         cls.bulk_update_state(synced_jobs)
         return True
 
+    def apply_state(self, state: JobStates, reason: str | None = None) -> bool:
+        """
+        Sets the job's state, timestamp, and reason.
+        Calls the dataset's method to sync the job's state.
+        Returns a boolean indicating if the caller should save updates.
+        """
+        if self.state == state:
+            return False
+
+        self.state = state
+        state_str = state.lower()
+        setattr(self, f"{state_str}_at", make_aware(datetime.now()))
+        if hasattr(self, f"{state_str}_reason"):
+            setattr(self, f"{state_str}_reason", reason)
+
+        self.dataset.apply_job_state(self)  # Sync the dataset state
+        return True
+
     def update_state_at(self, save: bool = True) -> None:
         """
         Updates timestamp fields, *_at, based on the latest job state.
@@ -327,10 +345,10 @@ class Job(TimestampedModel):
 
     def submit(self) -> bool:
         """
-        Submits the unsaved PENDING job to AWS Batch.
-        Updates batch_job_id, state, and processing_at fields,
-        and its associated dataset state.
-        Saves the changes to the db on success.
+        Submits the PENDING job to AWS Batch and assigns batch_job_id.
+        Saves the job as PROCESSING (state, timestamp).
+        Calls the dataset's method to sync the job's state.
+        Returns a boolean indicating if the job and dataset were updated and saved.
         """
         if self.state is not JobStates.PENDING:
             return False
@@ -364,15 +382,21 @@ class Job(TimestampedModel):
             return False
 
         self.batch_job_id = job_id
-        self.state = JobStates.PROCESSING
-        self.update_state_at(save=False)
-
-        self.save()  # Save this instance before bulk updating fields
-        Job.bulk_update_state([self])
+        changed = self.apply_state(JobStates.PROCESSING)
+        if changed:
+            self.save()
+            if self.dataset:  # TODD: common.TODO_AFTER_DATASET_RELEASE
+                self.dataset.save()
 
         return True
 
     def sync_state(self) -> bool:
+        """
+        Syncs the job state with the AWS Batch status.
+        Saves the job if the state has changed (state, timestamp, reason).
+        Calls the dataset's method to sync the job's state.
+        Returns a boolean indicating if the job and dataset were updated and saved.
+        """
         if self.state is not JobStates.PROCESSING:
             return False
 
@@ -381,23 +405,25 @@ class Job(TimestampedModel):
         if not aws_jobs:
             return False
 
-        new_state, failed_reason = self.get_job_state(aws_jobs[0])
+        new_state, reason = self.get_job_state(aws_jobs[0])
 
         if new_state == self.state:
             return False
 
-        self.state = new_state
-        self.failed_reason = failed_reason
-        self.update_state_at(save=False)
-
-        Job.bulk_update_state([self])
+        changed = self.apply_state(new_state, reason)
+        if changed:
+            self.save()
+            if self.dataset:  # TODD: common.TODO_AFTER_DATASET_RELEASE
+                self.dataset.save()
 
         return True
 
     def terminate(self, reason: str | None = "Terminated processing job") -> bool:
         """
-        Terminates the processing, incomplete job on AWS Batch.
-        Updates state and terminated_at with the given terminated reason.
+        Terminates the PROCESSING job (incomplete) on AWS Batch.
+        Save the job as TERMINATED (state, timestamp, reason)
+        Calls the dataset's method to sync the job's state.
+        Returns a boolean indicating if the job and dataset were updated and saved.
         """
         if self.state in common.FINAL_JOB_STATES:
             return self.state == JobStates.TERMINATED
@@ -405,25 +431,29 @@ class Job(TimestampedModel):
         if not batch.terminate_job(self):
             return False
 
-        self.state = JobStates.TERMINATED
-        self.terminated_reason = reason
-        self.update_state_at(save=False)
-
-        Job.bulk_update_state([self])
+        changed = self.apply_state(JobStates.TERMINATED, reason)
+        if changed:
+            self.save()
+            if self.dataset:  # TODD: common.TODO_AFTER_DATASET_RELEASE
+                self.dataset.save()
 
         return True
 
-    def get_retry_job(self) -> Self | bool:
+    def get_retry_job(self, save: bool = True) -> Self | bool:
         """
-        Prepares a new Job instance for retry.
-        Returns newly instantiated jobs.
+        Prepares a new PENDING job for retry with:
+        - incremented attempt count
+        - batch fields
+        - the associated dataset
+        By default, saves the new job as PENDING (state, timestamp).
+        (For bulk operations, the caller should pass False to prevent saving.)
+        Calls the dataset's method to sync the job's state.
+        Returns the new job, or False if the current job is not in a final state.
         """
         if self.state not in common.FINAL_JOB_STATES:
             return False
 
-        Job.bulk_update_state([self])
-
-        return Job(
+        new_job = Job(
             attempt=self.attempt + 1,
             batch_job_name=self.batch_job_name,
             batch_job_definition=self.batch_job_definition,
@@ -431,3 +461,11 @@ class Job(TimestampedModel):
             batch_container_overrides=self.batch_container_overrides,
             dataset=self.dataset,
         )
+
+        new_job.apply_state(JobStates.PENDING)
+        if save:
+            new_job.save()
+            if new_job.dataset:  # TODD: common.TODO_AFTER_DATASET_RELEASE
+                new_job.dataset.save()
+
+        return new_job

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -305,6 +305,7 @@ class Job(TimestampedModel):
         self.dataset.apply_job_state(self)  # Sync the dataset state
         return True
 
+    # TODO: common.TODO_REMOVE_OBSOLETE
     def update_state_at(self, save: bool = True) -> None:
         """
         Updates timestamp fields, *_at, based on the latest job state.
@@ -325,23 +326,6 @@ class Job(TimestampedModel):
 
         if save:
             self.save()
-
-    def set_state(self, state: JobStates, reason: str = None):
-        """
-        Sets the job state and its corresponding timestamp.
-        Calls the associated dataset's on_job_<state> event handler.
-        """
-        state_str = state.lower()
-        reason_attr = f"{state_str}_reason"
-        # event_handler = f"on_job_{state_str}"
-
-        self.state = state
-        if hasattr(self, reason_attr):
-            setattr(self, reason_attr, reason)
-        self.update_state_at()
-
-        # TODO: Update and improve Dataset model
-        # getattr(self.dataset, event_handler)()
 
     def submit(self) -> bool:
         """

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -47,31 +47,67 @@ class TestJob(TestCase):
             self.assertIsInstance(dataset.terminated_at, datetime)
         self.assertEqual(dataset.terminated_reason, terminated_reason)
 
-    def test_set_state(self):
-        # TODO: After refactoring dataset methods, add assertDatasetState.
+    def test_apply_state(self):
         job = JobFactory(state=JobStates.PENDING, dataset=DatasetFactory())
 
-        job.set_state(JobStates.PROCESSING)
+        # Update the state to PROCESSING
+        changed = job.apply_state(JobStates.PROCESSING)
+        if changed:
+            job.save()
+            job.dataset.save()
+        # Saved job and dataset should be updated
         saved_job = Job.objects.get(pk=job.pk)
         self.assertEqual(saved_job.state, JobStates.PROCESSING)
         self.assertIsInstance(saved_job.processing_at, datetime)
+        self.assertDatasetState(saved_job.dataset, is_pending=False, is_processing=True)
 
-        job.set_state(JobStates.SUCCEEDED)
+        # Update the state to SUCEEDED
+        changed = job.apply_state(JobStates.SUCCEEDED)
+        if changed:
+            job.save()
+            job.dataset.save()
+        # Saved job and dataset should be updated
         saved_job = Job.objects.get(pk=job.pk)
         self.assertEqual(saved_job.state, JobStates.SUCCEEDED)
         self.assertIsInstance(saved_job.succeeded_at, datetime)
+        self.assertDatasetState(saved_job.dataset, is_processing=False, is_succeeded=True)
 
-        job.set_state(JobStates.FAILED, reason=f"Job {JobStates.FAILED}")
+        # Update the state to FAILED
+        failed_reason = f"Job {JobStates.FAILED}"
+        changed = job.apply_state(JobStates.FAILED, failed_reason)
+        if changed:
+            job.save()
+            job.dataset.save()
+        # Saved job and dataset should be updated
         saved_job = Job.objects.get(pk=job.pk)
         self.assertEqual(saved_job.state, JobStates.FAILED)
-        self.assertEqual(saved_job.failed_reason, f"Job {JobStates.FAILED}")
+        self.assertEqual(saved_job.failed_reason, failed_reason)
         self.assertIsInstance(saved_job.failed_at, datetime)
+        self.assertDatasetState(
+            saved_job.dataset,
+            is_succeeded=False,
+            is_failed=True,
+            failed_reason=failed_reason,
+        )
 
-        job.set_state(JobStates.TERMINATED, reason=f"Job {JobStates.TERMINATED}")
+        # Update the state to TERMINATED
+        terminated_reason = f"Job {JobStates.TERMINATED}"
+        changed = job.apply_state(JobStates.TERMINATED, terminated_reason)
+        if changed:
+            job.save()
+            job.dataset.save()
+        # Saved job and dataset should be updated
         saved_job = Job.objects.get(pk=job.pk)
         self.assertEqual(saved_job.state, JobStates.TERMINATED)
-        self.assertEqual(saved_job.terminated_reason, f"Job {JobStates.TERMINATED}")
+        self.assertEqual(saved_job.terminated_reason, terminated_reason)
         self.assertIsInstance(saved_job.terminated_at, datetime)
+        self.assertDatasetState(
+            saved_job.dataset,
+            is_failed=False,
+            failed_reason=None,
+            is_terminated=True,
+            terminated_reason=terminated_reason,
+        )
 
     @patch("scpca_portal.batch.submit_job")
     def test_submit(self, mock_batch_submit_job):
@@ -211,7 +247,7 @@ class TestJob(TestCase):
         mock_batch_get_jobs.return_value = [
             {
                 "status": "FAILED",
-                "statusReason": "Job FAILED",
+                "statusReason": "Job TERMINATED",
                 "isTerminated": True,
             }
         ]
@@ -224,7 +260,7 @@ class TestJob(TestCase):
         saved_job = Job.objects.get(pk=processing_job.pk)
         self.assertEqual(saved_job.state, JobStates.TERMINATED)
         self.assertIsInstance(saved_job.terminated_at, datetime)
-        self.assertEqual(saved_job.failed_reason, "Job FAILED")
+        self.assertEqual(saved_job.terminated_reason, "Job TERMINATED")
         saved_job.dataset.update_from_last_job()  # Sync the associated dataset
         self.assertDatasetState(
             saved_job.dataset,
@@ -490,9 +526,8 @@ class TestJob(TestCase):
         job.batch_container_overrides = "BATCH_CONTAINER_OVERRIDES"
         job.attempt = 1
 
-        # After execution, the call should returns a new unsaved instance for retry
+        # After execution, the call should returns a new saved instance for retry
         retry_job = job.get_retry_job()
-        self.assertIsNone(retry_job.id)  # Should not have an ID
         # Should correctly copy the exsiting field values
         self.assertEqual(retry_job.batch_job_name, job.batch_job_name)
         self.assertEqual(retry_job.batch_job_definition, job.batch_job_definition)

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -51,40 +51,25 @@ class TestJob(TestCase):
         job = JobFactory(state=JobStates.PENDING, dataset=DatasetFactory())
 
         # Update the state to PROCESSING
-        changed = job.apply_state(JobStates.PROCESSING)
-        if changed:
-            job.save()
-            job.dataset.save()
-        # Saved job and dataset should be updated
-        saved_job = Job.objects.get(pk=job.pk)
-        self.assertEqual(saved_job.state, JobStates.PROCESSING)
-        self.assertIsInstance(saved_job.processing_at, datetime)
-        self.assertDatasetState(saved_job.dataset, is_pending=False, is_processing=True)
+        job.apply_state(JobStates.PROCESSING)
+        self.assertEqual(job.state, JobStates.PROCESSING)
+        self.assertIsInstance(job.processing_at, datetime)
+        self.assertDatasetState(job.dataset, is_pending=False, is_processing=True)
 
         # Update the state to SUCEEDED
-        changed = job.apply_state(JobStates.SUCCEEDED)
-        if changed:
-            job.save()
-            job.dataset.save()
-        # Saved job and dataset should be updated
-        saved_job = Job.objects.get(pk=job.pk)
-        self.assertEqual(saved_job.state, JobStates.SUCCEEDED)
-        self.assertIsInstance(saved_job.succeeded_at, datetime)
-        self.assertDatasetState(saved_job.dataset, is_processing=False, is_succeeded=True)
+        job.apply_state(JobStates.SUCCEEDED)
+        self.assertEqual(job.state, JobStates.SUCCEEDED)
+        self.assertIsInstance(job.succeeded_at, datetime)
+        self.assertDatasetState(job.dataset, is_processing=False, is_succeeded=True)
 
         # Update the state to FAILED
         failed_reason = f"Job {JobStates.FAILED}"
-        changed = job.apply_state(JobStates.FAILED, failed_reason)
-        if changed:
-            job.save()
-            job.dataset.save()
-        # Saved job and dataset should be updated
-        saved_job = Job.objects.get(pk=job.pk)
-        self.assertEqual(saved_job.state, JobStates.FAILED)
-        self.assertEqual(saved_job.failed_reason, failed_reason)
-        self.assertIsInstance(saved_job.failed_at, datetime)
+        job.apply_state(JobStates.FAILED, failed_reason)
+        self.assertEqual(job.state, JobStates.FAILED)
+        self.assertEqual(job.failed_reason, failed_reason)
+        self.assertIsInstance(job.failed_at, datetime)
         self.assertDatasetState(
-            saved_job.dataset,
+            job.dataset,
             is_succeeded=False,
             is_failed=True,
             failed_reason=failed_reason,
@@ -92,17 +77,12 @@ class TestJob(TestCase):
 
         # Update the state to TERMINATED
         terminated_reason = f"Job {JobStates.TERMINATED}"
-        changed = job.apply_state(JobStates.TERMINATED, terminated_reason)
-        if changed:
-            job.save()
-            job.dataset.save()
-        # Saved job and dataset should be updated
-        saved_job = Job.objects.get(pk=job.pk)
-        self.assertEqual(saved_job.state, JobStates.TERMINATED)
-        self.assertEqual(saved_job.terminated_reason, terminated_reason)
-        self.assertIsInstance(saved_job.terminated_at, datetime)
+        job.apply_state(JobStates.TERMINATED, terminated_reason)
+        self.assertEqual(job.state, JobStates.TERMINATED)
+        self.assertEqual(job.terminated_reason, terminated_reason)
+        self.assertIsInstance(job.terminated_at, datetime)
         self.assertDatasetState(
-            saved_job.dataset,
+            job.dataset,
             is_failed=False,
             failed_reason=None,
             is_terminated=True,


### PR DESCRIPTION
## Issue Number

Closes #1322 

## Purpose/Implementation Notes

Changes include:
- Added the `Job.apply_state` instance method for instance-level sync flow 
- Removed the now-obsolete `Job.set_state`
- Updated `Job` instance methods to use `Job.apply_state`
  - **NOTE:** `Job.get_retry_job` now takes a `save` kwarg for bulk updates (called via `Job.create_retry_jobs`) 
- Updated `Dataset.apply_job_state` to accept a job instance
- Temporarily updated the soon-to-be-removed `Dataset` methods to align with the changes (prevent tests failures)
- Added a new test for `Job.apply_state` and updated relevant tests in `TestJob`

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

- Updated `TestJob` to reflect the changes

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
