### PR TITLE
Fix - Define serializer_class and queryset to DatasetViewSet

### DIFF
--- a/api/scpca_portal/test/views/test_dataset.py
+++ b/api/scpca_portal/test/views/test_dataset.py
@@ -11,6 +11,13 @@ from scpca_portal.test.expected_values import DatasetCustomSingleCellExperiment
 from scpca_portal.test.factories import DatasetFactory, LeafComputedFileFactory
 
 
+class EmptyDatasetTestCase(APITestCase):
+    def test_get_list(self):
+        url = reverse("datasets-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
 class DatasetsTestCase(APITestCase):
     """Tests /datasets/ operations."""
 

--- a/api/scpca_portal/views/dataset.py
+++ b/api/scpca_portal/views/dataset.py
@@ -21,6 +21,12 @@ logger = get_and_configure_logger(__name__)
 class DatasetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     ordering_fields = "__all__"
 
+    # TODO: Either add serializer_class/queryset to the class or use viewsets.ViewSet
+    # Fixes browser error 500 (not caught by tests) by setting default serializer and queryset
+    # https://www.django-rest-framework.org/api-guide/generic-views/#examples
+    queryset = Dataset.objects.all()
+    serializer_class = DatasetSerializer
+
     def list(self, request):
         queryset = Dataset.objects.filter(is_ccdl=True)
         serializer = DatasetSerializer(queryset, many=True)


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Currently, the datasets endpoint returns a `500 `status code in the browser, but this is not caught by the BE tests. The issue occurs when the `DatasetViewSet` class inherits from `ModelViewSet` instead of `ViewSet`.

To resolve the browser error, we'll temporarily define default `serializer_class `and `queryset` attributes in `DatasetViewSet`. We may switch to using `ViewSet` later in development (TBD).

Changes include:
- Added `serializer_class` and `queryset` attributes at the top of the class with a `TODO` comment
- Added a new  test case ,`EmptyDatasetTestCase`, to `test_dataset`


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

- `EmptyDatasetTestCase`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
