### PR TITLE
Fix a typo in the Download File Summary section on My Dataset page

### DIFF
--- a/api/scpca_portal/models/dataset.py
+++ b/api/scpca_portal/models/dataset.py
@@ -391,7 +391,7 @@ class Dataset(TimestampedModel):
                 "libraries": spatial_libraries,
             },
             {
-                "name": "Bulk-RNA seq samples",
+                "name": "Bulk RNA-seq samples",
                 "format": ".tsv",
                 "samples": bulk_samples,
                 "libraries": bulk_libraries,

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -565,7 +565,7 @@ class TestDataset(TestCase):
             # Single-cell multiplexed should be included here
             {"samples_count": 2, "name": "Single-nuclei multiplexed samples", "format": ".rds"},
             {"samples_count": 1, "name": "Spatial samples", "format": "Spatial format"},
-            {"samples_count": 1, "name": "Bulk-RNA seq samples", "format": ".tsv"},
+            {"samples_count": 1, "name": "Bulk RNA-seq samples", "format": ".tsv"},
         ]
 
         single_cell_files_summary = single_cell_dataset.get_files_summary()
@@ -605,7 +605,7 @@ class TestDataset(TestCase):
         expected_ann_data = [
             {"samples_count": 4, "name": "Single-cell samples", "format": ".h5ad"},
             {"samples_count": 1, "name": "Single-cell samples with CITE-seq", "format": ".h5ad"},
-            {"samples_count": 1, "name": "Bulk-RNA seq samples", "format": ".tsv"},
+            {"samples_count": 1, "name": "Bulk RNA-seq samples", "format": ".tsv"},
         ]
 
         ann_data_files_summary = ann_data_dataset.get_files_summary()


### PR DESCRIPTION
## Issue Number

Closes #1595

## Purpose/Implementation Notes

I've fixed a typo in `dataset.get_files_summary` and adjusted the corresponding test.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
