### PR TITLE
1355 - Add tri-state checkbox and modality checkboxes to the project samples table

### DIFF
--- a/client/src/components/DataFormatChangeModal.js
+++ b/client/src/components/DataFormatChangeModal.js
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react'
+import { Box, Button, FormField, Select, Text } from 'grommet'
+import { useScPCAPortal } from 'hooks/useScPCAPortal'
+import { HelpLink } from 'components/HelpLink'
+import { Modal, ModalBody } from 'components/Modal'
+import { getReadableOptions } from 'helpers/getReadableOptions'
+import { config } from 'config'
+import styled, { css } from 'styled-components'
+
+// TODO: Temporarily disable Change button until format flow is finalized
+const BlueButton = styled(Button)`
+  ${({ theme, disabled }) => css`
+    color: ${disabled
+      ? theme.global.colors['black-tint-60']
+      : theme.global.colors.brand.light};
+    cursor: ${disabled ? 'not-allowed' : 'pointer'};
+  `}
+`
+
+export const DataFormatChangeModal = ({
+  label = 'Change',
+  title = 'Set Data Format',
+  project,
+  disabled,
+  showing = false,
+  setShowing = () => {}
+}) => {
+  const { userFormat, setUserFormat } = useScPCAPortal()
+
+  const formatOptions = [
+    { key: 'SINGLE_CELL_EXPERIMENT', value: project.has_single_cell_data },
+    { key: 'ANN_DATA', value: project.includes_anndata }
+  ]
+    .filter((f) => f.value)
+    .map((f) => f.key)
+  const defaultFormat = formatOptions.includes(userFormat)
+    ? userFormat
+    : formatOptions[0]
+
+  const [format, setFormat] = useState(defaultFormat)
+
+  const handleChange = (value) => {
+    setFormat(value)
+  }
+
+  const handleSave = () => {
+    setUserFormat(format)
+    setShowing(false)
+  }
+
+  // Reset form on cancel
+  useEffect(() => {
+    if (!showing) {
+      setFormat(userFormat)
+    }
+  }, [showing])
+
+  return (
+    <>
+      <BlueButton
+        label={label}
+        plain
+        color="brand"
+        disabled={disabled}
+        onClick={() => setShowing(!showing)}
+      />
+      <Modal title={title} showing={showing} setShowing={setShowing}>
+        <ModalBody>
+          <Text>
+            These options will be applied to all the samples in this project
+          </Text>
+          <Box>
+            <Box
+              direction="row"
+              alignContent="between"
+              gap="large"
+              pad={{ bottom: 'large' }}
+            >
+              <FormField
+                label={
+                  <HelpLink
+                    label="Data Format"
+                    link={config.links.what_downloading}
+                  />
+                }
+              >
+                <Select
+                  options={getReadableOptions(formatOptions)}
+                  labelKey="label"
+                  valueKey={{ key: 'value', reduce: true }}
+                  value={format}
+                  onChange={({ value }) => handleChange(value)}
+                />
+              </FormField>
+            </Box>
+            <Box direction="row" gap="medium" justify="end">
+              <Button label="Cancel" onClick={() => setShowing(false)} />
+              <Button label="Save" primary onClick={handleSave} />
+            </Box>
+          </Box>
+        </ModalBody>
+      </Modal>
+    </>
+  )
+}
+
+export default DataFormatChangeModal

--- a/client/src/components/DatasetSamplesTable.js
+++ b/client/src/components/DatasetSamplesTable.js
@@ -1,77 +1,13 @@
 import React from 'react'
-import { Box, CheckBox as GrommetCheckBox, Text } from 'grommet'
-import { FormCheckmark } from 'grommet-icons'
-import styled, { css } from 'styled-components'
+import { Box, Text } from 'grommet'
 import { useDatasetSamplesTable } from 'hooks/useDatasetSamplesTable'
-import { Button } from 'components/Button'
-import { Pill } from 'components/Pill'
-import { Table } from 'components/Table'
 import { getReadable } from 'helpers/getReadable'
 import { getReadableModality } from 'helpers/getReadableModality'
