### PR TITLE
Add Cellbrowser Static Site Bucket

### DIFF
--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -30,6 +30,8 @@ jobs:
           SSH_PUBLIC_KEY: "${{ secrets.OP_SSH_PUBLIC_KEY }}"
           SENTRY_DSN: "${{ secrets.OP_SENTRY_DSN }}"
           SLACK_CCDL_TEST_CHANNEL_EMAIL: "${{ secrets.OP_SLACK_CCDL_TEST_CHANNEL_EMAIL }}"
+          CELLBROWSER_SECURITY_TOKEN: "${{ secrets.OP_CELLBROWSER_SECURITY_TOKEN }}"
+          CELLBROWSER_UPLOADERS: "${{ secrets.OP_CELLBROWSER_UPLOADERS }}"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/deploy_staging_backend.yml
+++ b/.github/workflows/deploy_staging_backend.yml
@@ -30,6 +30,8 @@ jobs:
           SSH_PUBLIC_KEY: "${{ secrets.OP_SSH_PUBLIC_KEY }}"
           SENTRY_DSN: "${{ secrets.OP_SENTRY_DSN }}"
           SLACK_CCDL_TEST_CHANNEL_EMAIL: "${{ secrets.OP_SLACK_CCDL_TEST_CHANNEL_EMAIL }}"
+          CELLBROWSER_SECURITY_TOKEN: "${{ secrets.OP_CELLBROWSER_SECURITY_TOKEN }}"
+          CELLBROWSER_UPLOADERS: "${{ secrets.OP_CELLBROWSER_UPLOADERS }}"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/bin/sportal
+++ b/bin/sportal
@@ -37,7 +37,7 @@ DEPLOY_ENVS = {
     "AWS_SECRET_ACCESS_KEY": "AWS credential accessing input bucket or any project resources.",
     "ENABLE_FEATURE_PREVIEW": "Turn on in-progress features. You probably want this set to True",
     "CELLBROWSER_SECURITY_TOKEN": "Cellbrowser security token for requests.",
-    "CELLBROWSER_UPLOADERS": "A list of IAM User ARNS to allow for uploading to the cellbrowser bucket.",
+    "CELLBROWSER_UPLOADERS": "List of IAM User ARNS allowed to upload to cellbrowser bucket.",
 }
 
 # Everything needs access to the system env.

--- a/bin/sportal
+++ b/bin/sportal
@@ -35,6 +35,9 @@ DEPLOY_ENVS = {
     "SLACK_CCDL_TEST_CHANNEL_EMAIL": "used for testing email",
     "AWS_ACCESS_KEY_ID": "AWS credential accessing input bucket or any project resources.",
     "AWS_SECRET_ACCESS_KEY": "AWS credential accessing input bucket or any project resources.",
+    "ENABLE_FEATURE_PREVIEW": "Turn on in-progress features. You probably want this set to True",
+    "CELLBROWSER_SECURITY_TOKEN": "Cellbrowser security token for requests.",
+    "CELLBROWSER_UPLOADERS": "A list of IAM User ARNS to allow for uploading to the cellbrowser bucket."
 }
 
 # Everything needs access to the system env.

--- a/bin/sportal
+++ b/bin/sportal
@@ -37,7 +37,7 @@ DEPLOY_ENVS = {
     "AWS_SECRET_ACCESS_KEY": "AWS credential accessing input bucket or any project resources.",
     "ENABLE_FEATURE_PREVIEW": "Turn on in-progress features. You probably want this set to True",
     "CELLBROWSER_SECURITY_TOKEN": "Cellbrowser security token for requests.",
-    "CELLBROWSER_UPLOADERS": "A list of IAM User ARNS to allow for uploading to the cellbrowser bucket."
+    "CELLBROWSER_UPLOADERS": "A list of IAM User ARNS to allow for uploading to the cellbrowser bucket.",
 }
 
 # Everything needs access to the system env.

