### PR TITLE
attach metadata dataset to project serializer

### DIFF
--- a/api/scpca_portal/serializers/project.py
+++ b/api/scpca_portal/serializers/project.py
@@ -8,6 +8,7 @@ from scpca_portal.serializers.external_accession import ExternalAccessionSeriali
 from scpca_portal.serializers.project_summary import ProjectSummarySerializer
 from scpca_portal.serializers.publication import PublicationSerializer
 from scpca_portal.serializers.sample import SampleSerializer
+from scpca_portal.enums.dataset_formats import DatasetFormats
 
 
 class ProjectLeafSerializer(serializers.ModelSerializer):
@@ -20,7 +21,6 @@ class ProjectLeafSerializer(serializers.ModelSerializer):
             "computed_files",
             "contacts",
             "created_at",
-            "datasets",
             "diagnoses_counts",
             "diagnoses",
             "disease_timings",
@@ -37,6 +37,7 @@ class ProjectLeafSerializer(serializers.ModelSerializer):
             "includes_merged_anndata",
             "includes_merged_sce",
             "includes_xenografts",
+            "metadata_dataset",
             "modalities",
             "multiplexed_sample_count",
             "organisms",
@@ -57,15 +58,17 @@ class ProjectLeafSerializer(serializers.ModelSerializer):
     # but we want these to always be included.
     computed_files = ComputedFileSerializer(read_only=True, many=True)
     contacts = ContactSerializer(read_only=True, many=True)
-    datasets = serializers.SerializerMethodField()
+    metadata_dataset = serializers.SerializerMethodField()
     external_accessions = ExternalAccessionSerializer(read_only=True, many=True)
     publications = PublicationSerializer(read_only=True, many=True)
     samples = serializers.SlugRelatedField(many=True, read_only=True, slug_field="scpca_id")
     summaries = ProjectSummarySerializer(many=True, read_only=True)
 
-    def get_datasets(self, obj):
-        datasets = Dataset.objects.filter(is_ccdl=True, ccdl_project_id=obj.scpca_id)
-        return DatasetSerializer(datasets, many=True).data
+    def get_metadata_dataset(self, obj):
+        dataset = Dataset.objects.filter(
+            is_ccdl=True, ccdl_project_id=obj.scpca_id, format=DatasetFormats.METADATA
+        ).first()
+        return DatasetSerializer(dataset).data
 
 
 class ProjectSerializer(ProjectLeafSerializer):

--- a/api/scpca_portal/serializers/project.py
+++ b/api/scpca_portal/serializers/project.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from scpca_portal.enums.dataset_formats import DatasetFormats
 from scpca_portal.models import Dataset, Project
 from scpca_portal.serializers.computed_file import ComputedFileSerializer
 from scpca_portal.serializers.contact import ContactSerializer
@@ -8,7 +9,6 @@ from scpca_portal.serializers.external_accession import ExternalAccessionSeriali
 from scpca_portal.serializers.project_summary import ProjectSummarySerializer
 from scpca_portal.serializers.publication import PublicationSerializer
 from scpca_portal.serializers.sample import SampleSerializer
-from scpca_portal.enums.dataset_formats import DatasetFormats
 
 
 class ProjectLeafSerializer(serializers.ModelSerializer):

--- a/api/scpca_portal/test/views/test_project.py
+++ b/api/scpca_portal/test/views/test_project.py
@@ -2,8 +2,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from scpca_portal.test.factories import DatasetFactory, ProjectFactory
 from scpca_portal.enums.dataset_formats import DatasetFormats
+from scpca_portal.test.factories import DatasetFactory, ProjectFactory
 
 
 class ProjectsTestCase(APITestCase):
@@ -66,4 +66,6 @@ class ProjectsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_json = response.json()
-        self.assertEqual(response_json["results"][0]["metadata_dataset"]["id"], str(metadata_dataset.id))
+        self.assertEqual(
+            response_json["results"][0]["metadata_dataset"]["id"], str(metadata_dataset.id)
+        )


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- To reduce the load time of /projects endpoint I want to test just serializing the metadata dataset when listing projects.

## Types of changes

- Adds `Project.metadata_dataset` to the project serializer.

Note: This is not a complete change, we will want to also list out the Ids of the datasets and then fully serialize them on the detail of the project or just always show the ids.

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A
