### PR TITLE
1350 - Move Sentry.ErrorBoundary to the outermost level in _app.js 

### DIFF
--- a/client/src/pages/_app.js
+++ b/client/src/pages/_app.js
@@ -25,8 +25,8 @@ const Portal = ({ Component, pageProps }) => {
   return (
     <>
       <Reset />
-      <Sentry.ErrorBoundary fallback={Fallback} showDialog>
-        <Grommet theme={theme}>
+      <Grommet theme={theme}>
+        <Sentry.ErrorBoundary fallback={Fallback} showDialog>
           <ScPCAPortalContextProvider>
             <AnalyticsContextProvider>
               <PageTitle />
@@ -38,8 +38,8 @@ const Portal = ({ Component, pageProps }) => {
               </BannerContextProvider>
             </AnalyticsContextProvider>
           </ScPCAPortalContextProvider>
-        </Grommet>
-      </Sentry.ErrorBoundary>
+        </Sentry.ErrorBoundary>
+      </Grommet>
     </>
   )
 }


### PR DESCRIPTION
## Issue Number

Closes #1350 

## Purpose/Implementation Notes

Change includes:
- Wrapped all context providers within `Sentry.ErrorBoundary`, excluding the `Grommet` provider and `Reset` (used for styling).

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

- Tested locally to ensure that runtime errors, including from context providers, are caught by `Sentry.ErrorBoundary` when an error is thrown.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
