### PR TITLE
Use useRouter in "My Dataset" and "Browse and Add Samples" buttons to prevent full page reload

### DIFF
--- a/client/src/components/DatasetEmpty.js
+++ b/client/src/components/DatasetEmpty.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import { Box, Text } from 'grommet'
+import { useRouter } from 'next/router'
 import { Button } from 'components/Button'
 import EmptyDatasetImg from '../images/empty-dataset.svg'
 
 export const DatasetEmpty = () => {
+  const { push } = useRouter()
+
   return (
     <Box align="center" gap="medium">
       <EmptyDatasetImg />
@@ -11,8 +14,8 @@ export const DatasetEmpty = () => {
       <Button
         aria-label="Browse and Add Samples"
         label="Browse and Add Samples"
-        href="/projects"
         primary
+        onClick={() => push('/projects')}
       />
     </Box>
   )

--- a/client/src/components/MyDatasetButton.js
+++ b/client/src/components/MyDatasetButton.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { Box, Text } from 'grommet'
+import { useRouter } from 'next/router'
 import { useMyDataset } from 'hooks/useMyDataset'
 import { Button } from 'components/Button'
 import styled, { css } from 'styled-components'
@@ -18,6 +19,7 @@ const YellowButton = styled(Button)`
 `
 
 export const MyDatasetButton = () => {
+  const { push } = useRouter()
   const { myDataset, getDataset } = useMyDataset()
   const { total_sample_count: count = 0 } = myDataset
 
@@ -35,7 +37,6 @@ export const MyDatasetButton = () => {
   return (
     <Box direction="row">
       <YellowButton
-        href="/download"
         label="My Dataset"
         primary
         badge={
@@ -55,6 +56,7 @@ export const MyDatasetButton = () => {
             <Text size="small-flat">{count}</Text>
           </Box>
         }
+        onClick={() => push('/download')}
       />
     </Box>
   )


### PR DESCRIPTION
## Issue Number

Closes #1581

## Purpose/Implementation Notes

I've utilized the `useRouter` hook for the `My Dataset` and `Browse and Add Samples` buttons to prevent a full page load. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
