### PR TITLE
upgrade postgres to 16.8

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -8,17 +8,17 @@ data "aws_rds_certificate" "cert" {
 }
 
 resource "aws_db_parameter_group" "postgres16_parameters" {
-  name = "scpca-portal-postgres16-parameters-${var.user}-${var.stage}"
+  name        = "scpca-portal-postgres16-parameters-${var.user}-${var.stage}"
   description = "Postgres Parameters ${var.user} ${var.stage}"
-  family = "postgres16"
+  family      = "postgres16"
 
   parameter {
-    name = "deadlock_timeout"
+    name  = "deadlock_timeout"
     value = "60000" # 60000ms = 60s
   }
 
   parameter {
-    name = "statement_timeout"
+    name  = "statement_timeout"
     value = "60000" # 60000ms = 60s
   }
 
@@ -28,25 +28,25 @@ resource "aws_db_parameter_group" "postgres16_parameters" {
 }
 
 resource "aws_db_instance" "postgres_db" {
-  identifier = "scpca-portal-${var.user}-${var.stage}"
+  identifier        = "scpca-portal-${var.user}-${var.stage}"
   allocated_storage = 100
-  storage_type = "gp2"
-  engine = "postgres"
-  engine_version = "16.3"
+  storage_type      = "gp2"
+  engine            = "postgres"
+  engine_version    = "16.8"
 
   # When doing a major version upgrade it is easier
   # to apply changes immediately to allow for subsequent deployments.
   # `allow_major_version_upgrade` and `apply_immediately`
   # should be set to false when the old parameter group is removed.
   allow_major_version_upgrade = false
-  apply_immediately = false
+  apply_immediately           = false
 
   auto_minor_version_upgrade = false
-  instance_class = var.database_instance_type
-  db_name = "scpca_portal"
-  port = "5432"
-  username = "scpcapostgresuser"
-  password = var.database_password
+  instance_class             = var.database_instance_type
+  db_name                    = "scpca_portal"
+  port                       = "5432"
+  username                   = "scpcapostgresuser"
+  password                   = var.database_password
 
   db_subnet_group_name = aws_db_subnet_group.scpca_portal.name
   parameter_group_name = aws_db_parameter_group.postgres16_parameters.name
@@ -54,14 +54,14 @@ resource "aws_db_instance" "postgres_db" {
   # TF is broken, but we do want this protection in prod.
   # Related: https://github.com/hashicorp/terraform/issues/5417
   # Only the prod's bucket prefix is empty.
-  skip_final_snapshot = var.stage == "prod" ? false : true
+  skip_final_snapshot       = var.stage == "prod" ? false : true
   final_snapshot_identifier = var.stage == "prod" ? "scpca-portal-prod-snapshot" : "none"
 
   vpc_security_group_ids = [aws_security_group.scpca_portal_db.id]
-  multi_az = true
-  publicly_accessible = true
+  multi_az               = true
+  publicly_accessible    = true
 
-  ca_cert_identifier  = data.aws_rds_certificate.cert.id
+  ca_cert_identifier = data.aws_rds_certificate.cert.id
 
-  backup_retention_period  = var.stage == "prod" ? "7" : "0"
+  backup_retention_period = var.stage == "prod" ? "7" : "0"
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Does a minor version upgrade to postgres to allow for dev deploys to go through.
Also applies default formatting with hcl language server which should be the standard moving forward.

Tested with fresh dev stack but need to see if there is any issue with deploy here and adjust next.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