--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -31,6 +31,8 @@ TF_ENV_VAR = {
     "SSH_PUBLIC_KEY": "TF_VAR_ssh_public_key",
     "SLACK_CCDL_TEST_CHANNEL_EMAIL": "TF_VAR_slack_ccdl_test_channel_email",
     "ENABLE_FEATURE_PREVIEW": "TF_VAR_enable_feature_preview",
+    "CELLBROWSER_SECURITY_TOKEN": "TF_VAR_cellbrowser_security_token",
+    "CELLBROWSER_UPLOADERS": "TF_VAR_cellbrowser_uploaders",
 }
 
 
@@ -245,7 +247,7 @@ if __name__ == "__main__":
         ]
 
     # Always init first
-    init_code = terraform.init(backend_configs)
+    init_code = terraform.init(backend_configs, env=env)
 
     if init_code != 0 or args.init:
         exit(init_code)
@@ -254,15 +256,15 @@ if __name__ == "__main__":
     var_file_arg = f"-var-file=tf_vars/{args.stage}.tfvars"
 
     if args.plan:
-        terraform.plan(var_file_arg, args.save_plan)
+        terraform.plan(var_file_arg, args.save_plan, env=env)
         exit(1)
 
     if args.console:
-        terraform.console(var_file_arg)
+        terraform.console(var_file_arg, env=env)
         exit(1)
 
     if args.destroy:
-        terraform.destroy(var_file_arg)
+        terraform.destroy(var_file_arg, env=env)
         exit(1)
 
     terraform_code, terraform_output = terraform.apply(var_file_arg, taints=TAINT_ON_APPLY, env=env)

--- a/infrastructure/deploy_modules/terraform.py
+++ b/infrastructure/deploy_modules/terraform.py
@@ -76,7 +76,9 @@ def console(var_file_arg, env=os.environ.copy()):
     """
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
-        terraform_process = subprocess.Popen(["terraform", "console", var_file_arg, "-plan"], env=env)
+        terraform_process = subprocess.Popen(
+            ["terraform", "console", var_file_arg, "-plan"], env=env
+        )
         terraform_process.wait()
         exit(terraform_process.returncode)
     except KeyboardInterrupt:
@@ -123,8 +125,7 @@ def destroy(var_file_arg, env=os.environ.copy()):
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
         terraform_process = subprocess.Popen(
-            ["terraform", "destroy", var_file_arg, "-auto-approve"],
-            env=env
+            ["terraform", "destroy", var_file_arg, "-auto-approve"], env=env
         )
         terraform_process.wait()
         exit(terraform_process.returncode)

--- a/infrastructure/deploy_modules/terraform.py
+++ b/infrastructure/deploy_modules/terraform.py
@@ -16,7 +16,7 @@ import signal
 import subprocess
 
 
-def init(backend_configs=[], init_args=["-upgrade"], log_trace=False):
+def init(backend_configs=[], init_args=["-upgrade"], env=os.environ.copy(), log_trace=False):
     """Initializes terraform's backend.
 
     Should be called before calling other terraform commands.
@@ -48,7 +48,7 @@ def init(backend_configs=[], init_args=["-upgrade"], log_trace=False):
     return terraform_process.returncode
 
 
