### PR TITLE
Suspend re-computed hashing in ccdl dataset serializer

### DIFF
--- a/api/scpca_portal/serializers/ccdl_dataset.py
+++ b/api/scpca_portal/serializers/ccdl_dataset.py
@@ -61,12 +61,12 @@ class CCDLDatasetSerializer(serializers.ModelSerializer):
 
     computed_file = ComputedFileSerializer(read_only=True, many=False)
 
-    current_combined_hash = serializers.SerializerMethodField(read_only=True, default=None)
-
-    def get_current_combined_hash(self, obj):
-        return Dataset.get_current_combined_hash(
-            obj.current_data_hash, obj.current_metadata_hash, obj.current_readme_hash
-        )
+    # TODO: see above TODO about attrs being added back in when hashing is optimized
+    # current_combined_hash = serializers.SerializerMethodField(read_only=True, default=None)
+    # def get_current_combined_hash(self, obj):
+    #     return Dataset.get_current_combined_hash(
+    #         obj.current_data_hash, obj.current_metadata_hash, obj.current_readme_hash
+    #    )
 
 
 class CCDLDatasetDetailSerializer(CCDLDatasetSerializer):


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

Since CCDL Dataset re-computed hashing attributes currently yield a timeout on list requests, this PR comments them out for the time being. If hashing can be optimized to the point where a request timeout can be averted, then these attributes may be added back in.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)


## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
