### PR TITLE
Enable moving spatial samples from dataset with one format to the active dataset with a different format

### DIFF
--- a/client/src/components/DatasetMoveSamplesModal.js
+++ b/client/src/components/DatasetMoveSamplesModal.js
@@ -34,7 +34,17 @@ export const DatasetMoveSamplesModal = ({
 
   const isMyDataset = myDataset.id
   const isFormatChanged = isMyDataset && myDataset.format !== dataset.format
-  const disableAppend = isDatasetDataEmpty || isFormatChanged
+
+  const hasSpatialSamples = Object.values(dataset.data).some(
+    (d) => d.SPATIAL.length > 0
+  )
+  const hasNoSingleCellSamples = Object.values(dataset.data).every(
+    (d) => d.SINGLE_CELL.length === 0
+  )
+  const onlyHasSpatialSamples = hasSpatialSamples && hasNoSingleCellSamples
+
+  const disableAppend =
+    isDatasetDataEmpty || (isFormatChanged && !onlyHasSpatialSamples)
 
   // Disable the append action if no data in myDataset or the format will change
   const radioOptions = [


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1644.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR enables a dataset with exclusively Spatial samples to move those samples to `MyDataset` regardless of either datasets format. This is necessary as differing formats on the datasets would previously disable the merging of exclusively Spatial samples from the old dataset to the new one, which is undesired behavior.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)


## Functional tests

Steps I took to test that this works:
- I created a dataset with AnnData format containing only Spatial samples and processed it
- I created a new dataset with SingleCellExperiment format and added some Single Cell samples
- I went to the original dataset's page, clicked the "Move to My Dataset" button, and the append radio button was no longer disabled

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes


## Screenshots

N/A
