### PR TITLE
Enable staging datasets with ENABLE_DATASETS envar

### DIFF
--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -40,3 +40,4 @@ jobs:
         run: cd infrastructure && python3 deploy.py -s staging -u deployer -a ccdlstaging -v $(git rev-parse HEAD) --project
         env:
           SENTRY_ENV: staging-api
+          ENABLE_DATASETS: "true"

--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -112,6 +112,8 @@ class Common(Configuration):
     # Indicates running in prod environment.
     PRODUCTION = False
 
+    # Management commands should remove locally downloaded or created data.
+    CLEAN_UP_DATA = False
     # Logging.
     LOGGING = {
         "version": 1,

--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -114,6 +114,12 @@ class Common(Configuration):
 
     # Management commands should remove locally downloaded or created data.
     CLEAN_UP_DATA = False
+
+    # Enable features before completed.
+    # Use this to prevent certain areas from going to production.
+    # By default this is enabled for local and tests.
+    ENABLE_FEATURE_PREVIEW = True
+
     # Logging.
     LOGGING = {
         "version": 1,

--- a/api/scpca_portal/config/production.py
+++ b/api/scpca_portal/config/production.py
@@ -46,6 +46,8 @@ class Production(Common):
 
     PRODUCTION = True
 
+    CLEAN_UP_DATA = True
+
     SENTRY_DSN = os.getenv("SENTRY_DSN", None)
 
     if SENTRY_DSN == "None":

--- a/api/scpca_portal/config/production.py
+++ b/api/scpca_portal/config/production.py
@@ -49,6 +49,8 @@ class Production(Common):
 
     CLEAN_UP_DATA = True
 
+    ENABLE_FEATURE_PREVIEW = strtobool(os.getenv("ENABLE_FEATURE_PREVIEW", "false"))
+
     SENTRY_DSN = os.getenv("SENTRY_DSN", None)
 
     if SENTRY_DSN == "None":

--- a/api/scpca_portal/config/production.py
+++ b/api/scpca_portal/config/production.py
@@ -1,4 +1,5 @@
 import os
+from distutils.util import strtobool
 from pathlib import Path
 
 import sentry_sdk

--- a/api/scpca_portal/management/commands/create_portal_metadata.py
+++ b/api/scpca_portal/management/commands/create_portal_metadata.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--clean-up-output-data", action=BooleanOptionalAction, default=settings.PRODUCTION
+            "--clean-up-output-data", action=BooleanOptionalAction, default=settings.CLEAN_UP_DATA
         )
         parser.add_argument(
             "--update-s3", action=BooleanOptionalAction, default=settings.UPDATE_S3_DATA

--- a/api/scpca_portal/management/commands/generate_computed_files.py
+++ b/api/scpca_portal/management/commands/generate_computed_files.py
@@ -44,13 +44,13 @@ class Command(BaseCommand):
             "--clean-up-input-data",
             action=BooleanOptionalAction,
             type=bool,
-            default=settings.PRODUCTION,
+            default=settings.CLEAN_UP_DATA,
         )
         parser.add_argument(
             "--clean-up-output-data",
             action=BooleanOptionalAction,
             type=bool,
-            default=settings.PRODUCTION,
+            default=settings.CLEAN_UP_DATA,
         )
         parser.add_argument("--max-workers", type=int, default=10)
         parser.add_argument("--scpca-project-id", type=str)

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -48,13 +48,13 @@ class Command(BaseCommand):
             "--clean-up-input-data",
             action=BooleanOptionalAction,
             type=bool,
-            default=settings.PRODUCTION,
+            default=settings.CLEAN_UP_DATA,
         )
         parser.add_argument(
             "--clean-up-output-data",
             action=BooleanOptionalAction,
             type=bool,
-            default=settings.PRODUCTION,
+            default=settings.CLEAN_UP_DATA,
         )
         parser.add_argument("--max-workers", type=int, default=10)
         parser.add_argument("--reload-existing", action="store_true", default=False)

--- a/api/scpca_portal/management/commands/load_metadata.py
+++ b/api/scpca_portal/management/commands/load_metadata.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
             "--clean-up-input-data",
             action=BooleanOptionalAction,
             type=bool,
