### PR TITLE
1349 - Add save kwarg to Job instance methods for bulk and instance-level updates

### DIFF
--- a/api/scpca_portal/batch.py
+++ b/api/scpca_portal/batch.py
@@ -8,6 +8,7 @@ from botocore.client import Config
 
 from scpca_portal import utils
 from scpca_portal.config.logging import get_and_configure_logger
+from scpca_portal.exceptions import BatchGetJobsFailedError
 
 logger = get_and_configure_logger(__name__)
 aws_batch = boto3.client(
@@ -73,7 +74,8 @@ def terminate_job(job) -> bool:
 def get_jobs(batch_jobs: Iterable["Job"]) -> List[Dict] | None:  # noqa: F821
     """
     Fetch AWS Batch job(s) for the given one or more job(s) in bulk.
-    Return a list of fetched jobs on success, otherwise return None.
+    Raises BatchGetJobsFailedError on failure.
+    Return a list of fetched jobs on success.
     """
     max_limit = 100  # Limit of job IDs to send per request
     jobs = []
@@ -86,8 +88,11 @@ def get_jobs(batch_jobs: Iterable["Job"]) -> List[Dict] | None:  # noqa: F821
         except Exception as error:
             logger.exception(
                 f"Failed to bulk fetch AWS Batch job{pluralize(len(batch_job_ids))} "
-                f"for job IDs: {', '.join(batch_job_ids)} due to: \n\t{error}"
+                f"for job ID{pluralize(len(batch_job_ids))}: "
+                f"{', '.join(batch_job_ids)} due to: \n\t{error}"
             )
-            return None
+            raise BatchGetJobsFailedError(job_ids=batch_job_ids) from error
+
+    logger.info("AWS Job fetch complete.", batch_job_ids=batch_job_ids)
 
     return jobs

--- a/api/scpca_portal/batch.py
+++ b/api/scpca_portal/batch.py
@@ -81,17 +81,16 @@ def get_jobs(batch_jobs: Iterable["Job"]) -> List[Dict] | None:  # noqa: F821
     jobs = []
 
     if batch_job_ids := [job.batch_job_id for job in batch_jobs]:
-        try:
-            for chunk in utils.get_chunk_list(batch_job_ids, max_limit):
+        for chunk in utils.get_chunk_list(batch_job_ids, max_limit):
+            try:
                 response = aws_batch.describe_jobs(jobs=chunk)
                 jobs.extend(response["jobs"])
-        except Exception as error:
-            logger.exception(
-                f"Failed to bulk fetch AWS Batch job{pluralize(len(batch_job_ids))} "
-                f"for job ID{pluralize(len(batch_job_ids))}: "
-                f"{', '.join(batch_job_ids)} due to: \n\t{error}"
-            )
-            raise BatchGetJobsFailedError(job_ids=batch_job_ids) from error
+            except Exception as error:
+                logger.exception(
+                    f"Failed to bulk fetch AWS Batch job{pluralize(len(chunk))} "
+                    f"for job IDs: {', '.join(chunk)} due to: \n\t{error}"
+                )
+                raise BatchGetJobsFailedError(job_ids=batch_job_ids) from error
 
     logger.info("AWS Job fetch complete.", batch_job_ids=batch_job_ids)
 

--- a/api/scpca_portal/exceptions.py
+++ b/api/scpca_portal/exceptions.py
@@ -46,3 +46,15 @@ class JobInvalidRetryStateError(JobError):
     def __init__(self, job=None):
         message = "Jobs in final states cannot be retried."
         super().__init__(message, job)
+
+
+class JobTerminateNotProcessingError(JobError):
+    def __init__(self, job=None):
+        message = "Jobs in final states cannot be terminated."
+        super().__init__(message, job)
+
+
+class JobTerminationFailedError(JobError):
+    def __init__(self, job=None):
+        message = "Error terminating job in Batch."
+        super().__init__(message, job)

--- a/api/scpca_portal/exceptions.py
+++ b/api/scpca_portal/exceptions.py
@@ -1,3 +1,30 @@
+from django.template.defaultfilters import pluralize
+
+
+# scpca_portal.batch
+class BatchError(Exception):
+    def __init__(self, message: str | None = None, job=None, job_ids=None):
+        default_message = "A boto3 batch client error occurred."
+        message = message or default_message
+        super().__init__(message)
+        # For logging
+        self.job = job
+        self.job_ids = job_ids
+
+
+class BatchGetJobsFailedError(BatchError):
+    def __init__(self, job_ids=None):
+        job_ids = job_ids or []
+        if job_ids:
+            message = (
+                f"Failed to fetch AWS Batch job{pluralize(len(job_ids))} "
+                f"for job ID{pluralize(len(job_ids))}: {', '.join(job_ids)}"
+            )
+        else:
+            message = "Failed to fetch AWS Batch jobs: no job IDs."
+        super().__init__(message, job_ids=job_ids)
+
+
 class DatasetError(Exception):
     def __init__(self, message: str | None = None, dataset=None):
         default_message = "A dataset error occurred."
@@ -36,6 +63,12 @@ class JobSubmitNotPendingError(JobError):
         super().__init__(message, job)
 
 
+class JobSyncNotProcessingError(JobError):
+    def __init__(self, job=None):
+        message = "Job is not in a processing state."
+        super().__init__(message, job)
+
+
 class JobSubmissionFailedError(JobError):
     def __init__(self, job=None):
         message = "Error submitting job to Batch."
@@ -51,6 +84,12 @@ class JobInvalidRetryStateError(JobError):
 class JobInvalidTerminateStateError(JobError):
     def __init__(self, job=None):
         message = "Jobs in final states cannot be terminated."
+        super().__init__(message, job)
+
+
+class JobSyncStateFailedError(JobError):
+    def __init__(self, job=None):
+        message = "Error syncing job state with Batch."
         super().__init__(message, job)
 
 

--- a/api/scpca_portal/exceptions.py
+++ b/api/scpca_portal/exceptions.py
@@ -48,7 +48,7 @@ class JobInvalidRetryStateError(JobError):
         super().__init__(message, job)
 
 
-class JobTerminateNotProcessingError(JobError):
+class JobInvalidTerminateStateError(JobError):
     def __init__(self, job=None):
         message = "Jobs in final states cannot be terminated."
         super().__init__(message, job)

--- a/api/scpca_portal/exceptions.py
+++ b/api/scpca_portal/exceptions.py
@@ -4,7 +4,7 @@ from django.template.defaultfilters import pluralize
 # scpca_portal.batch
 class BatchError(Exception):
     def __init__(self, message: str | None = None, job=None, job_ids=None):
-        default_message = "A boto3 batch client error occurred."
+        default_message = "An error occurred while communicating with AWS Batch API."
         message = message or default_message
         super().__init__(message)
         # For logging

--- a/api/scpca_portal/management/commands/process_dataset.py
+++ b/api/scpca_portal/management/commands/process_dataset.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
             # only locked datasets should generate retry jobs
             # datasets without libraries are malformed and should not be retried
             if isinstance(e, DatasetLockedProjectError):
-                job.get_retry_job()
+                job.create_retry_job()
             job.apply_state(JobStates.FAILED)
 
         job.save()

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -196,7 +196,7 @@ class Job(TimestampedModel):
         retry_datasets = []
 
         for job in jobs:
-            if retry_job := job.get_retry_job(save=False):
+            if retry_job := job.create_retry_job(save=False):
                 retry_jobs.append(retry_job)
                 if job.dataset:  # TODO: Remove after the dataset release
                     retry_datasets.append(job.dataset)
@@ -453,7 +453,7 @@ class Job(TimestampedModel):
 
         return True
 
-    def get_retry_job(self, save: bool = True) -> Self:
+    def create_retry_job(self, save: bool = True) -> Self:
         """
         Prepares a new PENDING job for retry with:
         - incremented attempt count

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -314,12 +314,10 @@ class Job(TimestampedModel):
         """
         processing_jobs = cls.objects.filter(state=JobStates.PROCESSING)
         if not processing_jobs.exists():
-            logger.info("No processing jobs to sync.")
             return False
 
         synced_jobs = []
         synced_datasets = []
-        unchanged_jobs = []
         failed_job_ids = []
 
         fetched_jobs = []
@@ -338,8 +336,6 @@ class Job(TimestampedModel):
                     synced_jobs.append(job)
                     if job.dataset:  # TODO: Remove after the dataset release
                         synced_datasets.append(job.dataset)
-                else:
-                    unchanged_jobs.append(job)
 
         if not synced_jobs:
             logger.info("No jobs were updated during sync.")
@@ -347,11 +343,10 @@ class Job(TimestampedModel):
 
         logger.info(f"Synced {len(synced_jobs)} jobs with AWS.")
         cls.bulk_update_state(synced_jobs)
+
         if synced_datasets:  # TODO: Remove after the dataset release
             Dataset.bulk_update_state(synced_datasets)
 
-        if unchanged_jobs:
-            logger.info(f"{len(unchanged_jobs)} jobs remain unchanged and are still processing.")
         if failed_job_ids:
             logger.info(f"{len(failed_job_ids)} jobs failed to sync.")
 

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -372,7 +372,7 @@ class Job(TimestampedModel):
         self.dataset.apply_job_state(self)  # Sync the dataset state
         return True
 
-    def submit(self, save=True):
+    def submit(self, *, save=True):
         """
         Submits the PENDING job to AWS Batch and assigns batch_job_id.
         By default, saves the job as PROCESSING (state, timestamp).
@@ -452,7 +452,7 @@ class Job(TimestampedModel):
 
         return True
 
-    def terminate(self, reason: str | None = "Terminated processing job", save=True):
+    def terminate(self, reason: str | None = "Terminated processing job", *, save=True):
         """
         Terminates the PROCESSING job (incomplete) on AWS Batch.
         By default, saves the job as TERMINATED (state, timestamp, reason)
@@ -474,7 +474,7 @@ class Job(TimestampedModel):
             if self.dataset:  # TODO: Remove after the dataset release
                 self.dataset.save()
 
-    def create_retry_job(self, save: bool = True) -> Self:
+    def create_retry_job(self, *, save: bool = True) -> Self:
         """
         Prepares a new PENDING job for retry with:
         - incremented attempt count

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -343,7 +343,6 @@ class Job(TimestampedModel):
 
         logger.info(f"Synced {len(synced_jobs)} jobs with AWS.")
         cls.bulk_update_state(synced_jobs)
-
         if synced_datasets:  # TODO: Remove after the dataset release
             Dataset.bulk_update_state(synced_datasets)
 

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -398,6 +398,10 @@ class Job(TimestampedModel):
                 self.batch_job_queue = settings.AWS_BATCH_EC2_JOB_QUEUE_NAME
                 self.batch_job_definition = settings.AWS_BATCH_EC2_JOB_DEFINITION_NAME
 
+            # Save job to get ID before submitting
+            if not self.id:
+                self.save()
+
             self.batch_container_overrides = {
                 "command": [
                     "python",

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -8,11 +8,14 @@ from django.utils.timezone import make_aware
 from scpca_portal import common
 from scpca_portal.enums import JobStates
 from scpca_portal.exceptions import (
+    BatchGetJobsFailedError,
     DatasetLockedProjectError,
     JobInvalidRetryStateError,
     JobInvalidTerminateStateError,
     JobSubmissionFailedError,
     JobSubmitNotPendingError,
+    JobSyncNotProcessingError,
+    JobSyncStateFailedError,
     JobTerminationFailedError,
 )
 from scpca_portal.models import Dataset, Job
@@ -239,31 +242,28 @@ class TestJob(TestCase):
 
     @patch("scpca_portal.batch.get_jobs")
     def test_sync_state(self, mock_batch_get_jobs):
-        # Job state is not PROCESSING
-        succeeded_job = JobFactory(state=JobStates.SUCCEEDED, dataset=DatasetFactory())
+        # Set up mock for get_jobs for AWS Batch 'PENDING' status
+        mock_batch_get_jobs.return_value = [
+            {
+                "status": "PENDING",
+                "statusReason": "Job PENDING",
+            }
+        ]
 
-        # Should return False early without calling get_jobs
-        success = succeeded_job.sync_state()
-        mock_batch_get_jobs.assert_not_called()
-        self.assertFalse(success)
-
-        # Job is in PROCESSING state
         processing_job = JobFactory(
             state=JobStates.PROCESSING, dataset=DatasetFactory(is_processing=True)
         )
 
-        # Set up mock for get_jobs call
-        mock_batch_get_jobs.return_value = False
-
-        success = processing_job.sync_state()
+        changed = processing_job.sync_state()
         mock_batch_get_jobs.assert_called()
-        self.assertFalse(success)  # Synced but no update in the db
+        self.assertFalse(changed)  # No job state change
 
-        # Job should remain unchanged and unsaved
+        # Job should remain in PROCESSING state
         saved_job = Job.objects.get(pk=processing_job.pk)
         self.assertEqual(saved_job, processing_job)
 
-        # Set up mock for get_jobs for 'RUNNING'
+        # Set up mock for get_jobs for AWS Batch 'RUNNING' status
+        mock_batch_get_jobs.reset_mock()
         mock_batch_get_jobs.return_value = [
             {
                 "status": "RUNNING",
@@ -271,15 +271,68 @@ class TestJob(TestCase):
             }
         ]
 
-        success = processing_job.sync_state()
+        changed = processing_job.sync_state()
         mock_batch_get_jobs.assert_called()
-        self.assertFalse(success)  # Synced but no update in the db
+        self.assertFalse(changed)  # No job state change
 
-        # Job should remain unchanged and unsaved
+        # Job should remain in PROCESSING state
         saved_job = Job.objects.get(pk=processing_job.pk)
         self.assertEqual(saved_job, processing_job)
 
-        # Set up mock for get_jobs with'TERMINATED'
+        # Set up mock for get_jobs for AWS 'SUCCEEDED' status
+        mock_batch_get_jobs.reset_mock()
+        mock_batch_get_jobs.return_value = [
+            {
+                "status": "SUCCEEDED",
+                "statusReason": "Job SUCCEEDED",
+            }
+        ]
+
+        processing_job = JobFactory(
+            state=JobStates.PROCESSING, dataset=DatasetFactory(is_processing=True)
+        )
+
+        changed = processing_job.sync_state()
+        mock_batch_get_jobs.assert_called()
+        self.assertTrue(changed)  # Job state synced
+
+        # Job should be updated from PROCESSING to SUCCEEDED
+        saved_job = Job.objects.get(pk=processing_job.pk)
+        self.assertEqual(saved_job.state, JobStates.SUCCEEDED)
+        self.assertIsInstance(saved_job.succeeded_at, datetime)
+        self.assertDatasetState(saved_job.dataset, is_processing=False, is_succeeded=True)
+
+        # Set up mock for get_jobs for AWS 'FAILED' status
+        mock_batch_get_jobs.reset_mock()
+        mock_batch_get_jobs.return_value = [
+            {
+                "status": "FAILED",
+                "statusReason": "Job FAILED",
+            }
+        ]
+
+        processing_job = JobFactory(
+            state=JobStates.PROCESSING, dataset=DatasetFactory(is_processing=True)
+        )
+
+        changed = processing_job.sync_state()
+        mock_batch_get_jobs.assert_called()
+        self.assertTrue(changed)  # Job state synced
+
+        # Job should be updated from PROCESSING to FAILED
+        saved_job = Job.objects.get(pk=processing_job.pk)
+        self.assertEqual(saved_job.state, JobStates.FAILED)
+        self.assertEqual(saved_job.failed_reason, "Job FAILED")
+        self.assertIsInstance(saved_job.failed_at, datetime)
+        self.assertDatasetState(
+            saved_job.dataset,
+            is_processing=False,
+            is_failed=True,
+            failed_reason=saved_job.failed_reason,
+        )
+
+        # Set up mock for get_jobs for AWS Batch 'TERMINATED' status
+        mock_batch_get_jobs.reset_mock()
         mock_batch_get_jobs.return_value = [
             {
                 "status": "FAILED",
@@ -288,11 +341,15 @@ class TestJob(TestCase):
             }
         ]
 
-        success = processing_job.sync_state()
-        mock_batch_get_jobs.assert_called()
-        self.assertTrue(success)  # Synced and updated the db
+        processing_job = JobFactory(
+            state=JobStates.PROCESSING, dataset=DatasetFactory(is_processing=True)
+        )
 
-        # Job should be updated and saved with correct field values
+        changed = processing_job.sync_state()
+        mock_batch_get_jobs.assert_called()
+        self.assertTrue(changed)  # Job state synced
+
+        # Job should be updated from PROCESSING to TERMINATED
         saved_job = Job.objects.get(pk=processing_job.pk)
         self.assertEqual(saved_job.state, JobStates.TERMINATED)
         self.assertIsInstance(saved_job.terminated_at, datetime)
@@ -304,33 +361,41 @@ class TestJob(TestCase):
             terminated_reason=saved_job.terminated_reason,
         )
 
-        # Job is in PROCESSING state
+    @patch("scpca_portal.batch.get_jobs")
+    def test_sync_state_handle_exception(self, mock_batch_get_jobs):
+        pending_job = JobFactory(
+            state=JobStates.PENDING,
+            dataset=DatasetFactory(is_pending=True, pending_at=make_aware(datetime.now())),
+        )
+
+        with self.assertRaises(JobSyncNotProcessingError):
+            pending_job.sync_state()
+
+        # Should not call get_jobs for the PENDING job
+        mock_batch_get_jobs.assert_not_called()
+
+        # Job should remain in PROCESSING state
+        saved_job = Job.objects.get(pk=pending_job.pk)
+        self.assertEqual(saved_job.state, pending_job.state)
+        self.assertDatasetState(saved_job.dataset, is_pending=True)
+
+        # Set up mock side effect for BatchGetJobsFailedError
+        mock_batch_get_jobs.side_effect = BatchGetJobsFailedError()
+
         processing_job = JobFactory(
-            state=JobStates.PROCESSING, dataset=DatasetFactory(is_processing=True)
+            state=JobStates.PROCESSING,
+            dataset=DatasetFactory(is_processing=True, processing_at=make_aware(datetime.now())),
         )
-        # Set up mock for get_jobs with 'FAILED'
-        mock_batch_get_jobs.return_value = [
-            {
-                "status": "FAILED",
-                "statusReason": "Job FAILED",
-            }
-        ]
 
-        success = processing_job.sync_state()
-        mock_batch_get_jobs.assert_called()
-        self.assertTrue(success)  # Synced and updated the db
+        with self.assertRaises(JobSyncStateFailedError):
+            processing_job.sync_state()
 
-        # Job should be updated and saved with correct field values
+        mock_batch_get_jobs.assert_called_once()
+
+        # Job should remain in PROCESSING state on boto3 request failure
         saved_job = Job.objects.get(pk=processing_job.pk)
-        self.assertEqual(saved_job.state, JobStates.FAILED)
-        self.assertEqual(saved_job.failed_reason, "Job FAILED")
-        self.assertIsInstance(saved_job.failed_at, datetime)
-        self.assertDatasetState(
-            saved_job.dataset,
-            is_processing=False,
-            is_failed=True,
-            failed_reason=saved_job.failed_reason,
-        )
+        self.assertEqual(saved_job.state, processing_job.state)
+        self.assertDatasetState(saved_job.dataset, is_processing=True)
 
     @patch("scpca_portal.batch.get_jobs")
     def test_bulk_sync_state(self, mock_batch_get_jobs):

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -543,7 +543,7 @@ class TestJob(TestCase):
         mock_batch_terminate_job.assert_not_called()
         self.assertEqual(response, [])  # No termination with no error
 
-    def test_get_retry_job(self):
+    def test_create_retry_job(self):
         # Set up a non-terminated job
         job = JobFactory(
             state=JobStates.PROCESSING,
@@ -551,7 +551,7 @@ class TestJob(TestCase):
         )
 
         with self.assertRaises(JobInvalidRetryStateError):
-            job.get_retry_job()
+            job.create_retry_job()
 
         # Change the job state to TERMINATED
         job.state = JobStates.TERMINATED
@@ -564,7 +564,7 @@ class TestJob(TestCase):
         job.attempt = 1
 
         # After execution, the call should returns a new saved instance for retry
-        retry_job = job.get_retry_job()
+        retry_job = job.create_retry_job()
         # Should correctly copy the exsiting field values
         self.assertEqual(retry_job.batch_job_name, job.batch_job_name)
         self.assertEqual(retry_job.batch_job_definition, job.batch_job_definition)

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -10,9 +10,9 @@ from scpca_portal.enums import JobStates
 from scpca_portal.exceptions import (
     DatasetLockedProjectError,
     JobInvalidRetryStateError,
+    JobInvalidTerminateStateError,
     JobSubmissionFailedError,
     JobSubmitNotPendingError,
-    JobTerminateNotProcessingError,
     JobTerminationFailedError,
 )
 from scpca_portal.models import Dataset, Job
@@ -478,7 +478,7 @@ class TestJob(TestCase):
         self.assertEqual(saved_job.state, processing_job.state)
         self.assertDatasetState(saved_job.dataset, is_processing=True)
 
-        # Reset mock call attributes for JobTerminateNotProcessingError
+        # Reset mock call attributes for JobInvalidTerminateStateError
         mock_batch_terminate_job.reset_mock()
 
         succeeded_job = JobFactory(
@@ -486,7 +486,7 @@ class TestJob(TestCase):
             dataset=DatasetFactory(is_succeeded=True, succeeded_at=make_aware(datetime.now())),
         )
 
-        with self.assertRaises(JobTerminateNotProcessingError):
+        with self.assertRaises(JobInvalidTerminateStateError):
             succeeded_job.terminate()
 
         # Should not call terminate_job for the job in final states


### PR DESCRIPTION
## Issue Number

Closes #1349

## Purpose/Implementation Notes

Changes include:

- In `Job` model:
  - Renamed `get_retry_job` to `create_retry_job`
  - Refactored instance methods and adjusted corresponding class methods for bulk operations:
    - `submit` and `submit_pending`
    - `terminate` and `terminate_processing`
    - `sync_state` and `bulk_sync_state`

- In `exceptions`:
  - Added new `JobError` subclasses: 
     -  `JobSyncNotProcessingError`
     -  `JobInvalidTerminateStateError`
     -  `JobSyncStateFailedError`
     -  `JobTerminationFailedError`
  - Added `BatchError` and its subclass `BatchGetJobsFailedError`

- In `batch`:
  - Refactor  `batch.get_jobs` to use `BatchGetJobsFailedError`

- Updated existing tests and added new one for exceptions in `TestJob`

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

Updated: 
- `TestJob.test_sync_state`
- `TestJob.test_terminate` 

Added:
- `TestJob.test_sync_state_handle_exception`
- `TestJob.test_terminate_handle_exception`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
