### PR TITLE
Remove spatial and ANN_DATA safeguards from DatasetProjectModalityOptions

### DIFF
--- a/client/src/components/DatasetAddProjectModal.js
+++ b/client/src/components/DatasetAddProjectModal.js
@@ -171,7 +171,6 @@ export const DatasetAddProjectModal = ({
                   />
                   <DatasetProjectModalityOptions
                     project={project}
-                    format={format}
                     modalities={modalities}
                     onModalitiesChange={setModalities}
                   />

--- a/client/src/components/DatasetProjectModalityOptions.js
+++ b/client/src/components/DatasetProjectModalityOptions.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { CheckBoxGroup } from 'grommet'
 import { getReadableOptions } from 'helpers/getReadableOptions'
 import { getProjectModalities } from 'helpers/getProjectModalities'
@@ -6,28 +6,10 @@ import { FormField } from 'components/FormField'
 
 export const DatasetProjectModalityOptions = ({
   project,
-  format, // TODO: Remove this once Spatial && ANN_DATA allowed
   modalities,
   onModalitiesChange
 }) => {
-  // TODO: Remove this once Spatial && ANN_DATA allowed
-  const modalityOptions = getReadableOptions(getProjectModalities(project)).map(
-    (mo) =>
-      mo.value === 'SPATIAL' && format === 'ANN_DATA'
-        ? {
-            ...mo,
-            disabled: true
-          }
-        : mo
-  )
-
-  // TODO: Remove this once Spatial && ANN_DATA allowed
-  // Deselect and disable the SPATIAL checkbox if ANN_DATA is selected
-  useEffect(() => {
-    if (format === 'ANN_DATA' && modalities.includes('SPATIAL')) {
-      onModalitiesChange(modalities.filter((m) => m !== 'SPATIAL'))
-    }
-  }, [modalities, format])
+  const modalityOptions = getReadableOptions(getProjectModalities(project))
 
   return (
     <FormField label="Modality" labelWeight="bold">


### PR DESCRIPTION
## Issue Number

Closes #1555

## Purpose/Implementation Notes

@dvenprasad, see the latest UI [here](https://scpca-portal-pjhwsq3ad-ccdl.vercel.app/). Thank you!

I've remove the safeguards for the spatial modality and the AnnData format from the `DatasetProjectModalityOptions` component. Now the spatial modality is data format agnostic.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
