### PR TITLE
Hotfix: only apply state if dataset exists

### DIFF
--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -222,7 +222,9 @@ class Job(TimestampedModel):
         if hasattr(self, f"{state_str}_reason"):
             setattr(self, f"{state_str}_reason", reason)
 
-        self.dataset.apply_job_state(self)  # Sync the dataset state
+        if self.dataset:
+            self.dataset.apply_job_state(self)  # Sync the dataset state
+
         return True
 
     @classmethod


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- when dispatching jobs, unable to iterate because after first submit we try to apply job state to dataset that does not exist, this PR fixes that


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
