### PR TITLE
Remove hashes from ccdl dataset serializer

### DIFF
--- a/api/scpca_portal/serializers/ccdl_dataset.py
+++ b/api/scpca_portal/serializers/ccdl_dataset.py
@@ -16,16 +16,6 @@ class CCDLDatasetSerializer(serializers.Serializer):
     format = serializers.CharField(read_only=True)
     regenerated_from = serializers.UUIDField(read_only=True, allow_null=True)
 
-    data_hash = serializers.CharField(read_only=True, allow_null=True)
-    metadata_hash = serializers.CharField(read_only=True, allow_null=True)
-    readme_hash = serializers.CharField(read_only=True, allow_null=True)
-    combined_hash = serializers.CharField(read_only=True, allow_null=True)
-    current_data_hash = serializers.ReadOnlyField()
-    current_metadata_hash = serializers.ReadOnlyField()
-    current_readme_hash = serializers.ReadOnlyField()
-    current_combined_hash = serializers.SerializerMethodField(read_only=True)
-    is_hash_changed = serializers.ReadOnlyField()
-
     includes_files_bulk = serializers.BooleanField(read_only=True)
     includes_files_cite_seq = serializers.BooleanField(read_only=True)
     includes_files_merged = serializers.BooleanField(read_only=True)
@@ -54,11 +44,6 @@ class CCDLDatasetSerializer(serializers.Serializer):
     terminated_reason = serializers.CharField(read_only=True, allow_null=True)
 
     computed_file = serializers.PrimaryKeyRelatedField(read_only=True)
-
-    def get_current_combined_hash(self, obj):
-        return Dataset.get_current_combined_hash(
-            obj.current_data_hash, obj.current_metadata_hash, obj.current_readme_hash
-        )
 
     # Rename the "_data attr" to "data" for output json
     def to_representation(self, instance):


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

In PR https://github.com/AlexsLemonade/scpca-portal/pull/1480, a CCDL Dataset Serializer was added. It was implemented with the base class of `serializers.Serializer` instead of `serializers.ModelSerializer` because of intended performance benefits. We did not see any performance gains with the new base class.

In order to adequately query ccdl portal wide datasets, this PR removes all hash attributes from the serializer.


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A