### PR TITLE
Add project_modality_sample_difference and project_downloadable_sample_counts properties to Dataset

### DIFF
--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -448,6 +448,7 @@ class Dataset(TimestampedModel):
             self.samples.filter(Q(has_single_cell_data=True) | Q(has_spatial_data=True))
             .values("project__scpca_id")
             .annotate(num_samples=Count("scpca_id", distinct=True))
+            .order_by("project__scpca_id")
         )
 
         return {project["project__scpca_id"]: project["num_samples"] for project in project_counts}

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -243,7 +243,7 @@ class Dataset(TimestampedModel):
             "project_diagnoses": self.project_diagnoses,
             "project_modality_counts": self.project_modality_counts,
             "modality_count_mismatch_projects": self.modality_count_mismatch_projects,
-            "project_downloadable_sample_counts": self.project_downloadable_sample_counts,
+            "project_sample_counts": self.project_sample_counts,
             "project_titles": self.project_titles,
         }
 
@@ -377,7 +377,7 @@ class Dataset(TimestampedModel):
         return diagnoses_counts
 
     @property
-    def project_modality_counts(self) -> Dict:
+    def project_modality_counts(self) -> Dict[str, Dict[Modalities, int]]:
         """
         Returns a dict where the key is a project id in the dataset and
         the value is an object of SINGLE_CELL and SPATIAL samples
@@ -385,11 +385,22 @@ class Dataset(TimestampedModel):
         """
         counts: dict[str, dict] = defaultdict(dict)
 
-        for project_id in self.data.keys():
+        project_modality_sample_counts = (
+            self.get_selected_samples(
+                [Modalities.SINGLE_CELL, Modalities.SPATIAL],
+            )
+            .values("project__scpca_id")
+            .annotate(
+                single_cell_count=Count("scpca_id", filter=Q(has_single_cell_data=True)),
+                spatial_count=Count("scpca_id", filter=Q(has_spatial_data=True)),
+            )
+            .order_by("project__scpca_id")
+        )
 
-            for modality in [Modalities.SINGLE_CELL, Modalities.SPATIAL]:
-                samples = self.get_project_modality_samples(project_id, modality)
-                counts[project_id][modality] = samples.count()
+        for count in project_modality_sample_counts:
+            project_id = count["project__scpca_id"]
+            counts[project_id][Modalities.SINGLE_CELL] = count.get("single_cell_count", 0)
+            counts[project_id][Modalities.SPATIAL] = count.get("spatial_count", 0)
 
         return counts
 
@@ -399,59 +410,51 @@ class Dataset(TimestampedModel):
         Returns a list of project ids where the samples differ between the SINGLE_CELL
         and SPATIAL modalities (i.e., samples are present in one modality but not the other).
         """
-        project_ids = self.data.keys()
+        dataset_samples = self.get_selected_samples(
+            [Modalities.SINGLE_CELL, Modalities.SPATIAL]
+        ).values_list("scpca_id", "project__scpca_id", "has_single_cell_data", "has_spatial_data")
 
-        single_cell_samples = self.samples.filter(has_single_cell_data=True).values_list(
-            "scpca_id", "project__scpca_id"
-        )
-
-        spatial_samples = self.samples.filter(has_spatial_data=True).values_list(
-            "scpca_id", "project__scpca_id"
-        )
-
-        modality_samples_by_project = {
-            project_id: (
-                set(
-                    scpca_id
-                    for scpca_id, project__scpca_id in single_cell_samples
-                    if project__scpca_id == project_id
-                ),
-                set(
-                    scpca_id
-                    for scpca_id, project__scpca_id in spatial_samples
-                    if project__scpca_id == project_id
-                ),
-            )
-            for project_id in project_ids
-        }
+        project_modality_samples = defaultdict(lambda: defaultdict(set))
+        for (
+            scpca_id,
+            project__scpca_id,
+            has_single_cell_data,
+            has_spatial_data,
+        ) in dataset_samples:
+            if has_single_cell_data:
+                project_modality_samples[project__scpca_id][Modalities.SINGLE_CELL].add(scpca_id)
+            if has_spatial_data:
+                project_modality_samples[project__scpca_id][Modalities.SPATIAL].add(scpca_id)
 
         mismatch_project_ids = []
         for project_id, modalities in self.data.items():
-            # Early exsit if either modality has no samples
+            # Early exit if either modality has no samples
             if not modalities[Modalities.SINGLE_CELL] or not modalities[Modalities.SPATIAL]:
                 continue
 
-            single_cell_samples, spatial_samples = modality_samples_by_project[project_id]
+            single_cell_samples = project_modality_samples[project_id][Modalities.SINGLE_CELL]
+            spatial_samples = project_modality_samples[project_id][Modalities.SPATIAL]
+
             if single_cell_samples ^ spatial_samples:
                 mismatch_project_ids.append(project_id)
 
         return mismatch_project_ids
 
     @property
-    def project_downloadable_sample_counts(self) -> Dict[str, int]:
+    def project_sample_counts(self) -> Dict[str, int]:
         """
         Returns a dict where the key is a project id in the dataset and
