### PR TITLE
Client Side - Hide Unavailable Spatial Counts When No Spatial Data 

### DIFF
--- a/client/src/components/DatasetAddSamplesModal.js
+++ b/client/src/components/DatasetAddSamplesModal.js
@@ -171,9 +171,11 @@ export const DatasetAddSamplesModal = ({
                 <Box as="li" style={{ display: 'list-item' }}>
                   {`${singleCellSamplesToAdd} samples with single-cell modality`}
                 </Box>
-                <Box as="li" style={{ display: 'list-item' }}>
-                  {`${spatialSamplesToAdd} samples with spatial modality`}
-                </Box>
+                {project.has_spatial_data && (
+                  <Box as="li" style={{ display: 'list-item' }}>
+                    {`${spatialSamplesToAdd} samples with spatial modality`}
+                  </Box>
+                )}
               </Box>
             </Box>
             <Heading level="3" size="small" margin={{ bottom: 'medium' }}>


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1641.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR hides the display of spatial sample counts when samples are being moved to a dataset on a project that doesn't have spatial data.


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)


## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

SCPCP000006 (project with spatial data)
<img width="716" height="520" alt="image" src="https://github.com/user-attachments/assets/0ca836ee-7bc8-45a5-a0f4-5a03dd1a36b7" />

SCPCP000003 (project without spatial data)
<img width="716" height="493" alt="image" src="https://github.com/user-attachments/assets/f8b35267-b529-491a-87d1-61d7978b977e" />
