### PR TITLE
Add support for initiating dataset download via DatasetProcessModal

### DIFF
--- a/client/src/components/DatasetProcessForm.js
+++ b/client/src/components/DatasetProcessForm.js
@@ -29,7 +29,7 @@ export const DatasetProcessForm = ({
   const [submitting, setSubmitting] = useState(false) // Disable the button while making request
   const [errors, setErrors] = useState([])
 
-  const isTokenReady = token && !requesting
+  const isToken = token && !requesting
 
   const handleRequestToken = () => {
     setSubmitting(true)
@@ -72,7 +72,7 @@ export const DatasetProcessForm = ({
 
   return (
     <Box>
-      {isTokenReady ? (
+      {isToken ? (
         <Paragraph>
           We’ll send a email to <Text weight="bold">{email}</Text> once the
           dataset is ready to be downloaded.

--- a/client/src/components/DatasetProcessForm.js
+++ b/client/src/components/DatasetProcessForm.js
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from 'react'
+import { Box, Paragraph, Text } from 'grommet'
+import { useScPCAPortal } from 'hooks/useScPCAPortal'
+import { useResponsive } from 'hooks/useResponsive'
+import { DownloadTokenInputs } from 'components/DownloadTokenInputs'
+import { Button } from 'components/Button'
+
+export const DatasetProcessForm = ({
+  buttonLabel = 'Agree and Continue',
+  text = '',
+  onCancel = () => {},
+  onContinue = () => {}
+}) => {
+  const {
+    token,
+    email,
+    setEmail,
+    wantsEmails,
+    setWantsEmails,
+    acceptsTerms,
+    setAcceptsTerms,
+    createToken,
+    validateToken,
+    emailListForm
+  } = useScPCAPortal()
+  const { responsive } = useResponsive()
+
+  const [requesting, setRequesting] = useState(false)
+  const [submitting, setSubmitting] = useState(false) // Disable the button while making request
+  const [errors, setErrors] = useState([])
+
+  const handleRequestToken = () => {
+    setSubmitting(true)
+    if (token) {
+      onContinue()
+    } else {
+      setRequesting(true)
+    }
+  }
+
+  // Request a token if none exists
+  useEffect(() => {
+    const asyncTokenRequest = async () => {
+      const validation = await validateToken()
+      if (validation.isValid) {
+        const tokenRequest = await createToken()
+        if (tokenRequest.isOK) {
+          setErrors([])
+        }
+        // quietly sign them up for emails if checked
+        if (wantsEmails) {
+          emailListForm.submit({ email })
+        }
+      } else {
+        // invalid set errors here
+        setErrors(validation.errors)
+        setRequesting(false)
+        setSubmitting(false)
+      }
+    }
+    if (requesting) asyncTokenRequest()
+  }, [requesting])
+
+  // Process dataset upon successful token request
+  useEffect(() => {
+    if (requesting && token) {
+      onContinue()
+    }
+  }, [token, requesting])
+
+  return (
+    <Box>
+      {token && !requesting ? (
+        <Paragraph>
+          We’ll send a email to <Text weight="bold">{email}</Text> once the
+          dataset is ready to be downloaded.
+        </Paragraph>
+      ) : (
+        <>
+          <Paragraph margin={{ bottom: 'small' }}>
+            {text ||
+              'Please provide your email and we’ll let you know when it’s ready for download.'}
+          </Paragraph>
+          {errors.length > 0 && (
+            <Box>
+              {errors.map((e) => (
+                <Text key={e} color="error">
+                  {e}
+                </Text>
+              ))}
+            </Box>
+          )}
+          <DownloadTokenInputs
+            acceptsTerms={acceptsTerms}
+            email={email}
+            wantsEmails={wantsEmails}
+            onAcceptsTermsChange={setAcceptsTerms}
+            onEmailChange={setEmail}
+            onWantEmailsChange={setWantsEmails}
+          />
+        </>
+      )}
+
+      <Box direction="row" justify="end" margin={{ top: 'medium' }} />
+      <Box
+        align="center"
+        justify="end"
+        direction={responsive('column', 'row')}
+        gap="medium"
+      >
+        <Button aria-label="Cancel" label="Cancel" onClick={onCancel} />
+        <Button
+          primary
+          label={buttonLabel}
+          disabled={!acceptsTerms || !email || submitting}
+          onClick={handleRequestToken}
+        />
+      </Box>
+    </Box>
+  )
+}
+
+export default DatasetProcessForm

--- a/client/src/components/DatasetProcessForm.js
+++ b/client/src/components/DatasetProcessForm.js
@@ -29,6 +29,8 @@ export const DatasetProcessForm = ({
   const [submitting, setSubmitting] = useState(false) // Disable the button while making request
   const [errors, setErrors] = useState([])
 
+  const isTokenReady = token && !requesting
+
   const handleRequestToken = () => {
     setSubmitting(true)
     if (token) {
@@ -70,7 +72,7 @@ export const DatasetProcessForm = ({
 
   return (
     <Box>
-      {token && !requesting ? (
+      {isTokenReady ? (
         <Paragraph>
           We’ll send a email to <Text weight="bold">{email}</Text> once the
           dataset is ready to be downloaded.

--- a/client/src/components/DatasetProcessModal.js
+++ b/client/src/components/DatasetProcessModal.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react'
+import { Box, Grid, Paragraph } from 'grommet'
+import { useRouter } from 'next/router'
+import { useDatasetManager } from 'hooks/useDatasetManager'
+import { Button } from 'components/Button'
+import { DatasetProcessForm } from 'components/DatasetProcessForm'
+import { Modal, ModalBody } from 'components/Modal'
+
+// Button and modal to show when initiating dataset processing for file download
+export const DatasetProcessModal = ({
+  label = 'Download Dataset',
+  title = 'Download Dataset',
+  disabled = false
+}) => {
+  const { push } = useRouter()
+  const { processDataset } = useDatasetManager()
+
+  const [showing, setShowing] = useState(false)
+
+  const handleProcessDataset = async () => {
+    const datasetRequest = await processDataset()
+
+    if (datasetRequest) {
+      push(`/datasets/${datasetRequest.id}`)
+    } else {
+      // TODO: Error handling
+    }
+  }
+
+  return (
+    <>
+      <Button
+        aria-label={label}
+        flex="grow"
+        primary
+        label={label}
+        disabled={disabled}
+        onClick={() => setShowing(true)}
+      />
+      <Modal title={title} showing={showing} setShowing={setShowing}>
+        <ModalBody>
+          <Grid columns={['auto']} pad={{ bottom: 'medium' }}>
+            <Box pad={{ bottom: 'large' }} gap="medium" width="500px">
+              <Paragraph>
+                We’re getting ready to put your dataset together. This can take
+                between a few hours to a day.
+              </Paragraph>
+              <DatasetProcessForm
+                buttonLabel="Continue"
+                onContinue={handleProcessDataset}
+              />
+            </Box>
+          </Grid>
+        </ModalBody>
+      </Modal>
+    </>
+  )
+}
+
+export default DatasetProcessModal

--- a/client/src/components/DatasetProcessModal.js
+++ b/client/src/components/DatasetProcessModal.js
@@ -47,6 +47,7 @@ export const DatasetProcessModal = ({
               </Paragraph>
               <DatasetProcessForm
                 buttonLabel="Continue"
+                onCancel={() => setShowing(false)}
                 onContinue={handleProcessDataset}
               />
             </Box>

--- a/client/src/contexts/DatasetManagerContext.js
+++ b/client/src/contexts/DatasetManagerContext.js
@@ -6,7 +6,7 @@ export const DatasetManagerContext = createContext({})
 export const DatasetManagerContextProvider = ({ children }) => {
   const [myDataset, setMyDataset] = useLocalStorage('myDataset', {})
   const [datasets, setDatasets] = useLocalStorage('datasets', []) // List of user-created dataset IDs for historical references
-  const [email, setEmail] = useLocalStorage('email', null) // Email associated with myDataset
+  const [email, setEmail] = useLocalStorage('dataset-email', null) // Email associated with myDataset
   const [errors, setErrors] = useState([]) //  TODO: Stores runtime error messages as strings (data structure TBD)
 
   return (

--- a/client/src/hooks/useDatasetManager.js
+++ b/client/src/hooks/useDatasetManager.js
@@ -10,12 +10,11 @@ export const useDatasetManager = () => {
     setMyDataset,
     datasets,
     setDatasets,
-    email,
     setEmail,
     errors,
     setErrors
   } = useContext(DatasetManagerContext)
-  const { token, userFormat, setUserFormat } = useScPCAPortal()
+  const { token, email, userFormat, setUserFormat } = useScPCAPortal()
 
   /* Helper */
   const addError = (message, returnValue = null) => {
@@ -84,10 +83,10 @@ export const useDatasetManager = () => {
       return addError('An error occurred while trying to update the dataset')
     }
 
-    // TODO: (TBD) To clearly distinguish between unprocessed and processed datasets on the client side,
-    // either default the 'start' field to null or add the 'processing_at' field in the serializer.
-    // Set only unprocessed dataset to myDataset (temporarily using 'start_at')
-    setMyDataset(dataset.start_at != null ? {} : datasetRequest.response)
+    const { response } = datasetRequest
+    // TODO: Determine which field should be used to clear localStorage (e.g., is_started, is_processing, start)
+    // Tmporarily using 'start' flag to clear or set the response to myDataset
+    setMyDataset(response.start ? {} : response)
 
     return datasetRequest.response
   }
@@ -95,20 +94,20 @@ export const useDatasetManager = () => {
   const clearDataset = async (dataset) =>
     updateDataset({ ...dataset, data: {} })
 
-  const processDataset = async (dataset) => {
+  const processDataset = async () => {
     // Token is required for dataset processing
     if (!token) {
       return addError('A valid token is required to update the dataset')
     }
 
-    if (!dataset.email) {
+    if (!email) {
       return addError('An email is required to process the dataset')
     }
 
-    // Save the user email
-    setEmail(dataset.email)
+    // Save the dataset email
+    setEmail(email)
     // Set the start flag to true for processing
-    return updateDataset({ ...dataset, start: true })
+    return updateDataset({ ...myDataset, email, start: true })
   }
 
   /* Project-level */

--- a/client/src/pages/download/index.js
+++ b/client/src/pages/download/index.js
@@ -3,9 +3,11 @@ import { Box, Text } from 'grommet'
 import { useScrollPosition } from 'hooks/useScrollPosition'
 import { useDatasetManager } from 'hooks/useDatasetManager'
 import { useResponsive } from 'hooks/useResponsive'
+import { formatBytes } from 'helpers/formatBytes'
 import { DatasetSummary } from 'components/DatasetSummary'
 import { DatasetDownloadFileSummary } from 'components/DatasetDownloadFileSummary'
 import { DatasetProjectCard } from 'components/DatasetProjectCard'
+import { DatasetProcessModal } from 'components/DatasetProcessModal'
 import { Loader } from 'components/Loader'
 import Error from 'pages/_error'
 
@@ -56,6 +58,13 @@ const Download = () => {
             <Text serif size="xlarge">
               My Dataset
             </Text>
+            <Box>
+              <DatasetProcessModal />
+              <Text weight="bold">
+                Uncompressed size:{' '}
+                {formatBytes(myDataset.stats.uncompressed_size)}
+              </Text>
+            </Box>
           </Box>
           <Box margin={{ bottom: 'large' }}>
             <DatasetSummary dataset={myDataset} />


### PR DESCRIPTION
## Issue Number

Closes #1406 

Stacked PR of #1455

## Purpose/Implementation Notes

@dvenprasad, see the latest UI Preview [here](https://scpca-portal-efo1qv6be-ccdl.vercel.app/). Thank you! 

I've added the support for initiating dataset download on My Dataset page.

Changes include:
- Added `DatasetProcessModal` for the `"Download Dataset"` modal, which initiates dataset processing for download
- Added `DatasetProcessForm`, which is rendered inside the modal and handles token generation and dataset submission
- Updated the `useDatasetManager.processDataset` method to directly use `myDataset` instead of accepting a dataset reference as an argument
- Renamed the localStorage state key for `email` to `dataset-email` in `DatasetManagerContext` for improved clarity

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

**UI Conditions and checks tested:**

1.  Add projects/samples to a dataset from the Browse page or the project samples table on the Project Details page
2. Go to My Dataset page by clicking the `My Dataset` button in the global menu

On the My Dataset page:
- Click the `Download Dataset` button to start dataset processing:
  - If no token exists, a token form will be displayed
  - If a token already exists, a message will be displayed with the email address you previously provided
  - After clicking the `"Continue"` button, upon a successful API request:
    - The portal will redirect to `datasets/[[dataset_id]` (currently an empty) 
    - My Dataset will be removed from your browser, as processing datasets cannot be modified

To confirm the successful request in the API endpoint: 
1. Grab the dataset ID from the brower's address bar

<img width="720" height="35" alt="dataset_id" src="https://github.com/user-attachments/assets/d9cba4db-2277-483e-aa1a-f83c09cd5293" />

2. Go to the staging `datasets` endpoint and append the dataset ID:

e.g.)
```
https://api.staging.scpca.alexslemonade.org/v1/datasets/63ae0536-650c-469d-8207-fff1e3bc2c5f
```

3. Confirm following in the response payload:

```py
"email": "youremail@example.com",  // your email address
"start": true, // set to true not false
```

e.g.) Or in the UI:
<img width="1051" height="141" alt="UI" src="https://github.com/user-attachments/assets/ba49be3e-9229-4322-8e91-460126e3890d" />

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A