### PR TITLE
Hot Fix - Add URL format override none setting in rest_framework config

### DIFF
--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -176,6 +176,7 @@ class Common(Configuration):
 
     # Django Rest Framework.
     REST_FRAMEWORK = {
+        "URL_FORMAT_OVERRIDE": None,
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
         "PAGE_SIZE": int(os.getenv("DJANGO_PAGINATION_LIMIT", 10)),
         "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],

--- a/api/scpca_portal/config/common.py
+++ b/api/scpca_portal/config/common.py
@@ -176,6 +176,7 @@ class Common(Configuration):
 
     # Django Rest Framework.
     REST_FRAMEWORK = {
+        # format is an attribute on some of our models, so it collides in the query param filtering
         "URL_FORMAT_OVERRIDE": None,
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
         "PAGE_SIZE": int(os.getenv("DJANGO_PAGINATION_LIMIT", 10)),


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

- Adds the config entry to remove `format` from default query parameters since we use this to specify data format with ComputedFiles and Datasets, and it collides with the response format option

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)


## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [X] Lint and unit tests pass locally with my changes


## Screenshots

N/A
