### PR TITLE
1515 - Missing comma on project card when there are multiple seq types

### DIFF
--- a/client/src/components/ProjectHeader.js
+++ b/client/src/components/ProjectHeader.js
@@ -9,7 +9,6 @@ import { InfoText } from 'components/InfoText'
 import { Pill } from 'components/Pill'
 import { WarningText } from 'components/WarningText'
 import { capitalize } from 'helpers/capitalize'
-import { filterOut } from 'helpers/filterOut'
 import { getReadable } from 'helpers/getReadable'
 import { getReadableModality } from 'helpers/getReadableModality'
 import { DownloadOptionsContextProvider } from 'contexts/DownloadOptionsContext'
@@ -19,6 +18,10 @@ export const ProjectHeader = ({ project, linked = false }) => {
   const hasUnavailableSample = Number(project.unavailable_samples_count) !== 0
   const unavailableSampleCountText =
     Number(project.unavailable_samples_count) > 1 ? 'samples' : 'sample'
+
+  const modalitiesExcludingSingleCell = project.modalities.filter(
+    (m) => m !== 'SINGLE_CELL'
+  )
 
   return (
     <DownloadOptionsContextProvider resource={project}>
@@ -66,13 +69,15 @@ export const ProjectHeader = ({ project, linked = false }) => {
           />
           <Badge
             badge="SeqUnit"
-            label={project.seq_units.map((su) => capitalize(su || ''))}
+            label={project.seq_units
+              .map((su) => capitalize(su || ''))
+              .join(', ')}
           />
           <Badge badge="Kit" label={project.technologies.join(', ')} />
-          {project.modalities.length > 0 && (
+          {modalitiesExcludingSingleCell.length > 0 && (
             <Badge
               badge="Modality"
-              label={filterOut(project.modalities, 'SINGLE_CELL')
+              label={modalitiesExcludingSingleCell
                 .map(getReadableModality)
                 .join(', ')}
             />


### PR DESCRIPTION
## Issue Number

Closes #1515

## Purpose/Implementation Notes

The last Vercel Preview [here]()

This PR includes fixes for the following: 
- Render a comma between each seq type
- Render the modality icon only when available

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

<img width="928" height="127" alt="project-header" src="https://github.com/user-attachments/assets/d384a42c-28dd-4fb4-8fe1-174476f09c20" />

