### PR TITLE
Show ScPCA Docs UI only when dataset state is isProcessing or isReady

### DIFF
--- a/client/src/components/DatasetHero.js
+++ b/client/src/components/DatasetHero.js
@@ -9,8 +9,7 @@ import { Loader } from 'components/Loader'
 
 export const DatasetHero = ({ dataset }) => {
   const { getDatasetState } = useDataset()
-  const { isUnprocessed, isProcessing, isReady, isExpired } =
-    getDatasetState(dataset)
+  const { isProcessing, isReady, isExpired } = getDatasetState(dataset)
 
   const [loading, setLoading] = useState(true)
 
@@ -22,7 +21,7 @@ export const DatasetHero = ({ dataset }) => {
 
   return (
     <>
-      {!isUnprocessed && (
+      {(isExpired || isProcessing || isReady) && (
         <Box
           justify="center"
           border={{ side: 'bottom', color: 'border-black', size: 'small' }}

--- a/client/src/hooks/useDataset.js
+++ b/client/src/hooks/useDataset.js
@@ -146,7 +146,6 @@ export const useDataset = () => {
   // TODO: Implementation might change
   const getDatasetState = (dataset) => {
     const {
-      started_at: startedAt,
       is_processing: isProcessing,
       is_succeeded: isSucceeded,
       is_failed: isFailed,
@@ -157,7 +156,7 @@ export const useDataset = () => {
     const processed = isSucceeded || isFailed || isTerminated
 
     return {
-      isUnprocessed: startedAt === null && (!isProcessing || !processed),
+      isUnprocessed: !isProcessing || !processed,
       isProcessing: isProcessing && !isFailed,
       isFailed,
       isTerminated,

--- a/client/src/pages/datasets/[dataset_id]/index.js
+++ b/client/src/pages/datasets/[dataset_id]/index.js
@@ -15,6 +15,8 @@ const Dataset = ({ dataset }) => {
   const { responsive } = useResponsive()
   const { getDatasetState } = useDataset()
 
+  // TODO: Add refirect if isMyDataset and check dataset ID history
+  // to display the Shared Dataset page header
   const { isUnprocessed } = getDatasetState(dataset)
 
   // Restore scroll position after component mounts


### PR DESCRIPTION
## Issue Number

Closes #1580

## Purpose/Implementation Notes

I've update `useDataset.getDatasetState` and the `DatasetHero` component to render the ScPCA Docs UI only when the dataset state is `isProcessing` or `isReady`. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
