### PR TITLE
Support Spaceranger string for spatial modality downloads

### DIFF
--- a/client/src/helpers/getReadable.js
+++ b/client/src/helpers/getReadable.js
@@ -25,7 +25,8 @@ export const readableNames = {
   SPATIAL: 'Spatial',
   MULTIPLEXED: 'Multiplexed',
   ANN_DATA: 'AnnData (Python)',
-  SINGLE_CELL_EXPERIMENT: 'SingleCellExperiment (R)'
+  SINGLE_CELL_EXPERIMENT: 'SingleCellExperiment (R)',
+  SPATIAL_SPACERANGER: 'Spaceranger'
 }
 
 // Alternate presentation


### PR DESCRIPTION
## Issue Number

Closes #1559

## Purpose/Implementation Notes

I've added support for the new spatial format, `"SPATIAL_SPACERANGER"`, to render as `"Spaceranger"` in the UI. This change supports the current non-dataset downloads on the `dev` server before the complete transition to the dataset feature (prior to merging `feature/dataset-integration`).

Change includes:
- Added the key `"SPATIAL_SPACERANGER"` and its value `"Spaceranger"` to `getReadable`.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
