### PR TITLE
Fix Dataset.get_diagnoses_summary by adding order_by to fix annotation

### DIFF
--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -320,10 +320,14 @@ class Dataset(TimestampedModel):
         of project and sample counts.
         """
         # all diagnoses in the dataset
-        if diagnoses := self.samples.values("diagnosis").annotate(
-            samples=Count("scpca_id"),
-            projects=Count("project_id", distinct=True),
-        ).order_by("diagnosis"):
+        if (
+            diagnoses := self.samples.values("diagnosis")
+            .annotate(
+                samples=Count("scpca_id"),
+                projects=Count("project_id", distinct=True),
+            )
+            .order_by("diagnosis")
+        ):
             return {d.pop("diagnosis"): d for d in diagnoses}
 
         return {}

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -519,8 +519,16 @@ class TestDataset(TestCase):
         self.assertEqual(summary.keys(), expected_counts.keys())
 
         for key in expected_counts.keys():
-            self.assertEqual(summary[key]["projects"], expected_counts[key]["projects"], f"Mismatch in {key} projects")
-            self.assertEqual(summary[key]["samples"], expected_counts[key]["samples"], f"Mismatch in {key} samples")
+            self.assertEqual(
+                summary[key]["projects"],
+                expected_counts[key]["projects"],
+                f"Mismatch in {key} projects",
+            )
+            self.assertEqual(
+                summary[key]["samples"],
+                expected_counts[key]["samples"],
+                f"Mismatch in {key} samples",
+            )
 
     def test_get_files_summary(self):
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Jackie pointed this out when looking at the portal. We were listing all 1's for number of samples in the Dataset Summary section.

This PR corrects the count by adding an order_by to allow the ORM to correctly group and count for the annotations. I also removed distinct for the samples count because the queryset should be unique against ID anyway and this should make it clearer.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

tested on the staging server but in a terminal

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A