-        the value is the total count of unique samples combined
-        across SINGLE_CELL and SPATIAL modalities for that project.
+        the value is the total count of unique samples combined across
+        SINGLE_CELL and SPATIAL modalities (excluding BULK_RNA_SEQ) for that project.
         """
-        project_counts = (
-            self.samples.filter(Q(has_single_cell_data=True) | Q(has_spatial_data=True))
+        return dict(
+            self.get_selected_samples([Modalities.SINGLE_CELL, Modalities.SPATIAL])
+            .distinct()
             .values("project__scpca_id")
-            .annotate(num_samples=Count("scpca_id", distinct=True))
+            .annotate(num_samples=Count("project__scpca_id"))
             .order_by("project__scpca_id")
+            .values_list("project__scpca_id", "num_samples")
         )
-
-        return {project["project__scpca_id"]: project["num_samples"] for project in project_counts}
 
     @property
     def project_titles(self) -> Dict:
@@ -623,9 +626,23 @@ class Dataset(TimestampedModel):
 
     @property
     def samples(self) -> Iterable[Sample]:
+        """
+        Returns a queryset of all samples contained in data attribute.
+        If a sample is present in more than one modality, it will be
+        duplicated in the resulting queryset.
+        """
+        return self.get_selected_samples(
+            [Modalities.SINGLE_CELL, Modalities.SPATIAL, Modalities.BULK_RNA_SEQ]
+        )
+
+    def get_selected_samples(self, modalities: Iterable[Modalities] = []) -> Iterable[Sample]:
+        """
+        Returns a queryset of samples for the specified modalities
+        contained in data attribute.
+        """
         dataset_samples = Sample.objects.none()
         for project_id in self.data.keys():
-            for modality in [Modalities.SINGLE_CELL, Modalities.SPATIAL, Modalities.BULK_RNA_SEQ]:
+            for modality in modalities:
                 dataset_samples |= self.get_project_modality_samples(project_id, modality)
 
         return dataset_samples

--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -401,13 +401,13 @@ class Dataset(TimestampedModel):
         """
         project_ids = self.data.keys()
 
-        single_cell_samples = self.samples.filter(
-            has_single_cell_data=True, project__scpca_id__in=project_ids
-        ).values_list("scpca_id", "project__scpca_id")
+        single_cell_samples = self.samples.filter(has_single_cell_data=True).values_list(
+            "scpca_id", "project__scpca_id"
+        )
 