-
-const CheckBox = styled(GrommetCheckBox)`
-  + div {
-    width: 24px;
-    height: 24px;
-  }
-  ${({ theme }) => css`
-    &:not(:checked) {
-      + div {
-        background: ${theme.global.colors.white};
-      }
-    }
-  `}
-`
-
-// NOTE: Ask Deepa for a checkmark SVG Icon
-const TriStateModalityCheckBox = ({ modality }) => {
-  const { selectedSamples, filteredSamples, toggleAllSamples } =
-    useDatasetSamplesTable()
-
-  const sampleIdsOnPage = filteredSamples.map((sample) => sample.scpca_id)
-  const currentSelectedSamples = selectedSamples[modality]
-
-  const selectedCountOnPage = sampleIdsOnPage.filter((id) =>
-    currentSelectedSamples.includes(id)
-  ).length
-
-  const isNoneSelected = selectedCountOnPage === 0
-  const isAllSelected = selectedCountOnPage === sampleIdsOnPage.length
-  const isSomeSelected = !isNoneSelected && !isAllSelected
-
-  return (
-    <Box
-      align="center"
-      border={{
-        side: 'all',
-        color: !isNoneSelected ? 'brand' : 'black-tint-60'
-      }}
-      justify="center"
-      round="4px"
-      width="24px"
-      height="24px"
-      onClick={() => toggleAllSamples(modality)}
-    >
-      {isSomeSelected && (
-        <Box background="brand" round="inherit" width="10px" height="3px" />
-      )}
-      {isAllSelected && <FormCheckmark color="brand" size="20px" />}
-    </Box>
-  )
-}
-
-const ModalityCheckBox = ({ modality, sampleId, disabled, onClick }) => {
-  const { selectedSamples } = useDatasetSamplesTable()
-
-  return (
-    <CheckBox
-      name={modality}
-      checked={!disabled ? selectedSamples[modality].includes(sampleId) : false}
-      disabled={disabled}
-      onClick={onClick}
-    />
-  )
-}
+import { Button } from 'components/Button'
+import { ModalityCheckBox } from 'components/ModalityCheckBox'
+import { Pill } from 'components/Pill'
+import { Table } from 'components/Table'
+import { TriStateModalityCheckBox } from 'components/TriStateModalityCheckBox'
 
 // NOTE: This component accepts 'samples' prop but it's subject to change
 // Currently mock data is used via Storybook for development

--- a/client/src/components/ModalityCheckBox.js
+++ b/client/src/components/ModalityCheckBox.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { CheckBox as GrommetCheckBox } from 'grommet'
+import styled, { css } from 'styled-components'
+import { useDatasetSamplesTable } from 'hooks/useDatasetSamplesTable'
+
+const CheckBox = styled(GrommetCheckBox)`
+  + div {
+    width: 24px;
+    height: 24px;
+  }
+  ${({ theme }) => css`
+    &:not(:checked) {
+      + div {
+        background: ${theme.global.colors.white};
+      }
+    }
+  `}
+`
+
+export const ModalityCheckBox = ({ modality, sampleId, disabled, onClick }) => {
+  const { selectedSamples } = useDatasetSamplesTable()
+
+  return (
+    <CheckBox
+      name={modality}
+      checked={!disabled ? selectedSamples[modality].includes(sampleId) : false}
+      disabled={disabled}
+      onClick={onClick}
+    />
+  )
+}
+
+export default ModalityCheckBox

--- a/client/src/components/ModalityCheckBox.js
+++ b/client/src/components/ModalityCheckBox.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { CheckBox as GrommetCheckBox } from 'grommet'
 import styled, { css } from 'styled-components'