-            default=settings.PRODUCTION,
+            default=settings.CLEAN_UP_DATA,
         )
         parser.add_argument(
             "--update-s3", action=BooleanOptionalAction, type=bool, default=settings.UPDATE_S3_DATA

--- a/api/scpca_portal/urls.py
+++ b/api/scpca_portal/urls.py
@@ -55,7 +55,7 @@ router.register(r"project-options", FilterOptionsViewSet, basename="project-opti
 router.register(r"stats", StatsViewSet, basename="stats")
 
 # Datasets are not ready for prime time yet.
-if not settings.ENABLE_DATASETS:
+if not settings.ENABLE_FEATURE_PREVIEW:
     router.register(r"datasets", DatasetViewSet, basename="datasets")
 
 urlpatterns = [

--- a/api/scpca_portal/urls.py
+++ b/api/scpca_portal/urls.py
@@ -55,7 +55,7 @@ router.register(r"project-options", FilterOptionsViewSet, basename="project-opti
 router.register(r"stats", StatsViewSet, basename="stats")
 
 # Datasets are not ready for prime time yet.
-if not settings.PRODUCTION:
+if not settings.ENABLE_DATASETS:
     router.register(r"datasets", DatasetViewSet, basename="datasets")
 
 urlpatterns = [

--- a/infrastructure/api-configuration/environment.tpl
+++ b/infrastructure/api-configuration/environment.tpl
@@ -17,4 +17,4 @@ AWS_SES_DOMAIN=${aws_ses_domain}
 SENTRY_DSN=${sentry_dsn}
 SENTRY_ENV=${sentry_env}
 SLACK_CCDL_TEST_CHANNEL_EMAIL=${slack_ccdl_test_channel_email}
-ENABLE_DATASETS=${enable_datasets}
+ENABLE_FEATURE_PREVIEW=${enable_feature_preview}

--- a/infrastructure/api-configuration/environment.tpl
+++ b/infrastructure/api-configuration/environment.tpl
@@ -17,3 +17,4 @@ AWS_SES_DOMAIN=${aws_ses_domain}
 SENTRY_DSN=${sentry_dsn}
 SENTRY_ENV=${sentry_env}
 SLACK_CCDL_TEST_CHANNEL_EMAIL=${slack_ccdl_test_channel_email}
+ENABLE_DATASETS=${enable_datasets}

--- a/infrastructure/api.tf
+++ b/infrastructure/api.tf
@@ -67,7 +67,7 @@ resource "aws_instance" "api_server_1" {
           sentry_dsn = var.sentry_dsn
           sentry_env = var.sentry_env
           slack_ccdl_test_channel_email = var.slack_ccdl_test_channel_email
-          enable_datasets = var.enable_datasets
+          enable_feature_preview = var.enable_feature_preview
         })
       start_api_with_migrations = templatefile(
         "api-configuration/start_api_with_migrations.tpl.sh",

--- a/infrastructure/api.tf
+++ b/infrastructure/api.tf
@@ -67,6 +67,7 @@ resource "aws_instance" "api_server_1" {
           sentry_dsn = var.sentry_dsn
           sentry_env = var.sentry_env
           slack_ccdl_test_channel_email = var.slack_ccdl_test_channel_email
+          enable_datasets = var.enable_datasets
         })
       start_api_with_migrations = templatefile(
         "api-configuration/start_api_with_migrations.tpl.sh",

--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -30,6 +30,7 @@ TF_ENV_VAR = {
     "SENTRY_ENV": "TF_VAR_sentry_env",
     "SSH_PUBLIC_KEY": "TF_VAR_ssh_public_key",
     "SLACK_CCDL_TEST_CHANNEL_EMAIL": "TF_VAR_slack_ccdl_test_channel_email",
+    "ENABLE_DATASETS": "TF_VAR_enable_datasets",
 }
 
 

--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -30,7 +30,7 @@ TF_ENV_VAR = {
     "SENTRY_ENV": "TF_VAR_sentry_env",
     "SSH_PUBLIC_KEY": "TF_VAR_ssh_public_key",
     "SLACK_CCDL_TEST_CHANNEL_EMAIL": "TF_VAR_slack_ccdl_test_channel_email",
-    "ENABLE_DATASETS": "TF_VAR_enable_datasets",
+    "ENABLE_FEATURE_PREVIEW": "TF_VAR_enable_feature_preview",
 }
 
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -76,8 +76,8 @@ variable "slack_ccdl_test_channel_email" {
   default = "testing@example.com"
 }
 
-variable "enable_datasets" {
-  default = "no"
+variable "enable_feature_preview" {
+  default = "false"
 }
 
 output "environment_variables" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -76,6 +76,10 @@ variable "slack_ccdl_test_channel_email" {
   default = "testing@example.com"
 }
 
+variable "enable_datasets" {
+  default = "no"
+}
+
 output "environment_variables" {
   value = [
     {name = "DATABASE_NAME"


### PR DESCRIPTION
## Issue Number

Closes #1345

## Purpose/Implementation Notes

- Changes use of `settings.PRODUCTION` to specifically use `settings.CLEAN_UP_DATA`
- Adds `settings.ENABLE_FEATURE_PREVIEW` to more generically allow for new features to be enabled on local and staging but not production.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
