### PR TITLE
1331 - Enforce filter_on_project_id usage in loader and metadata_parser

### DIFF
--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Set
 
 from django.conf import settings
 from django.db import connection
-from django.db.models import Q
 from django.template.defaultfilters import pluralize
 
 from scpca_portal import metadata_parser, s3
@@ -22,22 +21,31 @@ from scpca_portal.models import (
 logger = get_and_configure_logger(__name__)
 
 
-def get_projects_metadata(filter_on_project_ids: List[str]) -> List[Dict[str, Any]]:
-    """
-    Download all metadata files associated with the project ids in the passed project id list,
-    load the project metadata files and return project metadata dicts.
-    """
-    all_metadata_original_files = OriginalFile.objects.filter(is_metadata=True)
-    metadata_original_files = all_metadata_original_files.filter(
-        Q(project_id__in=filter_on_project_ids) | Q(project_id__isnull=True)
-    )
+def download_projects_metadata() -> None:
+    """Download the projects metadata file."""
+    projects_metadata_file = OriginalFile.objects.filter(
+        is_metadata=True, project_id__isnull=True
+    ).first()
 
-    bulk_original_files = OriginalFile.objects.filter(
-        is_bulk=True, project_id__in=filter_on_project_ids
-    )
+    s3.download_files([projects_metadata_file])
+
+
+def download_projects_related_metadata(filter_on_project_ids: List[str]) -> None:
+    """
+    Download all metadata files associated with the project ids in the passed project id list.
+    """
+    filter_on_projects_files = OriginalFile.objects.filter(project_id__in=filter_on_project_ids)
+
+    metadata_original_files = filter_on_projects_files.filter(is_metadata=True)
+    bulk_original_files = filter_on_projects_files.filter(is_bulk=True)
 
     s3.download_files(metadata_original_files | bulk_original_files)
 
+
+def get_projects_metadata(filter_on_project_ids: List[str]) -> List[Dict[str, Any]]:
+    """
+    Load the project metadata files and return project metadata dicts.
+    """
     projects_metadata = metadata_parser.load_projects_metadata(filter_on_project_ids)
     return projects_metadata
 

--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -38,9 +38,7 @@ def get_projects_metadata(filter_on_project_ids: List[str]) -> List[Dict[str, An
 
     s3.download_files(metadata_original_files | bulk_original_files)
 
-    projects_metadata = metadata_parser.load_projects_metadata(
-        filter_on_project_ids=filter_on_project_ids
-    )
+    projects_metadata = metadata_parser.load_projects_metadata(filter_on_project_ids)
     return projects_metadata
 
 

--- a/api/scpca_portal/loader.py
+++ b/api/scpca_portal/loader.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db import connection
 from django.template.defaultfilters import pluralize
 
-from scpca_portal import metadata_parser, s3
+from scpca_portal import s3
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.models import (
     ComputedFile,
@@ -40,14 +40,6 @@ def download_projects_related_metadata(filter_on_project_ids: List[str]) -> None
     bulk_original_files = filter_on_projects_files.filter(is_bulk=True)
 
     s3.download_files(metadata_original_files | bulk_original_files)
-
-
-def get_projects_metadata(filter_on_project_ids: List[str]) -> List[Dict[str, Any]]:
-    """
-    Load the project metadata files and return project metadata dicts.
-    """
-    projects_metadata = metadata_parser.load_projects_metadata(filter_on_project_ids)
-    return projects_metadata
 
 
 # TODO: Remove after the dataset release

--- a/api/scpca_portal/management/commands/load_data.py
+++ b/api/scpca_portal/management/commands/load_data.py
@@ -5,7 +5,7 @@ from typing import Set
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from scpca_portal import common, loader, utils
+from scpca_portal import common, loader, metadata_parser, utils
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -88,9 +88,11 @@ class Command(BaseCommand):
     ) -> None:
         """Loads data from S3. Creates projects and loads data for them."""
         utils.create_data_dirs()
+        loader.download_projects_metadata()
+        loader.download_projects_related_metadata([scpca_project_id])
 
         # load metadata
-        for project_metadata in loader.get_projects_metadata(scpca_project_id):
+        for project_metadata in metadata_parser.load_projects_metadata([scpca_project_id]):
             # validate that a project can be added to the db,
             # then creates it, all its samples and libraries, and all other relations
             if project := loader.create_project(

--- a/api/scpca_portal/management/commands/load_metadata.py
+++ b/api/scpca_portal/management/commands/load_metadata.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
                 return
 
         loader.download_projects_related_metadata(filter_on_project_ids)
-        for project_metadata in loader.get_projects_metadata(filter_on_project_ids):
+        for project_metadata in metadata_parser.load_projects_metadata(filter_on_project_ids):
             # validate that a project can be added to the db,
             # then creates it, all its samples and libraries, and all other relations
             if project := loader.create_project(

--- a/api/scpca_portal/management/commands/load_metadata.py
+++ b/api/scpca_portal/management/commands/load_metadata.py
@@ -106,9 +106,7 @@ class Command(BaseCommand):
                 logger.info(f"{scpca_project_id} is not available to reload.")
                 return
 
-        for project_metadata in loader.get_projects_metadata(
-            filter_on_project_ids=filter_on_project_ids
-        ):
+        for project_metadata in loader.get_projects_metadata(filter_on_project_ids):
             # validate that a project can be added to the db,
             # then creates it, all its samples and libraries, and all other relations
             if project := loader.create_project(

--- a/api/scpca_portal/management/commands/load_metadata.py
+++ b/api/scpca_portal/management/commands/load_metadata.py
@@ -86,6 +86,7 @@ class Command(BaseCommand):
             )
 
         utils.create_data_dirs()
+        loader.download_projects_metadata()
 
         projects_metadata_ids = set(metadata_parser.get_projects_metadata_ids())
         lockfile_project_ids = set(lockfile.get_lockfile_project_ids())
@@ -106,6 +107,7 @@ class Command(BaseCommand):
                 logger.info(f"{scpca_project_id} is not available to reload.")
                 return
 
+        loader.download_projects_related_metadata(filter_on_project_ids)
         for project_metadata in loader.get_projects_metadata(filter_on_project_ids):
             # validate that a project can be added to the db,
             # then creates it, all its samples and libraries, and all other relations

--- a/api/scpca_portal/metadata_parser.py
+++ b/api/scpca_portal/metadata_parser.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 from django.conf import settings
 
-from scpca_portal import common, s3, utils
+from scpca_portal import common, utils
 from scpca_portal.models.original_file import OriginalFile
 
 PROJECT_METADATA_KEYS = [
@@ -50,9 +50,6 @@ def get_projects_metadata_ids(*, bucket: str = settings.AWS_S3_INPUT_BUCKET_NAME
 
     """
     projects_metadata_file = OriginalFile.get_input_projects_metadata_file(bucket=bucket)
-
-    if projects_metadata_file.local_file_path:
-        s3.download_files([projects_metadata_file])
 
     with open(projects_metadata_file.local_file_path) as raw_file:
         projects_metadata = csv.DictReader(raw_file)

--- a/api/scpca_portal/metadata_parser.py
+++ b/api/scpca_portal/metadata_parser.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 from django.conf import settings
 
-from scpca_portal import common, utils
+from scpca_portal import common, s3, utils
 from scpca_portal.models.original_file import OriginalFile
 
 PROJECT_METADATA_KEYS = [
@@ -50,6 +50,10 @@ def get_projects_metadata_ids(*, bucket: str = settings.AWS_S3_INPUT_BUCKET_NAME
 
     """
     projects_metadata_file = OriginalFile.get_input_projects_metadata_file(bucket=bucket)
+
+    if projects_metadata_file.local_file_path:
+        s3.download_files([projects_metadata_file])
+
     with open(projects_metadata_file.local_file_path) as raw_file:
         projects_metadata = csv.DictReader(raw_file)
         return [row["scpca_project_id"] for row in projects_metadata]

--- a/api/scpca_portal/metadata_parser.py
+++ b/api/scpca_portal/metadata_parser.py
@@ -56,7 +56,7 @@ def get_projects_metadata_ids(*, bucket: str = settings.AWS_S3_INPUT_BUCKET_NAME
 
 
 def load_projects_metadata(
-    *, filter_on_project_ids: List[str] = [], bucket: str = settings.AWS_S3_INPUT_BUCKET_NAME
+    *, filter_on_project_ids: List[str], bucket: str = settings.AWS_S3_INPUT_BUCKET_NAME
 ) -> List[Dict]:
     """
     Opens, loads and parses list of project metadata dicts.

--- a/api/scpca_portal/metadata_parser.py
+++ b/api/scpca_portal/metadata_parser.py
@@ -56,7 +56,7 @@ def get_projects_metadata_ids(*, bucket: str = settings.AWS_S3_INPUT_BUCKET_NAME
 
 
 def load_projects_metadata(
-    *, filter_on_project_ids: List[str], bucket: str = settings.AWS_S3_INPUT_BUCKET_NAME
+    filter_on_project_ids: List[str], *, bucket: str = settings.AWS_S3_INPUT_BUCKET_NAME
 ) -> List[Dict]:
     """
     Opens, loads and parses list of project metadata dicts.

--- a/api/scpca_portal/test/management/commands/test_create_ccdl_datasets.py
+++ b/api/scpca_portal/test/management/commands/test_create_ccdl_datasets.py
@@ -14,7 +14,10 @@ class TestCreateCCDLDatasets(TestCase):
         bucket = settings.AWS_S3_INPUT_BUCKET_NAME
         call_command("sync_original_files", bucket=bucket)
 
+        loader.download_projects_metadata()
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
+
+        loader.download_projects_related_metadata(project_ids)
         for project_metadata in metadata_parser.load_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,

--- a/api/scpca_portal/test/management/commands/test_create_ccdl_datasets.py
+++ b/api/scpca_portal/test/management/commands/test_create_ccdl_datasets.py
@@ -4,20 +4,22 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
-from scpca_portal import loader
+from scpca_portal import loader, metadata_parser
 from scpca_portal.models import Dataset, Job
 
 
 class TestCreateCCDLDatasets(TestCase):
     @classmethod
     def setUpTestData(cls):
-        call_command("sync_original_files", bucket=settings.AWS_S3_INPUT_BUCKET_NAME)
+        bucket = settings.AWS_S3_INPUT_BUCKET_NAME
+        call_command("sync_original_files", bucket=bucket)
 
-        for project_metadata in loader.get_projects_metadata():
+        project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
+        for project_metadata in loader.get_projects_metadata(filter_on_project_ids=project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},
-                input_bucket_name=settings.AWS_S3_INPUT_BUCKET_NAME,
+                input_bucket_name=bucket,
                 reload_existing=True,
                 update_s3=False,
             )

--- a/api/scpca_portal/test/management/commands/test_create_ccdl_datasets.py
+++ b/api/scpca_portal/test/management/commands/test_create_ccdl_datasets.py
@@ -15,7 +15,7 @@ class TestCreateCCDLDatasets(TestCase):
         call_command("sync_original_files", bucket=bucket)
 
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
-        for project_metadata in loader.get_projects_metadata(project_ids):
+        for project_metadata in metadata_parser.load_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},

--- a/api/scpca_portal/test/management/commands/test_create_ccdl_datasets.py
+++ b/api/scpca_portal/test/management/commands/test_create_ccdl_datasets.py
@@ -15,7 +15,7 @@ class TestCreateCCDLDatasets(TestCase):
         call_command("sync_original_files", bucket=bucket)
 
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
-        for project_metadata in loader.get_projects_metadata(filter_on_project_ids=project_ids):
+        for project_metadata in loader.get_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -43,7 +43,6 @@ class TestCreatePortalMetadata(TransactionTestCase):
             input_bucket_name=settings.AWS_S3_INPUT_BUCKET_NAME,
             clean_up_input_data=False,
             reload_existing=False,
-            scpca_project_id="",
             update_s3=False,
             submitter_whitelist="scpca",
         )

--- a/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_create_portal_metadata.py
@@ -26,7 +26,7 @@ class TestCreatePortalMetadata(TransactionTestCase):
         call_command("sync_original_files", bucket=settings.AWS_S3_INPUT_BUCKET_NAME)
 
         self.create_portal_metadata = partial(call_command, "create_portal_metadata")
-        self.load_data = partial(call_command, "load_data")
+        self.load_metadata = partial(call_command, "load_metadata")
 
     @classmethod
     def tearDownClass(cls):
@@ -39,11 +39,9 @@ class TestCreatePortalMetadata(TransactionTestCase):
         SAMPLES_COUNT = 9
         LIBRARIES_COUNT = 8
 
-        self.load_data(
+        self.load_metadata(
             input_bucket_name=settings.AWS_S3_INPUT_BUCKET_NAME,
             clean_up_input_data=False,
-            clean_up_output_data=False,
-            max_workers=4,
             reload_existing=False,
             scpca_project_id="",
             update_s3=False,

--- a/api/scpca_portal/test/management/commands/test_load_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_load_metadata.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
-from scpca_portal import common, metadata_parser
+from scpca_portal import common
 from scpca_portal.models import Project
 from scpca_portal.test.factories import OriginalFileFactory
 
@@ -38,14 +38,14 @@ class TestLoadMetadata(TestCase):
         # Handle patching in setUp function
         create_data_dirs_patch = patch("scpca_portal.utils.create_data_dirs")
         download_files_patch = patch("scpca_portal.s3.download_files")
-        get_projects_metadata_patch = patch("scpca_portal.loader.get_projects_metadata")
+        load_projects_metadata_patch = patch("scpca_portal.metadata_parser.load_projects_metadata")
         create_project_patch = patch("scpca_portal.loader.create_project")
         remove_nested_data_dirs_patch = patch("scpca_portal.utils.remove_nested_data_dirs")
 
         # Start patches
         self.mock_create_data_dirs = create_data_dirs_patch.start()
         self.mock_download_files_patch = download_files_patch.start()
-        self.mock_get_projects_metadata = get_projects_metadata_patch.start()
+        self.mock_load_projects_metadata = load_projects_metadata_patch.start()
         self.mock_create_project = create_project_patch.start()
         self.mock_remove_nested_data_dirs = remove_nested_data_dirs_patch.start()
 
@@ -53,14 +53,14 @@ class TestLoadMetadata(TestCase):
         self.patches = [
             create_data_dirs_patch,
             download_files_patch,
-            get_projects_metadata_patch,
+            load_projects_metadata_patch,
             create_project_patch,
             remove_nested_data_dirs_patch,
         ]
 
         # Configure necessary output values
         self.projects_metadata = [{"key": "value"}]
-        self.mock_get_projects_metadata.return_value = self.projects_metadata
+        self.mock_load_projects_metadata.return_value = self.projects_metadata
         self.project = Project()
         self.mock_create_project.return_value = self.project
 
@@ -73,7 +73,7 @@ class TestLoadMetadata(TestCase):
 
     def assertMethodsCalled(self):
         self.mock_create_data_dirs.assert_called()
-        self.mock_get_projects_metadata.assert_called()
+        self.mock_load_projects_metadata.assert_called()
         self.mock_create_project.assert_called()
 
     def test_input_bucket_name(self):
@@ -151,12 +151,12 @@ class TestLoadMetadata(TestCase):
         )
 
     def test_scpca_project_id(self):
-        scpca_project_id = metadata_parser.get_projects_metadata_ids()[0]
+        scpca_project_id = "SCPCP999990"
         project = Project(scpca_id=scpca_project_id)
         project.save()
 
         self.load_metadata(scpca_project_id=scpca_project_id)
-        self.mock_get_projects_metadata.assert_called_with([scpca_project_id])
+        self.mock_load_projects_metadata.assert_called_with([scpca_project_id])
 
     def test_update_s3(self):
         self.load_metadata()
@@ -200,12 +200,12 @@ class TestLoadMetadata(TestCase):
             self.update_s3,
         )
 
-    def test_get_projects_metadata_failure(self):
-        self.mock_get_projects_metadata.return_value = []
+    def test_load_projects_metadata_failure(self):
+        self.mock_load_projects_metadata.return_value = []
         self.load_metadata()
 
         self.mock_create_data_dirs.assert_called_once()
-        self.mock_get_projects_metadata.assert_called_once()
+        self.mock_load_projects_metadata.assert_called_once()
         self.mock_create_project.assert_not_called()
         self.mock_remove_nested_data_dirs.assert_not_called()
 
@@ -214,6 +214,6 @@ class TestLoadMetadata(TestCase):
         self.load_metadata()
 
         self.mock_create_data_dirs.assert_called_once()
-        self.mock_get_projects_metadata.assert_called_once()
+        self.mock_load_projects_metadata.assert_called_once()
         self.mock_create_project.assert_called_once()
         self.mock_remove_nested_data_dirs.assert_not_called()

--- a/api/scpca_portal/test/management/commands/test_load_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_load_metadata.py
@@ -153,7 +153,7 @@ class TestLoadMetadata(TestCase):
         project.save()
 
         self.load_metadata(scpca_project_id=scpca_project_id)
-        self.mock_get_projects_metadata.assert_called_with(filter_on_project_ids=[scpca_project_id])
+        self.mock_get_projects_metadata.assert_called_with([scpca_project_id])
 
     def test_update_s3(self):
         self.load_metadata()

--- a/api/scpca_portal/test/management/commands/test_load_metadata.py
+++ b/api/scpca_portal/test/management/commands/test_load_metadata.py
@@ -37,12 +37,14 @@ class TestLoadMetadata(TestCase):
 
         # Handle patching in setUp function
         create_data_dirs_patch = patch("scpca_portal.utils.create_data_dirs")
+        download_files_patch = patch("scpca_portal.s3.download_files")
         get_projects_metadata_patch = patch("scpca_portal.loader.get_projects_metadata")
         create_project_patch = patch("scpca_portal.loader.create_project")
         remove_nested_data_dirs_patch = patch("scpca_portal.utils.remove_nested_data_dirs")
 
         # Start patches
         self.mock_create_data_dirs = create_data_dirs_patch.start()
+        self.mock_download_files_patch = download_files_patch.start()
         self.mock_get_projects_metadata = get_projects_metadata_patch.start()
         self.mock_create_project = create_project_patch.start()
         self.mock_remove_nested_data_dirs = remove_nested_data_dirs_patch.start()
@@ -50,6 +52,7 @@ class TestLoadMetadata(TestCase):
         # Save patches that so they can be stopped during tearDown
         self.patches = [
             create_data_dirs_patch,
+            download_files_patch,
             get_projects_metadata_patch,
             create_project_patch,
             remove_nested_data_dirs_patch,

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -44,7 +44,10 @@ class TestGetFile(TestCase):
         bucket = settings.AWS_S3_INPUT_BUCKET_NAME
         call_command("sync_original_files", bucket=bucket)
 
+        loader.download_projects_metadata()
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
+
+        loader.download_projects_related_metadata(project_ids)
         for project_metadata in metadata_parser.load_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
-from scpca_portal import loader, utils
+from scpca_portal import loader, metadata_parser, utils
 from scpca_portal.enums import CCDLDatasetNames
 from scpca_portal.models import ComputedFile, Dataset
 from scpca_portal.test import expected_values as test_data
@@ -41,13 +41,15 @@ class TestComputedFile(TestCase):
 class TestGetFile(TestCase):
     @classmethod
     def setUpTestData(cls):
-        call_command("sync_original_files", bucket=settings.AWS_S3_INPUT_BUCKET_NAME)
+        bucket = settings.AWS_S3_INPUT_BUCKET_NAME
+        call_command("sync_original_files", bucket=bucket)
 
-        for project_metadata in loader.get_projects_metadata():
+        project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
+        for project_metadata in loader.get_projects_metadata(filter_on_project_ids=project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},
-                input_bucket_name=settings.AWS_S3_INPUT_BUCKET_NAME,
+                input_bucket_name=bucket,
                 reload_existing=True,
                 update_s3=False,
             )

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -45,7 +45,7 @@ class TestGetFile(TestCase):
         call_command("sync_original_files", bucket=bucket)
 
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
-        for project_metadata in loader.get_projects_metadata(filter_on_project_ids=project_ids):
+        for project_metadata in loader.get_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -45,7 +45,7 @@ class TestGetFile(TestCase):
         call_command("sync_original_files", bucket=bucket)
 
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
-        for project_metadata in loader.get_projects_metadata(project_ids):
+        for project_metadata in metadata_parser.load_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase, tag
 
-from scpca_portal import loader
+from scpca_portal import loader, metadata_parser
 from scpca_portal.enums import CCDLDatasetNames, DatasetFormats, Modalities
 from scpca_portal.models import Dataset, OriginalFile, Project
 from scpca_portal.test import expected_values as test_data
@@ -17,13 +17,15 @@ from scpca_portal.test.factories import DatasetFactory, OriginalFileFactory
 class TestDataset(TestCase):
     @classmethod
     def setUpTestData(cls):
-        call_command("sync_original_files", bucket=settings.AWS_S3_INPUT_BUCKET_NAME)
+        bucket = settings.AWS_S3_INPUT_BUCKET_NAME
+        call_command("sync_original_files", bucket=bucket)
 
-        for project_metadata in loader.get_projects_metadata():
+        project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
+        for project_metadata in loader.get_projects_metadata(filter_on_project_ids=project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},
-                input_bucket_name=settings.AWS_S3_INPUT_BUCKET_NAME,
+                input_bucket_name=bucket,
                 reload_existing=True,
                 update_s3=False,
             )

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -27,7 +27,10 @@ class TestDataset(TestCase):
         bucket = settings.AWS_S3_INPUT_BUCKET_NAME
         call_command("sync_original_files", bucket=bucket)
 
+        loader.download_projects_metadata()
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
+
+        loader.download_projects_related_metadata(project_ids)
         for project_metadata in metadata_parser.load_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -21,7 +21,7 @@ class TestDataset(TestCase):
         call_command("sync_original_files", bucket=bucket)
 
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
-        for project_metadata in loader.get_projects_metadata(filter_on_project_ids=project_ids):
+        for project_metadata in loader.get_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -28,7 +28,7 @@ class TestDataset(TestCase):
         call_command("sync_original_files", bucket=bucket)
 
         project_ids = metadata_parser.get_projects_metadata_ids(bucket=bucket)
-        for project_metadata in loader.get_projects_metadata(project_ids):
+        for project_metadata in metadata_parser.load_projects_metadata(project_ids):
             loader.create_project(
                 project_metadata,
                 submitter_whitelist={"scpca"},

--- a/api/scpca_portal/test/test_loader.py
+++ b/api/scpca_portal/test/test_loader.py
@@ -21,9 +21,7 @@ class TestLoader(TransactionTestCase):
 
         # When passing a project_id to get_projects_metadata, a list of one item is returned
         # This lambda creates a shorthand to access the single returned project_metadata
-        self.get_project_metadata = lambda project_id: loader.get_projects_metadata(
-            filter_on_project_ids=[project_id]
-        )[0]
+        self.get_project_metadata = lambda project_id: loader.get_projects_metadata([project_id])[0]
 
         self.create_project = partial(
             loader.create_project,

--- a/api/scpca_portal/test/test_loader.py
+++ b/api/scpca_portal/test/test_loader.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TransactionTestCase
 
-from scpca_portal import loader, utils
+from scpca_portal import loader, metadata_parser, utils
 from scpca_portal.models import ComputedFile, Project
 from scpca_portal.test import expected_values as test_data
 
@@ -19,9 +19,14 @@ class TestLoader(TransactionTestCase):
     def setUp(self):
         call_command("sync_original_files", bucket=settings.AWS_S3_INPUT_BUCKET_NAME)
 
-        # When passing a project_id to get_projects_metadata, a list of one item is returned
+        # When passing a project_id to load_projects_metadata, a list of one item is returned
         # This lambda creates a shorthand to access the single returned project_metadata
-        self.get_project_metadata = lambda project_id: loader.get_projects_metadata([project_id])[0]
+        def load_project_metadata(project_id):
+            loader.download_projects_metadata()
+            loader.download_projects_related_metadata([project_id])
+            return metadata_parser.load_projects_metadata([project_id])[0]
+
+        self.load_project_metadata = load_project_metadata
 
         self.create_project = partial(
             loader.create_project,
@@ -89,7 +94,7 @@ class TestLoader(TransactionTestCase):
         utils.create_data_dirs()
 
         returned_project = self.create_project(
-            self.get_project_metadata(test_data.Project_SCPCP999990.SCPCA_ID)
+            self.load_project_metadata(test_data.Project_SCPCP999990.SCPCA_ID)
         )
 
         # CHECK FOR PROJECT EXISTENCE
@@ -259,7 +264,7 @@ class TestLoader(TransactionTestCase):
         utils.create_data_dirs()
 
         returned_project = self.create_project(
-            self.get_project_metadata(test_data.Project_SCPCP999991.SCPCA_ID)
+            self.load_project_metadata(test_data.Project_SCPCP999991.SCPCA_ID)
         )
 
         # CHECK FOR PROJECT EXISTENCE
@@ -398,7 +403,7 @@ class TestLoader(TransactionTestCase):
         utils.create_data_dirs()
 
         returned_project = self.create_project(
-            self.get_project_metadata(test_data.Project_SCPCP999992.SCPCA_ID)
+            self.load_project_metadata(test_data.Project_SCPCP999992.SCPCA_ID)
         )
 
         # CHECK FOR PROJECT EXISTENCE
@@ -525,7 +530,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
-            self.get_project_metadata(test_data.Computed_File_Project.SINGLE_CELL_SCE.PROJECT_ID)
+            self.load_project_metadata(test_data.Computed_File_Project.SINGLE_CELL_SCE.PROJECT_ID)
         )
         self.assertIsNotNone(
             project,
@@ -569,7 +574,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
-            self.get_project_metadata(
+            self.load_project_metadata(
                 test_data.Computed_File_Project.SINGLE_CELL_SCE_MULTIPLEXED.PROJECT_ID
             )
         )
@@ -622,7 +627,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
-            self.get_project_metadata(
+            self.load_project_metadata(
                 test_data.Computed_File_Project.SINGLE_CELL_SCE_MERGED.PROJECT_ID
             )
         )
@@ -670,7 +675,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
-            self.get_project_metadata(
+            self.load_project_metadata(
                 test_data.Computed_File_Project.SINGLE_CELL_ANN_DATA.PROJECT_ID
             )
         )
@@ -718,7 +723,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
-            self.get_project_metadata(
+            self.load_project_metadata(
                 test_data.Computed_File_Project.SINGLE_CELL_ANN_DATA_MERGED.PROJECT_ID
             )
         )
@@ -770,7 +775,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project = self.create_project(
-            self.get_project_metadata(
+            self.load_project_metadata(
                 test_data.Computed_File_Project.SPATIAL_SINGLE_CELL_EXPERIMENT.PROJECT_ID
             )
         )
@@ -822,7 +827,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Project.ALL_METADATA.PROJECT_ID
-        project = self.create_project(self.get_project_metadata(project_id))
+        project = self.create_project(self.load_project_metadata(project_id))
         self.assertIsNotNone(
             project,
             "Problem creating project, unable to test "
@@ -867,7 +872,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SINGLE_CELL_SCE.PROJECT_ID
-        project = self.create_project(self.get_project_metadata(project_id))
+        project = self.create_project(self.load_project_metadata(project_id))
         # Make sure that create_project didn't fail and return a None value
         self.assertIsNotNone(
             project,
@@ -922,7 +927,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SINGLE_CELL_ANN_DATA.PROJECT_ID
-        project = self.create_project(self.get_project_metadata(project_id))
+        project = self.create_project(self.load_project_metadata(project_id))
         # Make sure that create_project didn't fail and return a None value
         self.assertIsNotNone(
             project,
@@ -979,7 +984,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.SPATIAL_SCE.PROJECT_ID
-        project = self.create_project(self.get_project_metadata(project_id))
+        project = self.create_project(self.load_project_metadata(project_id))
         # Make sure that create_project didn't fail and return a None value
         self.assertIsNotNone(
             project,
@@ -1032,7 +1037,7 @@ class TestLoader(TransactionTestCase):
 
         # GENERATE COMPUTED FILES
         project_id = test_data.Computed_File_Sample.MULTIPLEXED_SINGLE_CELL_SCE.PROJECT_ID
-        project = self.create_project(self.get_project_metadata(project_id))
+        project = self.create_project(self.load_project_metadata(project_id))
         # Make sure that create_project didn't fail and return a None value
         self.assertIsNotNone(
             project,

--- a/api/scpca_portal/test/test_metadata_parser.py
+++ b/api/scpca_portal/test/test_metadata_parser.py
@@ -20,15 +20,17 @@ class TestMetadataParser(TestCase):
         """
         self.assertTrue(any(expected_key in actual_keys for expected_key in expected_keys))
 
+    def test_get_projects_metadata_ids(self):
+        expected_project_ids = ["SCPCP999990", "SCPCP999991", "SCPCP999992"]
+        actual_project_ids = metadata_parser.get_projects_metadata_ids()
+        self.assertListEqual(actual_project_ids, expected_project_ids)
+
     def test_load_projects_metadata(self):
-        PROJECT_IDS = ["SCPCP999990", "SCPCP999991", "SCPCP999992"]
-
         # Load metadata for projects
-        projects_metadata = metadata_parser.load_projects_metadata()
-
-        # Make sure that all projects metadata are loaded
-        actual_project_ids = [project["scpca_project_id"] for project in projects_metadata]
-        self.assertEqual(sorted(actual_project_ids), PROJECT_IDS)
+        project_ids = metadata_parser.get_projects_metadata_ids()
+        projects_metadata = metadata_parser.load_projects_metadata(
+            filter_on_project_ids=project_ids
+        )
 
         # Verify that metadata keys are transformed correctly
         expected_keys = {

--- a/api/scpca_portal/test/test_metadata_parser.py
+++ b/api/scpca_portal/test/test_metadata_parser.py
@@ -28,9 +28,7 @@ class TestMetadataParser(TestCase):
     def test_load_projects_metadata(self):
         # Load metadata for projects
         project_ids = metadata_parser.get_projects_metadata_ids()
-        projects_metadata = metadata_parser.load_projects_metadata(
-            filter_on_project_ids=project_ids
-        )
+        projects_metadata = metadata_parser.load_projects_metadata(project_ids)
 
         # Verify that metadata keys are transformed correctly
         expected_keys = {

--- a/api/scpca_portal/test/test_metadata_parser.py
+++ b/api/scpca_portal/test/test_metadata_parser.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
-from scpca_portal import metadata_parser
+from scpca_portal import loader, metadata_parser
 from scpca_portal.test.factories import ProjectFactory
 
 
@@ -22,12 +22,16 @@ class TestMetadataParser(TestCase):
 
     def test_get_projects_metadata_ids(self):
         expected_project_ids = ["SCPCP999990", "SCPCP999991", "SCPCP999992"]
+        loader.download_projects_metadata()
         actual_project_ids = metadata_parser.get_projects_metadata_ids()
         self.assertListEqual(actual_project_ids, expected_project_ids)
 
     def test_load_projects_metadata(self):
         # Load metadata for projects
+        loader.download_projects_metadata()
         project_ids = metadata_parser.get_projects_metadata_ids()
+
+        loader.download_projects_related_metadata(project_ids)
         projects_metadata = metadata_parser.load_projects_metadata(project_ids)
 
         # Verify that metadata keys are transformed correctly


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1331.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

- Remove the default value for `filter_on_project_ids` in `loader::get_projects_metadata`
- Remove the default value for `filter_on_project_ids` in `metadata_parser::load_projects_metadata`
- Bug fix: download `projects_metadata.csv` file in `metadata_parser::get_projects_metadata_ids` if file doesn't previously exist

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A