### PR TITLE
1328 - Requeue locked jobs during processing

### DIFF
--- a/api/scpca_portal/management/commands/process_dataset.py
+++ b/api/scpca_portal/management/commands/process_dataset.py
@@ -47,7 +47,10 @@ class Command(BaseCommand):
         try:
             job.process_dataset_job()
             job.state = JobStates.SUCCEEDED
-        except Exception:
+        except Exception as e:
+            if str(e) == "Dataset has a locked project.":
+                retry_job = job.get_retry_job()
+                retry_job.save()
             job.state = JobStates.FAILED
 
         job.update_state_at()

--- a/api/scpca_portal/management/commands/process_dataset.py
+++ b/api/scpca_portal/management/commands/process_dataset.py
@@ -49,8 +49,7 @@ class Command(BaseCommand):
             job.state = JobStates.SUCCEEDED
         except Exception as e:
             if str(e) == "Dataset has a locked project.":
-                retry_job = job.get_retry_job()
-                retry_job.save()
+                job.get_retry_job(save=True)
             job.state = JobStates.FAILED
 
         job.update_state_at()

--- a/api/scpca_portal/management/commands/process_dataset.py
+++ b/api/scpca_portal/management/commands/process_dataset.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             job.state = JobStates.SUCCEEDED
         except Exception as e:
             if str(e) == "Dataset has a locked project.":
-                job.get_retry_job(save=True)
+                job.get_retry_job()
             job.state = JobStates.FAILED
 
         job.update_state_at()

--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -165,11 +165,18 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
         """
         Computes a given dataset's zip archive and returns a corresponding ComputedFile object.
         """
+        if dataset.has_lockfile_projects or dataset.has_locked_projects:
+            raise Exception("Dataset has a locked project.")
+
         # If the query returns empty, then throw an error occurred.
         if not dataset.libraries.exists():
             raise ValueError("Unable to find libraries for Dataset.")
 
-        s3.download_files(dataset.original_files)
+        dataset_original_files = dataset.original_files
+        for project in dataset.projects:
+            s3.download_files(dataset_original_files.filter(project_id=project.scpca_id))
+            if dataset.has_lockfile_projects or dataset.has_locked_projects:
+                raise Exception("Dataset has a locked project.")
 
         with ZipFile(dataset.computed_file_local_path, "w") as zip_file:
             # Readme file

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -429,13 +429,13 @@ class Job(TimestampedModel):
 
         return True
 
-    def get_retry_job(self) -> Self | bool:
+    def get_retry_job(self) -> Self:
         """
         Prepares a new Job instance for retry.
         Returns newly instantiated jobs.
         """
         if self.state not in common.FINAL_JOB_STATES:
-            return False
+            raise Exception("Jobs in final states cannot be retried.")
 
         Job.bulk_update_state([self])
 

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 from zipfile import ZipFile
 
 from django.conf import settings
@@ -89,7 +89,12 @@ class TestGetFile(TestCase):
         dataset, _ = Dataset.get_or_find_ccdl_dataset(ccdl_name, project_id)
         dataset.save()
 
-        computed_file = ComputedFile.get_dataset_file(dataset)
+        with patch(
+            "scpca_portal.models.dataset.Dataset.has_lockfile_projects",
+            new_callable=PropertyMock,
+            return_value=[],
+        ):
+            computed_file = ComputedFile.get_dataset_file(dataset)
 
         # CHECK ZIP FILE
         with ZipFile(dataset.computed_file_local_path) as project_zip:
@@ -119,7 +124,12 @@ class TestGetFile(TestCase):
         )
         dataset.save()
 
-        ComputedFile.get_dataset_file(dataset)
+        with patch(
+            "scpca_portal.models.dataset.Dataset.has_lockfile_projects",
+            new_callable=PropertyMock,
+            return_value=[],
+        ):
+            ComputedFile.get_dataset_file(dataset)
 
         with ZipFile(dataset.computed_file_local_path) as project_zip:
             # Check if file list is as expected

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -544,7 +544,7 @@ class TestJob(TestCase):
         )
 
         with self.assertRaises(Exception) as e:
-            job.submit()
+            job.get_retry_job()
             self.assertEqual(str(e.exception), "Jobs in final states cannot be retried.")
 
         # Change the job state to TERMINATED

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -527,9 +527,9 @@ class TestJob(TestCase):
             dataset=DatasetFactory(is_processing=True),
         )
 
-        # After execution, the call should returns None
-        retry_job = job.get_retry_job()
-        self.assertFalse(retry_job)
+        with self.assertRaises(Exception) as e:
+            job.submit()
+            self.assertEqual(str(e.exception), "Jobs in final states cannot be retried.")
 
         # Change the job state to TERMINATED
         job.state = JobStates.TERMINATED


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1328.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

In this PR, checks are made for lockfile and locked projects during processing, and should lockfile or locked projects be found, jobs are failed and cloned. The retry job then enters into the pending queue, to be dispatched at a later point.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

- Additions and updates made to current tests to account for changes

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A