-def plan(var_file_arg, out=False):
+def plan(var_file_arg, out=False, env=os.environ.copy()):
     """Plan changes that will be made to infrastructure.
 
     Should be called after init.
@@ -62,21 +62,21 @@ def plan(var_file_arg, out=False):
         command += ["-out=PLAN"]
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
-        terraform_process = subprocess.Popen(command)
+        terraform_process = subprocess.Popen(command, env=env)
         terraform_process.wait()
         exit(terraform_process.returncode)
     except KeyboardInterrupt:
         terraform_process.send_signal(signal.SIGINT)
 
 
-def console(var_file_arg):
+def console(var_file_arg, env=os.environ.copy()):
     """Enter a terraform REPL.
 
     Should be called after init.
     """
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
-        terraform_process = subprocess.Popen(["terraform", "console", var_file_arg, "-plan"])
+        terraform_process = subprocess.Popen(["terraform", "console", var_file_arg, "-plan"], env=env)
         terraform_process.wait()
         exit(terraform_process.returncode)
     except KeyboardInterrupt:
@@ -119,11 +119,12 @@ def apply(var_file_arg, taints=[], env=os.environ.copy(), print_output=True):
     return process.returncode, merged_output
 
 
-def destroy(var_file_arg):
+def destroy(var_file_arg, env=os.environ.copy()):
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
         terraform_process = subprocess.Popen(
-            ["terraform", "destroy", var_file_arg, "-auto-approve"]
+            ["terraform", "destroy", var_file_arg, "-auto-approve"],
+            env=env
         )
         terraform_process.wait()
         exit(terraform_process.returncode)

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -79,3 +79,88 @@ resource "aws_s3_bucket_public_access_block" "scpca_portal_cert_bucket" {
   block_public_acls   = true
   block_public_policy = true
 }
+
+# Static site hosting for cellbrowser iframe on portal
+resource "aws_s3_bucket" "scpca_portal_cellbrowser_bucket" {
+  bucket = "scpca-portal-cellbrowser-${var.user}-${var.stage}"
+}
+
+resource "aws_s3_bucket_acl" "scpca_portal_cellbrowser_bucket" {
+  bucket = aws_s3_bucket.scpca_portal_bucket.id
+  acl = "public-read"
+}
+
+resource "aws_s3_bucket_website_configuration" "scpca_portal_cellbrowser_bucket" {
+  bucket = aws_s3_bucket.scpca_portal_cellbrowser_bucket.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  # Optional: specify a custom error page
+  # error_document {
+  #   key = "error.html"
+  # }
+
+  # Optional: Add routing rules if needed
+  # routing_rule {
+  #   condition {
+  #     key_prefix_equals = "images/"
+  #   }
+  #   redirect {
+  #     replace_key_prefix_with = "assets/"
+  #   }
+  # }
+}
+
+resource "aws_s3_bucket_policy" "scpca_portal_cellbrowser_access_policy" {
+  bucket = aws_s3_bucket.scpca_portal_cellbrowser_bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "PublicReadGetObjectWithCustomHeader"
+        Effect = "Allow"
+        Principal = "*"
+        Action = "s3:GetObject"
+        Resource = "${aws_s3_bucket.scpca_portal_cellbrowser_bucket.arn}/*"
+        Condition = {
+          StringLike = {
+              "s3:x-amz-meta-security-token" = [
+                var.cellbrowser_security_token
+              ]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_policy" "scpca_portal_cellbrowser_upload_policy" {
+  bucket = aws_s3_bucket.scpca_portal_cellbrowser_bucket.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ScienceTeamWriteObject"
+        Effect = "Allow"
+        Principal = {
+          "AWS": var.cellbrowser_uploaders
+        }
+        Action = "s3:PutObject"
+        Resource = "${aws_s3_bucket.scpca_portal_cellbrowser_bucket.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "scpca_portal_cellbrowser_bucket" {
+  bucket = aws_s3_bucket.scpca_portal_cellbrowser_bucket.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -163,4 +163,3 @@ resource "aws_s3_bucket_public_access_block" "scpca_portal_cellbrowser_bucket" {
   ignore_public_acls      = false
   restrict_public_buckets = false
 }
-

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -80,6 +80,15 @@ variable "enable_feature_preview" {
   default = "false"
 }
 
+variable "cellbrowser_security_token" {
+  default = "MISSING_VALUE"
+}
+
+variable "cellbrowser_uploaders" {
+  default = []
+  type = list(string)
+}
+
 output "environment_variables" {
   value = [
     {name = "DATABASE_NAME"


### PR DESCRIPTION
## Issue Number

#1445 

## Purpose/Implementation Notes

- Fixes some issues when locally testing changes for cellbrowser 
- Adds the cellbrowser bucket with a static site policy as well as limited permissions for uploading defined by a list of iam user ARNS


## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A tested with `sportal deploy:console` and `sportal deploy:plan`

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
