### PR TITLE
remove lifecycle ignore cors_rule

### DIFF
--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -78,12 +78,6 @@ resource "aws_s3_bucket_public_access_block" "scpca_portal_cert_bucket" {
 
   block_public_acls   = true
   block_public_policy = true
-
-  lifecycle {
-    ignore_changes = [
-      cors_rule
-    ]
-  }
 }
 
 # Static site hosting for cellbrowser iframe on portal


### PR DESCRIPTION
## Issue Number

#1445 

## Purpose/Implementation Notes

This is a relic from the old approach where cors_rule was defined inside of the s3 bucket resource. Removing as it shouldn't affect the bucket in the same way with the new related cors resource.

## Types of changes


- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A ran a terraform plan

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
