### PR TITLE
Remaining api changes to support portal wide datasets on client

### DIFF
--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -650,6 +650,10 @@ class Dataset(TimestampedModel):
         Returns all project instances associated with the dataset
         which have cite seq data.
         """
+        # Spatial CCDL Datasets don't have cite seq data
+        if self.is_ccdl and self.ccdl_modality == Modalities.SPATIAL:
+            return Project.objects.none()
+
         return self.projects.filter(has_cite_seq_data=True)
 
     @property

--- a/api/scpca_portal/serializers/ccdl_dataset.py
+++ b/api/scpca_portal/serializers/ccdl_dataset.py
@@ -43,7 +43,7 @@ class CCDLDatasetSerializer(serializers.Serializer):
     is_terminated = serializers.BooleanField(read_only=True)
     terminated_reason = serializers.CharField(read_only=True, allow_null=True)
 
-    computed_file = serializers.PrimaryKeyRelatedField(read_only=True)
+    computed_file = ComputedFileSerializer(read_only=True, many=False)
 
     # Rename the "_data attr" to "data" for output json
     def to_representation(self, instance):
@@ -56,8 +56,6 @@ class CCDLDatasetSerializer(serializers.Serializer):
 
 class CCDLDatasetDetailSerializer(CCDLDatasetSerializer):
     download_url = serializers.SerializerMethodField(read_only=True)
-
-    computed_file = ComputedFileSerializer(read_only=True, many=False)
 
     def get_download_url(self, obj):
         dataset = Dataset.objects.filter(pk=obj.pk).first()


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

- Removes the ability for ccdl datasets with spatial modality to falsely contain cite_seq projects (which is impossible)
- Exposes the entire related ComputedFile object on the CCDLDataset serializer list endpoint
  - NOTE: this change is not necessary to make on the DatasetSerializer because there is no list endpoint on the DatasetSerializer, while the ComputeFile object is available on the DatasetSerializer retrieve endpoint.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes


## Screenshots

N/A