### PR TITLE
add missing closing bracket

### DIFF
--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -172,4 +172,5 @@ resource "aws_s3_bucket_cors_configuration" "scpca_portal_cellbrowser_cors_confi
     allowed_origins = ["*"]
     expose_headers = []
     max_age_seconds = 3000
+  }
 }


### PR DESCRIPTION
## Issue Number

#1445 

## Purpose/Implementation Notes

Adds missing closing curly brace from terraform in s3.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