-        spatial_samples = self.samples.filter(
-            has_spatial_data=True, project__scpca_id__in=project_ids
-        ).values_list("scpca_id", "project__scpca_id")
+        spatial_samples = self.samples.filter(has_spatial_data=True).values_list(
+            "scpca_id", "project__scpca_id"
+        )
 
         modality_samples_by_project = {
             project_id: (
@@ -444,14 +444,10 @@ class Dataset(TimestampedModel):
         the value is the total count of unique samples combined
         across SINGLE_CELL and SPATIAL modalities for that project.
         """
-        dataset_samples = self.samples.filter(
-            Q(has_single_cell_data=True) | Q(has_spatial_data=True)
-        )
-
         project_counts = (
-            dataset_samples.values("project__scpca_id")
+            self.samples.filter(Q(has_single_cell_data=True) | Q(has_spatial_data=True))
+            .values("project__scpca_id")
             .annotate(num_samples=Count("scpca_id", distinct=True))
-            .order_by("project__scpca_id")
         )
 
         return {project["project__scpca_id"]: project["num_samples"] for project in project_counts}

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -648,6 +648,66 @@ class TestDataset(TestCase):
                     actual_counts[project_id][modality], expected_counts[project_id][modality]
                 )
 
+    def test_modality_count_mismatch_projects(self):
+        dataset = Dataset(format=DatasetFormats.SINGLE_CELL_EXPERIMENT)
+        dataset.data = {
+            "SCPCP999990": {
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: "MERGED",
+                Modalities.SPATIAL: ["SCPCS999991"],
+            },
+            "SCPCP999991": {
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: [
+                    "SCPCS999992",
+                    "SCPCS999993",
+                    "SCPCS999995",
+                ],
+                Modalities.SPATIAL: [],
+            },
+            "SCPCP999992": {
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: [],
+                Modalities.SPATIAL: [],
+            },
+        }
+
+        expected_mismatch_projects = ["SCPCP999990"]
+
+        actual_mismatch_projects = dataset.modality_count_mismatch_projects
+
+        self.assertCountEqual(actual_mismatch_projects, expected_mismatch_projects)
+
+    def test_project_downloadable_sample_counts(self):
+        dataset = Dataset(format=DatasetFormats.SINGLE_CELL_EXPERIMENT)
+        dataset.data = {
+            "SCPCP999990": {
+                "includes_bulk": True,
+                Modalities.SINGLE_CELL: "MERGED",
+                Modalities.SPATIAL: ["SCPCS999991"],
+            },
+            "SCPCP999991": {
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: [
+                    "SCPCS999992",
+                    "SCPCS999993",
+                    "SCPCS999995",
+                ],
+                Modalities.SPATIAL: [],
+            },
+            "SCPCP999992": {
+                "includes_bulk": False,
+                Modalities.SINGLE_CELL: ["SCPCS999996", "SCPCS999998"],
+                Modalities.SPATIAL: [],
+            },
+        }
+
+        expected_counts = {"SCPCP999990": 3, "SCPCP999991": 3, "SCPCP999992": 2}
+
+        actual_counts = dataset.project_downloadable_sample_counts
+
+        self.assertEqual(actual_counts, expected_counts)
+
     def test_project_titles(self):
         dataset = Dataset(format=DatasetFormats.SINGLE_CELL_EXPERIMENT)
         dataset.data = {

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -678,7 +678,7 @@ class TestDataset(TestCase):
 
         self.assertCountEqual(actual_mismatch_projects, expected_mismatch_projects)
 
-    def test_project_downloadable_sample_counts(self):
+    def test_project_sample_counts(self):
         dataset = Dataset(format=DatasetFormats.SINGLE_CELL_EXPERIMENT)
         dataset.data = {
             "SCPCP999990": {
@@ -704,7 +704,7 @@ class TestDataset(TestCase):
 
         expected_counts = {"SCPCP999990": 3, "SCPCP999991": 3, "SCPCP999992": 2}
 
-        actual_counts = dataset.project_downloadable_sample_counts
+        actual_counts = dataset.project_sample_counts
 
         self.assertEqual(actual_counts, expected_counts)
 

--- a/api/scpca_portal/test/views/test_dataset.py
+++ b/api/scpca_portal/test/views/test_dataset.py
@@ -209,7 +209,7 @@ class DatasetsTestCase(APITestCase):
             "project_diagnoses",
             "project_modality_counts",
             "modality_count_mismatch_projects",
-            "project_downloadable_sample_counts",
+            "project_sample_counts",
             "project_titles",
         }
         for field in stats_property_fields:

--- a/api/scpca_portal/test/views/test_dataset.py
+++ b/api/scpca_portal/test/views/test_dataset.py
@@ -208,6 +208,8 @@ class DatasetsTestCase(APITestCase):
             "files_summary",
             "project_diagnoses",
             "project_modality_counts",
+            "modality_count_mismatch_projects",
+            "project_downloadable_sample_counts",
             "project_titles",
         }
         for field in stats_property_fields:


### PR DESCRIPTION
## Issue Number

N/A 

Related PR: #1421 (which requires the changes included in this PR)

@davidsmejia, to get the downloadable samples counts and modality samples differences on each project card, I added the following new properties. I wasn't able to calculate these using the existing `dataset` fields on the client side (e.g., when single-cell samples are `"MERGED"`, no sample IDs are available in the API response) . Let me know what you think. Thank you! 

## Purpose/Implementation Notes

I've added the following properties to the `Dataset` model for the project card (`DatasetProjectCard`) on My Dataset page:

- ~~`project_modality_sample_difference`: a dict where the key is a project id in the dataset and the value is the number of samples that are unique to either the SINGLE_CELL or SPATIAL modality~~

e.g.) Data structure of this property:
```py
# "project_modality_sample_difference": {
#     "SCPCP000002": 0,
#     "SCPCP000006": 5, 
#     "SCPCP000007": 0
# },

# UPDATED:
  
"modality_count_mismatch_projects": [ "SCPCP000006" ]
```

**UPDATE:** We no longer require sample counts and will simply return a list of project IDs for projects containing mismatched modality samples (see https://github.com/AlexsLemonade/scpca-portal/pull/1440#discussion_r2301480988)

---

- `project_downloadable_sample_counts`: a dict where the key is a project id in the dataset and the value is the total count of unique downloadable samples combined across all modalities for that project.

e.g.) Data structure of this property:
```py
 "project_downloadable_sample_counts": {
      "SCPCP000002": 26,
      "SCPCP000006": 43,
      "SCPCP000007": 5
  },
```

## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)

## Functional tests

New tests added:

- `.models.test_dataset.TestDataset.test_modality_count_mismatch_projects`
- `.models.test_dataset.TestDataset.test_project_downloadable_sample_counts`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

<img width="841" height="925" alt="project_cards" src="https://github.com/user-attachments/assets/5d3ee7da-50ce-4d88-a040-b7f0cdb15633" />