+import { useDatasetManager } from 'hooks/useDatasetManager'
 import { useDatasetSamplesTable } from 'hooks/useDatasetSamplesTable'
 
 const CheckBox = styled(GrommetCheckBox)`
@@ -18,13 +19,17 @@ const CheckBox = styled(GrommetCheckBox)`
 `
 
 export const ModalityCheckBox = ({ modality, sampleId, disabled, onClick }) => {
+  const { myDataset, userFormat } = useDatasetManager()
   const { selectedSamples } = useDatasetSamplesTable()
+
+  const disableSpatial =
+    modality === 'SPATIAL' && (myDataset.format || userFormat) === 'ANN_DATA'
 
   return (
     <CheckBox
       name={modality}
       checked={!disabled ? selectedSamples[modality].includes(sampleId) : false}
-      disabled={disabled}
+      disabled={disabled || disableSpatial}
       onClick={onClick}
     />
   )

--- a/client/src/components/ProjectSamplesTable.js
+++ b/client/src/components/ProjectSamplesTable.js
@@ -2,20 +2,18 @@ import React, { useEffect, useState } from 'react'
 import { api } from 'api'
 import { config } from 'config'
 import { Box, Text } from 'grommet'
-import { Download as DownloadIcon } from 'grommet-icons'
-import { useDownloadOptionsContext } from 'hooks/useDownloadOptionsContext'
-import { useProjectMetadataOnly } from 'hooks/useProjectMetadataOnly'
-import { formatBytes } from 'helpers/formatBytes'
+import { useDatasetManager } from 'hooks/useDatasetManager'
+import { useDatasetSamplesTable } from 'hooks/useDatasetSamplesTable'
 import { getReadable } from 'helpers/getReadable'
 import { getReadableModality } from 'helpers/getReadableModality'
-import { DownloadModal } from 'components/DownloadModal'
-import { DownloadOptionsModal } from 'components/DownloadOptionsModal'
+import { DataFormatChangeModal } from 'components/DataFormatChangeModal'
 import { Icon } from 'components/Icon'
 import { Link } from 'components/Link'
 import { Loader } from 'components/Loader'
+import { ModalityCheckBox } from 'components/ModalityCheckBox'
 import { Pill } from 'components/Pill'
 import { Table } from 'components/Table'
-
+import { TriStateModalityCheckBox } from 'components/TriStateModalityCheckBox'
 import { WarningAnnDataMultiplexed } from 'components/WarningAnnDataMultiplexed'
 
 export const ProjectSamplesTable = ({
@@ -23,111 +21,83 @@ export const ProjectSamplesTable = ({
   samples: defaultSamples,
   stickies = 3
 }) => {
-  // We only want to show the applied donwload options.
-  // Also need some helpers for presentation.
-  const { modality, format, getFoundFile } = useDownloadOptionsContext()
-  const { metadataComputedFile, isMetadataOnlyAvailable } =
-    useProjectMetadataOnly(project)
+  const { myDataset, userFormat } = useDatasetManager()
+  const { getFilteredSamples, selectedSamples, toggleSample } =
+    useDatasetSamplesTable()
+
   const [loaded, setLoaded] = useState(false)
   const [samples, setSamples] = useState(defaultSamples)
-  const [showDownloadOptions, setShowDownloadOptions] = useState(false)
-  const [hasFilter, setHasFilter] = useState(false) // For setting the metadata only download button state
+
+  const [showing, setShowing] = useState(false)
+
   const hasMultiplexedData = project.has_multiplexed_data
+  const showWarningMultiplexed =
+    hasMultiplexedData && (myDataset.forat || userFormat) === 'ANN_DATA'
+
   const infoText =
     project && project.has_bulk_rna_seq
       ? 'Bulk RNA-seq data available only when you download the entire project'
       : false
 
-  const onFilterChange = (value) => {
-    setHasFilter(!!value)
-  }
+  const availableFormats = [
+    // List of formats supported in the project
+    { key: 'SINGLE_CELL_EXPERIMENT', value: project.has_single_cell_data },
+    { key: 'ANN_DATA', value: project.includes_anndata }
+  ]
+    .filter((f) => f.value)
+    .map((f) => f.key)
+  const defaultFormat = availableFormats.includes(userFormat)
+    ? userFormat
+    : availableFormats[0]
 
-  const onOptionsSave = () => {
-    setShowDownloadOptions(false)
-    setLoaded(false)
-  }
-
-  // Update after save
-  useEffect(() => {
-    if (samples) setLoaded(false)
-  }, [samples, modality, format])
-
-  useEffect(() => {
-    const asyncFetch = async () => {
-      const samplesRequest = await api.samples.list({
-        project__scpca_id: project.scpca_id,
-        limit: 1000 // TODO:: 'all' option
-      })
-      if (samplesRequest.isOk) {
-        setSamples(samplesRequest.response.results)
-        setLoaded(true)
-      }
-    }
-    if (!samples && !loaded) asyncFetch()
-    if (samples && !loaded) setLoaded(true)
-  }, [samples, loaded])
-
-  if (!loaded)
-    return (
-      <Box margin="64px">
-        <Loader />
-      </Box>
-    )
+  const allModalities = ['SINGLE_CELL', 'SPATIAL'] // List of all modalities available on the portal
+  const checkBoxCellWidth = '200px'
 
   const columns = [
     {
-      Header: 'Download',
-      id: 'download',
-      accessor: ({ computed_files: computedFiles }) => {
-        if (computedFiles.length === 0) return -1
-        const computedFile = getFoundFile(computedFiles)
-        return computedFile ? computedFile.size_in_bytes : 0
-      },
-      Cell: ({ row }) => {
-        // there is nothing available to download
-        if (row.original.computed_files.length === 0) {
-          return (
-            <Box direction="row" align="center" gap="small">
-              <DownloadIcon color="status-disabled" />
-              <Box width={{ min: '120px' }}>
-                <Text>Not Available</Text>
-                <Text>for download</Text>
-              </Box>
-            </Box>
-          )
-        }
-
-        const computedFile = getFoundFile(row.original.computed_files, true)
-
-        if (computedFile) {
-          return (
-            <Box
-              align="center"
-              direction="row"
-              gap="small"
-              margin={{ top: 'small' }}
-            >
-              <DownloadModal
-                icon={<DownloadIcon color="brand" />}
-                resource={row.original}
-                publicComputedFile={computedFile}
-              />
-              <Text>{formatBytes(computedFile.size_in_bytes)}</Text>
-            </Box>
-          )
-        }
-
-        // No Match for the modality/format
-        return (
-          <Box direction="row" align="center" gap="small">
-            <DownloadIcon color="status-disabled" />
-            <Box width={{ min: '120px' }}>
-              <Text>Not available in</Text>
-              <Text>specified format</Text>
-            </Box>
+      Header: (
+        <Box width={checkBoxCellWidth}>
+          <Box align="center" margin={{ bottom: 'small' }} pad="small">
+            Select Modality
           </Box>
-        )
-      }
+          <Box
+            border={{ side: 'bottom' }}
+            width="100%"
+            style={{ position: 'absolute', top: '45px', left: 0 }}
+          />
+          <Box direction="row" justify="around">
+            {allModalities.map((m) => (
+              <Box key={m} align="center" pad={{ horizontal: 'small' }}>
+                <Text margin={{ bottom: 'xsmall' }}>{getReadable(m)}</Text>
+                <TriStateModalityCheckBox
+                  modality={m}
+                  disabled={!project[`has_${m.toLowerCase()}_data`]}
+                />
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      ),
+      disableSortBy: true,
+      accessor: 'data',
+      Cell: ({ row }) => (
+        <Box
+          align="center"
+          direction="row"
+          justify="around"
+          width={checkBoxCellWidth}
+        >
+          {allModalities.map((m) => (
+            <ModalityCheckBox
+              key={`${row.original.scpca_id}_${m}`}
+              modality={m}
+              sampleId={row.original.scpca_id}
+              disabled={!row.original[`has_${m.toLowerCase()}_data`]}
+              onClick={() => toggleSample(m, row.original)}
+            />
+          ))}
+        </Box>
+      )
     },
     {
       Header: 'Sample ID',
@@ -223,52 +193,59 @@ export const ProjectSamplesTable = ({
     }
   ]
 
+  useEffect(() => {
+    const asyncFetch = async () => {
+      const samplesRequest = await api.samples.list({
+        project__scpca_id: project.scpca_id,
+        limit: 1000 // TODO:: 'all' option
+      })
+      if (samplesRequest.isOk) {
+        setSamples(samplesRequest.response.results)
+        setLoaded(true)
+      }
+    }
+    if (!samples && !loaded) asyncFetch()
+    if (samples && !loaded) setLoaded(true)
+  }, [samples, loaded])
+
+  if (!loaded)
+    return (
+      <Box margin="64px">
+        <Loader />
+      </Box>
+    )
+
   return (
     <Table
-      filter
       columns={columns}
       data={samples}
+      filter
       stickies={stickies}
       pageSize={5}
       pageSizeOptions={[5, 10, 20, 50]}
       infoText={infoText}
-      defaultSort={[{ id: 'download', desc: true }]}
-      onFilterChange={onFilterChange}
+      defaultSort={[{ id: 'scpca_id', asc: true }]} // TODO: Ask about new defaultSort
+      selectedRows={selectedSamples}
+      onFilteredRowsChange={getFilteredSamples}
     >
       <Box direction="row" justify="between" pad={{ bottom: 'medium' }}>
         <Box direction="row" gap="xlarge" align="center">
           <Box direction="row">
             <Text weight="bold" margin={{ right: 'small' }}>
-              Modality:
-            </Text>
-            <Text>{getReadable(modality)}</Text>
-          </Box>
-          <Box direction="row">
-            <Text weight="bold" margin={{ right: 'small' }}>
               Data Format:
             </Text>
-            <Text>{getReadable(format)}</Text>
+            <Text>{getReadable(myDataset.format || defaultFormat)}</Text>
           </Box>
-          <DownloadOptionsModal
+          <DataFormatChangeModal
             label="Change"
-            showing={showDownloadOptions}
-            setShowing={setShowDownloadOptions}
-            onSave={onOptionsSave}
-          />
-        </Box>
-        <Box>
-          <DownloadModal
-            label="Download Sample Metadata"
-            icon={<DownloadIcon color="brand" />}
-            resource={project}
-            publicComputedFile={metadataComputedFile}
-            disabled={!isMetadataOnlyAvailable || hasFilter}
+            project={project}
+            disabled={!!myDataset.format} // TODO: Temporarily disable Change button until format flow is finalized.
+            showing={showing}
+            setShowing={setShowing}
           />
         </Box>
       </Box>
-      {project.has_multiplexed_data && format === 'ANN_DATA' && (
-        <WarningAnnDataMultiplexed />
-      )}
+      {showWarningMultiplexed && <WarningAnnDataMultiplexed />}
     </Table>
   )
 }

--- a/client/src/components/Table.js
+++ b/client/src/components/Table.js
@@ -239,7 +239,6 @@ export const Table = ({
   selectedRows, // For highlighting selected samples rows
   infoText,
   children,
-  onFilterChange = () => {},
   onFilteredRowsChange = () => {}
 }) => {
   const filterTypes = useMemo(
@@ -302,10 +301,6 @@ export const Table = ({
         .map((column) => column.accessor)
     )
   }, [setHiddenColumns, columns])
-
-  useEffect(() => {
-    onFilterChange(state.globalFilter)
-  }, [state.globalFilter])
 
   const justify = filter && infoText ? 'between' : 'end'
   const pad = filter ? { vertical: 'medium' } : {}

--- a/client/src/components/TriStateModalityCheckBox.js
+++ b/client/src/components/TriStateModalityCheckBox.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Box } from 'grommet'
+import { FormCheckmark } from 'grommet-icons'
+import { useDatasetSamplesTable } from 'hooks/useDatasetSamplesTable'
+
+// NOTE: Ask Deepa for a checkmark SVG Icon
+export const TriStateModalityCheckBox = ({ modality }) => {
+  const { selectedSamples, filteredSamples, toggleAllSamples } =
+    useDatasetSamplesTable()
+
+  const sampleIdsOnPage = filteredSamples.map((sample) => sample.scpca_id)
+  const currentSelectedSamples = selectedSamples[modality]
+
+  const selectedCountOnPage = sampleIdsOnPage.filter((id) =>
+    currentSelectedSamples.includes(id)
+  ).length
+
+  const isNoneSelected = selectedCountOnPage === 0
+  const isAllSelected = selectedCountOnPage === sampleIdsOnPage.length
+  const isSomeSelected = !isNoneSelected && !isAllSelected
+
+  return (
+    <Box
+      align="center"
+      border={{
+        side: 'all',
+        color: !isNoneSelected ? 'brand' : 'black-tint-60'
+      }}
+      justify="center"
+      round="4px"
+      width="24px"
+      height="24px"
+      onClick={() => toggleAllSamples(modality)}
+    >
+      {isSomeSelected && (
+        <Box background="brand" round="inherit" width="10px" height="3px" />
+      )}
+      {isAllSelected && <FormCheckmark color="brand" size="20px" />}
+    </Box>
+  )
+}
+
+export default TriStateModalityCheckBox

--- a/client/src/components/TriStateModalityCheckBox.js
+++ b/client/src/components/TriStateModalityCheckBox.js
@@ -1,12 +1,21 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Box } from 'grommet'
 import { FormCheckmark } from 'grommet-icons'
+import { useDatasetManager } from 'hooks/useDatasetManager'
 import { useDatasetSamplesTable } from 'hooks/useDatasetSamplesTable'
 
 // NOTE: Ask Deepa for a checkmark SVG Icon
-export const TriStateModalityCheckBox = ({ modality }) => {
+export const TriStateModalityCheckBox = ({ modality, disabled }) => {
+  const { myDataset, userFormat } = useDatasetManager()
   const { selectedSamples, filteredSamples, toggleAllSamples } =
     useDatasetSamplesTable()
+
+  const disableSpatial =
+    modality === 'SPATIAL' && (myDataset.format || userFormat) === 'ANN_DATA'
+
+  const borderRegular = !isNoneSelected && !disabled ? 'brand' : 'black-tint-60'
+  const borderColor =
+    disabled || disableSpatial ? 'black-tint-80' : borderRegular
 
   const sampleIdsOnPage = filteredSamples.map((sample) => sample.scpca_id)
   const currentSelectedSamples = selectedSamples[modality]
@@ -19,18 +28,31 @@ export const TriStateModalityCheckBox = ({ modality }) => {
   const isAllSelected = selectedCountOnPage === sampleIdsOnPage.length
   const isSomeSelected = !isNoneSelected && !isAllSelected
 
+  const handleToggleAllSamples = () => {
+    if (disabled) return
+    toggleAllSamples(modality)
+  }
+
+  // Deselect all samples for spatial when a user selects ANN_DATA
+  useEffect(() => {
+    if (disableSpatial) {
+      toggleAllSamples('SPATIAL')
+    }
+  }, [userFormat])
+
   return (
     <Box
       align="center"
       border={{
         side: 'all',
-        color: !isNoneSelected ? 'brand' : 'black-tint-60'
+        color: borderColor
       }}
       justify="center"
       round="4px"
       width="24px"
       height="24px"
-      onClick={() => toggleAllSamples(modality)}
+      style={{ pointerEvents: disabled || disableSpatial ? 'none' : 'auto' }}
+      onClick={handleToggleAllSamples}
     >
       {isSomeSelected && (
         <Box background="brand" round="inherit" width="10px" height="3px" />

--- a/client/src/pages/projects/[scpca_id].js
+++ b/client/src/pages/projects/[scpca_id].js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Box, Tabs, Tab, Text } from 'grommet'
 import { useRouter } from 'next/router'
+import { DatasetSamplesTableContextProvider } from 'contexts/DatasetSamplesTableContext'
 import { ProjectHeader } from 'components/ProjectHeader'
 import { DetailsTable } from 'components/DetailsTable'
 import { ProjectAbstractDetail } from 'components/ProjectAbstractDetail'
@@ -145,10 +146,12 @@ const Project = ({ project }) => {
                   resource={project}
                   attribute="samples"
                 >
-                  <ProjectSamplesTable
-                    project={project}
-                    stickies={responsive(0, 3)}
-                  />
+                  <DatasetSamplesTableContextProvider>
+                    <ProjectSamplesTable
+                      project={project}
+                      stickies={responsive(0, 3)}
+                    />
+                  </DatasetSamplesTableContextProvider>
                 </DownloadOptionsContextProvider>
               </Box>
             </Tab>


### PR DESCRIPTION
## Issue Number

Closes #1355 

Stacked PR of # 1376

## Purpose/Implementation Notes

Changes include:
- Updated `ProjectSamplesTable`, along with adjustments to `Table` and `pages/[scpca_id]`:
  -  Added the tri-state checkbox and modality checkboxes
  - Removed code blocks related to  computed file downloads (e.g., `DownloadModal`, `DownloadOptionsModal`)
- Added new components: 
  - `TriStateModalityCheckBox` - previously part of `DatasetSamplesTable`,  now revised
  - `ModalityCheckBox` - previously part of `DatasetSamplesTable` , now revised
  - `DataFormatChangeModal` - supports the portal user preference `userFormat` (temporarily disabled if `myDataset.format` is already defined,. This behavior will be updated once the flow is finalized.)

Conditions and checks:
- Disabled the `SPATIAL` modality checkboxes in the table if the selected format is `ANN_DATA` selected or  if `SPATIAL` is not available in the project
- Automatically deselect any selected `SPATIAL` modality checkboxes when the user changes `userFormat` from `SINGLE_CELL_EXPERIMENT` to `ANN_DATA` via `DataFormatChangeModal`
- The `"Change"` button of `DataFormatChangeModal` is disabled once `myDataset` is defined (i.e., `myDataset.format` is set)

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Tested on `localhost`.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
