### PR TITLE
Update Dataset.get_files_summary to prevent skipping samples

### DIFF
--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -550,8 +550,10 @@ class TestDataset(TestCase):
         )
 
         expected_single_cell = [
-            {"samples_count": 4, "name": "Single-cell samples", "format": ".rds"},
+            {"samples_count": 7, "name": "Single-cell samples", "format": ".rds"},
+            {"samples_count": 2, "name": "Single-nuclei samples", "format": ".rds"},
             {"samples_count": 1, "name": "Single-cell samples with CITE-seq", "format": ".rds"},
+            {"samples_count": 2, "name": "Single-cell multiplexed samples", "format": ".rds"},
             {"samples_count": 2, "name": "Single-nuclei multiplexed samples", "format": ".rds"},
             {"samples_count": 1, "name": "Spatial samples", "format": "Spatial format"},
             {"samples_count": 1, "name": "Bulk-RNA seq samples", "format": ".tsv"},
@@ -592,7 +594,7 @@ class TestDataset(TestCase):
         )
 
         expected_ann_data = [
-            {"samples_count": 4, "name": "Single-cell samples", "format": ".h5ad"},
+            {"samples_count": 5, "name": "Single-cell samples", "format": ".h5ad"},
             {"samples_count": 1, "name": "Single-cell samples with CITE-seq", "format": ".h5ad"},
             {"samples_count": 1, "name": "Bulk-RNA seq samples", "format": ".tsv"},
         ]

--- a/api/scpca_portal/utils/helpers.py
+++ b/api/scpca_portal/utils/helpers.py
@@ -166,26 +166,6 @@ def get_sorted_field_names(fieldnames: List | Set) -> List:
     )
 
 
-def get_sorted_files_summary(files_summary: List[Dict], *, key="name") -> List[Dict]:
-    """
-    Returns a list of files_summary sorted by key_order of the specified key.
-    Includes only entries with key values in key_order.
-    """
-    key_order = [
-        "Single-cell samples",
-        "Single-nuclei samples",
-        "Single-cell samples with CITE-seq",
-        "Single-cell multiplexed samples",
-        "Single-nuclei multiplexed samples",
-        "Spatial samples",
-        "Bulk-RNA seq samples",
-    ]
-
-    filtered_files_summaries = [s for s in files_summary if s[key] in key_order]
-
-    return sorted(filtered_files_summaries, key=lambda s: key_order.index(s[key]))
-
-
 def get_sorted_modalities(modalities: List | Set) -> List:
     """
     Returns a list of sorted modality values.


### PR DESCRIPTION
## Issue Number

N/A

Related PR comment: https://github.com/AlexsLemonade/scpca-portal/pull/1485#pullrequestreview-3254315337  (which requires the changes included in this PR)

## Purpose/Implementation Notes

@davidsmejia ~~I’ve updated the `Dataset.get_files_summary` to prevent skipping bulk samples (see the related PR comment above). Let me know your insights on this. Thank you, David!~~

**UPDATE:** We noticed that not only  bulk samples but also other filtered samples were skipped. For this reason, I've refactored the method as mentioned in the "Changes include" list. Let me know your feedback. Thank you, David!

@dvenprasad Based on the Figma, the `"Single-cell samples"` should always come first, with the "`Bulk-RNA seq"` samples at the end. Currently, the `files_summary` is sorted as shown below. Let me know if this is correct or if you have any other preferences. Thank you, Deepa!

```py
# Files Summary order:
  [ 
       "Single-cell samples",
        "Single-nuclei samples",
        "Single-cell samples with CITE-seq",
        "Spatial samples",
        "Single-cell multiplexed samples",
        "Single-nuclei multiplexed samples",
        "Bulk-RNA seq samples",
    ]
```

Changes include:
- In `Dataset.get_files_summary`:
   - Removed the `seen_samples` logic from the loop
   - Filtered using library objects instead of library IDs to ensure samples are filtered accurately based on the specified conditions in `summary_queries`
   - Reordered the entries in `summary_queries` for the UI (see [comment](https://github.com/AlexsLemonade/scpca-portal/pull/1507#issuecomment-3324259161)) 
- Adjusted the `TestDataset.get_files_summary` accordingly

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

- Updated `TestDataset.test_get_sorted_files_summary` accordingly

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

**Example 1:** Adding `SCPCP000002` (single cell: **26**, bulk: **20**) and `SCPCP000006` (single cell: **40**, spatial **41**, nuclei **40**, bulk: **43**) to `myDataset`:

<img width="989" height="735" alt="project_card" src="https://github.com/user-attachments/assets/147aec02-f4d6-4a64-81cc-c20cb4ecd62c" />

Should render the following items in the Download File Summary:

<img width="982" height="227" alt="files_summary" src="https://github.com/user-attachments/assets/3967693b-d2c3-4b7f-a09a-9043cd70dad6" />

**Example 1:** Adding `SCPCP000009` without multiplexed samples:

<img width="1231" height="782" alt="exclude_m_samples" src="https://github.com/user-attachments/assets/de2dce71-16be-49a4-a802-0d85b2ab694d" />

Include multiplexed samples:

<img width="1252" height="872" alt="include_m_samples" src="https://github.com/user-attachments/assets/38060eac-e2f6-485a-983e-2d03d4ba3619" />

