### PR TITLE
Prepopulate options in DatasetAddSamplesModal 

### DIFF
--- a/client/src/components/DatasetSamplesProjectOptions.js
+++ b/client/src/components/DatasetSamplesProjectOptions.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Box, CheckBox } from 'grommet'
+import { useMyDataset } from 'hooks/useMyDataset'
 import { FormField } from 'components/FormField'
 
 export const DatasetSamplesProjectOptions = ({
@@ -7,6 +8,15 @@ export const DatasetSamplesProjectOptions = ({
   includeBulk,
   onIncludeBulkChange
 }) => {
+  const { myDataset, isProjectIncludeBulk } = useMyDataset()
+
+  // Preselect options based on the values in myDataset
+  useEffect(() => {
+    if (!myDataset) return
+
+    onIncludeBulkChange(isProjectIncludeBulk(project))
+  }, [myDataset])
+
   return (
     <FormField label="Project Options" gap="medium" labelWeight="bold">
       <Box direction="row">


### PR DESCRIPTION
## Issue Number

Closes #1465

Stacked PR of  #1461

## Purpose/Implementation Notes

I've preselected the project options checkbox in the `"Add Samples to Dataset"` modal on the View Project page(undeer the Sample Details tab) based on the values stored in `myDataset`.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
