### PR TITLE
Update Dataset.get_files_summary method 

### DIFF
--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -549,10 +549,13 @@ class TestDataset(TestCase):
             },
         )
 
+        # TODO: This test should cover all potential counts
         expected_single_cell = [
-            {"samples_count": 2, "name": "Single-nuclei multiplexed samples", "format": ".rds"},
-            {"samples_count": 1, "name": "Single-cell samples with CITE-seq", "format": ".rds"},
             {"samples_count": 4, "name": "Single-cell samples", "format": ".rds"},
+            # Single-nuclei should be included here
+            {"samples_count": 1, "name": "Single-cell samples with CITE-seq", "format": ".rds"},
+            # Single-cell multiplexed should be included here
+            {"samples_count": 2, "name": "Single-nuclei multiplexed samples", "format": ".rds"},
             {"samples_count": 1, "name": "Spatial samples", "format": "Spatial format"},
             {"samples_count": 1, "name": "Bulk-RNA seq samples", "format": ".tsv"},
         ]
@@ -592,8 +595,8 @@ class TestDataset(TestCase):
         )
 
         expected_ann_data = [
-            {"samples_count": 1, "name": "Single-cell samples with CITE-seq", "format": ".h5ad"},
             {"samples_count": 4, "name": "Single-cell samples", "format": ".h5ad"},
+            {"samples_count": 1, "name": "Single-cell samples with CITE-seq", "format": ".h5ad"},
             {"samples_count": 1, "name": "Bulk-RNA seq samples", "format": ".tsv"},
         ]
 


### PR DESCRIPTION
## Issue Number

Related PR comment: https://github.com/AlexsLemonade/scpca-portal/pull/1485#pullrequestreview-3254315337  (which requires the changes included in this PR)


## Purpose/Implementation Notes

Changes include:
- In `Dataset.get_files_summary`:
   - Removed the `seen_samples` logic from the loop
   - Filtered using library objects instead of library IDs to ensure samples are filtered accurately based on the specified conditions in `summary_queries`
   - Reordered the entries in `summary_queries` for the UI (see [comment](https://github.com/AlexsLemonade/scpca-portal/pull/1507#issuecomment-3324259161)) 

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

- Updated `TestDataset.test_get_sorted_files_summary` accordingly

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

**Example 1:** Adding `SCPCP000002` (single cell: **26**, bulk: **20**) and `SCPCP000006` (single cell: **40**, spatial **41**, nuclei **40**, bulk: **43**) to `myDataset`:

<img width="989" height="735" alt="project_card" src="https://github.com/user-attachments/assets/147aec02-f4d6-4a64-81cc-c20cb4ecd62c" />

Should render the following items in the Download File Summary:

<img width="982" height="227" alt="files_summary" src="https://github.com/user-attachments/assets/3967693b-d2c3-4b7f-a09a-9043cd70dad6" />

**Example 1:** Adding `SCPCP000009` without multiplexed samples:

<img width="1231" height="782" alt="exclude_m_samples" src="https://github.com/user-attachments/assets/de2dce71-16be-49a4-a802-0d85b2ab694d" />

Include multiplexed samples:

<img width="1221" height="818" alt="include_m_samples" src="https://github.com/user-attachments/assets/fd3d46f8-67ec-4997-9f12-caca1bf96211" />


