### PR TITLE
Remove "Moved x Samples to My Dataset" banner when the user navigates away from My Dataset page 

### DIFF
--- a/client/src/components/DatasetMoveSamplesModal.js
+++ b/client/src/components/DatasetMoveSamplesModal.js
@@ -57,7 +57,7 @@ export const DatasetMoveSamplesModal = ({
   const showErrorNotification = (
     message = "We're having trouble moving samples to My Dataset. Please try again later."
   ) => {
-    showNotification(message, 'error')
+    showNotification(message, 'error', label)
     setShowing(false)
   }
 
@@ -91,7 +91,11 @@ export const DatasetMoveSamplesModal = ({
     }
 
     push(`/download`)
-    showNotification(`Moved ${sharedSampleCount} Samples to My Dataset`)
+    showNotification(
+      `Moved ${sharedSampleCount} Samples to My Dataset`,
+      'success',
+      label
+    )
     setShowing(false)
   }
 

--- a/client/src/pages/download/index.js
+++ b/client/src/pages/download/index.js
@@ -3,6 +3,7 @@ import { Box, Text } from 'grommet'
 import { useScrollRestore } from 'hooks/useScrollRestore'
 import { useMyDataset } from 'hooks/useMyDataset'
 import { useResponsive } from 'hooks/useResponsive'
+import { useNotification } from 'hooks/useNotification'
 import { formatBytes } from 'helpers/formatBytes'
 import { getReadable } from 'helpers/getReadable'
 import { DatasetEmpty } from 'components/DatasetEmpty'
@@ -28,6 +29,15 @@ const Download = () => {
 
   const [loading, setLoading] = useState(true)
   const [isFormatChanged, setIsFormatChanged] = useState(false)
+
+  const { hideNotification } = useNotification()
+  // Clean up the moved samples banner on component unmounts
+  useEffect(() => {
+    const bannerName = 'Move to My Dataset' // A moved samples banner ID
+    return () => {
+      hideNotification(bannerName)
+    }
+  }, [])
 
   // Restore scroll position after component mounts
   useEffect(() => {


### PR DESCRIPTION
## Issue Number

Closes #1594

## Purpose/Implementation Notes

I've removed the green banner "Moved x Samples to My Dataset" when the user navigates away from the **My Dataset** page  (e.g., to **Home**, **About**, or **Browse**).


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
