### PR TITLE
HOTFIX: blunt fix for existing data types

### DIFF
--- a/api/scpca_portal/migrations/0073_auto_20250604_1611.py
+++ b/api/scpca_portal/migrations/0073_auto_20250604_1611.py
@@ -11,54 +11,87 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
+        # Remove old Project fields
+        migrations.RemoveField(
+            model_name="project",
+            name="additional_metadata_keys",
+        ),
+        migrations.RemoveField(
+            model_name="project",
+            name="diagnoses",
+        ),
+        migrations.RemoveField(
+            model_name="project",
+            name="diagnoses_counts",
+        ),
+        migrations.RemoveField(
+            model_name="project",
+            name="disease_timings",
+        ),
+        migrations.RemoveField(
+            model_name="project",
+            name="seq_units",
+        ),
+        migrations.RemoveField(
+            model_name="project",
+            name="technologies",
+        ),
+        migrations.AddField(
             model_name="project",
             name="additional_metadata_keys",
             field=django.contrib.postgres.fields.ArrayField(
                 base_field=models.TextField(), default=list, size=None
             ),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name="project",
             name="diagnoses",
             field=django.contrib.postgres.fields.ArrayField(
                 base_field=models.TextField(), default=list, size=None
             ),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name="project",
             name="diagnoses_counts",
             field=models.JSONField(default=dict),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name="project",
             name="disease_timings",
             field=django.contrib.postgres.fields.ArrayField(
                 base_field=models.TextField(), default=list, size=None
             ),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name="project",
             name="seq_units",
             field=django.contrib.postgres.fields.ArrayField(
                 base_field=models.TextField(), default=list, size=None
             ),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name="project",
             name="technologies",
             field=django.contrib.postgres.fields.ArrayField(
                 base_field=models.TextField(), default=list, size=None
             ),
         ),
-        migrations.AlterField(
+        migrations.RemoveField(
+            model_name="sample",
+            name="seq_units",
+        ),
+        migrations.RemoveField(
+            model_name="sample",
+            name="technologies",
+        ),
+        migrations.AddField(
             model_name="sample",
             name="seq_units",
             field=django.contrib.postgres.fields.ArrayField(
                 base_field=models.TextField(), default=list, size=None
             ),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name="sample",
             name="technologies",
             field=django.contrib.postgres.fields.ArrayField(


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

When migrating data types from strings to lists and dicts we didn't handle existing data in the database.

This PR updates the migration to drop those columns and re-create them.
Due to limitations of our implementation this migration will require re-loading everything on the portal which will take the portal offline for a few minutes while the new metadata is parsed and everything will be downloadable again within a couple hours.


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
