### PR TITLE
set domain based on stage, prevent destroy

### DIFF
--- a/infrastructure/api.tf
+++ b/infrastructure/api.tf
@@ -11,10 +11,10 @@ data "local_file" "api_crontab_file" {
 
 data "aws_ami" "ubuntu" {
   most_recent = true
-  owners = ["099720109477"]
+  owners      = ["099720109477"]
 
   filter {
-    name   = "name"
+    name = "name"
     # This is a HVM, EBS backed SSD Ubuntu LTS AMI
     values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22*amd64-server*"]
   }
@@ -27,13 +27,13 @@ data "aws_ami" "ubuntu" {
 }
 
 resource "aws_instance" "api_server_1" {
-  ami = data.aws_ami.ubuntu.id
-  instance_type = var.api_instance_type
-  availability_zone = "${var.region}a"
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.api_instance_type
+  availability_zone      = "${var.region}a"
   vpc_security_group_ids = [aws_security_group.scpca_portal_api.id]
-  iam_instance_profile = aws_iam_instance_profile.scpca_portal_instance_profile.name
-  subnet_id = aws_subnet.scpca_portal_1a.id
-  key_name = aws_key_pair.scpca_portal.key_name
+  iam_instance_profile   = aws_iam_instance_profile.scpca_portal_instance_profile.name
+  subnet_id              = aws_subnet.scpca_portal_1a.id
+  key_name               = aws_key_pair.scpca_portal.key_name
   depends_on = [
     aws_db_instance.postgres_db,
     aws_security_group_rule.scpca_portal_api_http,
@@ -45,55 +45,55 @@ resource "aws_instance" "api_server_1" {
   user_data = templatefile(
     "api-configuration/api-server-instance-user-data.tpl.sh",
     {
-      nginx_config = data.local_file.api_nginx_config.content
-      crontab_file = data.local_file.api_crontab_file.content
+      nginx_config             = data.local_file.api_nginx_config.content
+      crontab_file             = data.local_file.api_crontab_file.content
       scpca_portal_cert_bucket = aws_s3_bucket.scpca_portal_cert_bucket.id
       api_environment = templatefile(
         "api-configuration/environment.tpl",
         {
-          django_secret_key = var.django_secret_key
-          database_host = aws_db_instance.postgres_db.address
-          database_port = aws_db_instance.postgres_db.port
-          database_user = aws_db_instance.postgres_db.username
-          database_name = aws_db_instance.postgres_db.db_name
-          database_password = var.database_password
-          aws_batch_fargate_job_queue_name = module.batch.job_queue_name_fargate
+          django_secret_key                     = var.django_secret_key
+          database_host                         = aws_db_instance.postgres_db.address
+          database_port                         = aws_db_instance.postgres_db.port
+          database_user                         = aws_db_instance.postgres_db.username
+          database_name                         = aws_db_instance.postgres_db.db_name
+          database_password                     = var.database_password
+          aws_batch_fargate_job_queue_name      = module.batch.job_queue_name_fargate
           aws_batch_fargate_job_definition_name = module.batch.job_definition_name_fargate
-          aws_batch_ec2_job_queue_name = module.batch.job_queue_name_ec2
-          aws_batch_ec2_job_definition_name = module.batch.job_definition_name_ec2
-          aws_region  = var.region
-          aws_s3_bucket_name = aws_s3_bucket.scpca_portal_bucket.id
-          aws_ses_domain = var.ses_domain
-          sentry_dsn = var.sentry_dsn
-          sentry_env = var.sentry_env
-          slack_ccdl_test_channel_email = var.slack_ccdl_test_channel_email
-          enable_feature_preview = var.enable_feature_preview
-        })
+          aws_batch_ec2_job_queue_name          = module.batch.job_queue_name_ec2
+          aws_batch_ec2_job_definition_name     = module.batch.job_definition_name_ec2
+          aws_region                            = var.region
+          aws_s3_bucket_name                    = aws_s3_bucket.scpca_portal_bucket.id
+          aws_ses_domain                        = local.ses_domain
+          sentry_dsn                            = var.sentry_dsn
+          sentry_env                            = var.sentry_env
+          slack_ccdl_test_channel_email         = var.slack_ccdl_test_channel_email
+          enable_feature_preview                = var.enable_feature_preview
+      })
       start_api_with_migrations = templatefile(
         "api-configuration/start_api_with_migrations.tpl.sh",
         {
-          region = var.region
+          region            = var.region
           dockerhub_account = var.dockerhub_account
-          log_group = aws_cloudwatch_log_group.scpca_portal_log_group.name
-          log_stream = aws_cloudwatch_log_stream.log_stream_api.name
-        })
+          log_group         = aws_cloudwatch_log_group.scpca_portal_log_group.name
+          log_stream        = aws_cloudwatch_log_stream.log_stream_api.name
+      })
       run_command_script = templatefile(
         "api-configuration/run_command.tpl.sh",
         {
           dockerhub_account = var.dockerhub_account
-        })
-      user = var.user
-      stage = var.stage
+      })
+      user   = var.user
+      stage  = var.stage
       region = var.region
 
-      log_group = aws_cloudwatch_log_group.scpca_portal_log_group.name
-      nginx_access_log_stream = aws_cloudwatch_log_stream.log_stream_api_nginx_access.name
-      nginx_error_log_stream = aws_cloudwatch_log_stream.log_stream_api_nginx_error.name
+      log_group                  = aws_cloudwatch_log_group.scpca_portal_log_group.name
+      nginx_access_log_stream    = aws_cloudwatch_log_stream.log_stream_api_nginx_access.name
+      nginx_error_log_stream     = aws_cloudwatch_log_stream.log_stream_api_nginx_error.name
       sync_batch_jobs_log_stream = aws_cloudwatch_log_stream.log_stream_api_sync_batch_jobs.name
-      submit_pending_log_stream = aws_cloudwatch_log_stream.log_stream_api_submit_pending.name
-    })
+      submit_pending_log_stream  = aws_cloudwatch_log_stream.log_stream_api_submit_pending.name
+  })
 
-  tags =  merge(
+  tags = merge(
     var.default_tags,
     {
       Name = "ScPCA Portal API ${var.user}-${var.stage}"
@@ -104,7 +104,7 @@ resource "aws_instance" "api_server_1" {
   root_block_device {
     volume_type = "gp3"
     volume_size = 1400
-    tags =  merge(
+    tags = merge(
       var.default_tags,
       {
         Name = "scpca-block-${var.user}-${var.stage}"

--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -2,32 +2,32 @@ module "batch" {
   source = "./batch"
 
   # networking
-  scpca_portal_vpc = aws_vpc.scpca_portal_vpc
+  scpca_portal_vpc       = aws_vpc.scpca_portal_vpc
   scpca_portal_subnet_1a = aws_subnet.scpca_portal_1a
 
   # job_definition envars
-  dockerhub_account = var.dockerhub_account
-  region = var.region
+  dockerhub_account   = var.dockerhub_account
+  region              = var.region
   scpca_portal_bucket = aws_s3_bucket.scpca_portal_bucket
-  postgres_db = aws_db_instance.postgres_db
+  postgres_db         = aws_db_instance.postgres_db
 
   # job_definition secret envars
   django_secret_key = aws_secretsmanager_secret.django_secret_key
   database_password = aws_secretsmanager_secret.database_password
-  sentry_dsn = aws_secretsmanager_secret.sentry_dsn
+  sentry_dsn        = aws_secretsmanager_secret.sentry_dsn
 
   # security
   scpca_portal_db_security_group = aws_security_group.scpca_portal_db
 
   # ses
-  ses_domain = var.ses_domain
+  ses_domain = local.ses_domain
 
   # general configuration
   aws_caller_identity_current = data.aws_caller_identity.current
-  user = var.user
-  stage = var.stage
+  user                        = var.user
+  stage                       = var.stage
   batch_tags = {
-    module = "batch",
+    module   = "batch",
     revision = "first - 16 vCPU compute environment with 1 vCPU per job"
   }
 }

--- a/infrastructure/batch/roles.tf
+++ b/infrastructure/batch/roles.tf
@@ -169,7 +169,7 @@ resource "aws_iam_role_policy_attachment" "batch_ses_send_policy" {
 }
 
 resource "aws_iam_role" "batch_instance" {
-  name = "scpca-portal-batch-instance-${var.user}-${var.stage}"
+  name               = "scpca-portal-batch-instance-${var.user}-${var.stage}"
   assume_role_policy = <<EOF
 {
   "Version": "2008-10-17",
@@ -193,6 +193,6 @@ resource "aws_iam_instance_profile" "batch_instance_profile" {
 }
 
 resource "aws_iam_role_policy_attachment" "batch_instance_ecs" {
-  role = aws_iam_role.batch_instance.name
+  role       = aws_iam_role.batch_instance.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -197,7 +197,7 @@ resource "aws_iam_policy" "api_ses_send_email" {
         "ses:SendEmail",
         "ses:SendRawEmail"
       ],
-      "Resource": "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/${var.ses_domain}"
+      "Resource": "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/${local.ses_domain}"
     }
   ]
 }

--- a/infrastructure/ses.tf
+++ b/infrastructure/ses.tf
@@ -1,7 +1,29 @@
+# These do not get destroyed on tear down.
+# They get destroyed when the DNS records are removed.
+# The DNS records are available in the console.
+
 resource "aws_ses_domain_identity" "scpca_portal" {
-  domain = var.ses_domain
+  domain = local.ses_domain
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_ses_domain_dkim" "scpca_portal" {
   domain = aws_ses_domain_identity.scpca_portal.domain
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ses_domain_mail_from" "scpca_portal" {
+  domain                 = aws_ses_domain_identity.scpca_portal.domain
+  mail_from_domain       = "mail.${local.ses_domain}"
+  behavior_on_mx_failure = "UseDefaultValue"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -5,11 +5,11 @@ data "aws_caller_identity" "current" {}
 
 variable "default_tags" {
   default = {
-    team = "engineering"
+    team    = "engineering"
     project = "ScPCA Portal"
   }
   description = "Default resource tags"
-  type = map(string)
+  type        = map(string)
 }
 
 variable "region" {
@@ -22,6 +22,11 @@ variable "user" {
 
 variable "stage" {
   default = "dev"
+
+  validation {
+    condition     = contains(["prod", "staging", "dev"], var.stage)
+    error_message = "The environment must be 'prod', 'staging', or 'dev'."
+  }
 }
 
 variable "dockerhub_account" {
@@ -68,10 +73,6 @@ variable "ssh_public_key" {
   default = "MISSING_VALUE"
 }
 
-variable "ses_domain" {
-  default = "staging.scpca.alexslemonade.org"
-}
-
 variable "slack_ccdl_test_channel_email" {
   default = "testing@example.com"
 }
@@ -86,18 +87,30 @@ variable "cellbrowser_security_token" {
 
 variable "cellbrowser_uploaders" {
   default = []
-  type = list(string)
+  type    = list(string)
+}
+
+locals {
+
+  stage_domains = {
+    prod    = "scpca.alexslemonade.org"
+    staging = "staging.scpca.alexslemonade.org"
+    dev     = "dev.scpca.alexslemonade.org"
+  }
+
+  ses_domain = local.stage_domains[var.stage]
+
 }
 
 output "environment_variables" {
   value = [
-    {name = "DATABASE_NAME"
-      value = aws_db_instance.postgres_db.db_name},
-    {name = "DATABASE_HOST"
-      value = aws_db_instance.postgres_db.address},
-    {name = "DATABASE_USER"
-      value = aws_db_instance.postgres_db.username},
-    {name = "DATABASE_PORT"
-      value = aws_db_instance.postgres_db.port}
+    { name = "DATABASE_NAME"
+    value = aws_db_instance.postgres_db.db_name },
+    { name = "DATABASE_HOST"
+    value = aws_db_instance.postgres_db.address },
+    { name = "DATABASE_USER"
+    value = aws_db_instance.postgres_db.username },
+    { name = "DATABASE_PORT"
+    value = aws_db_instance.postgres_db.port }
   ]
 }


### PR DESCRIPTION
## Issue Number

Closes #1258 

## Purpose/Implementation Notes

- Moves ses_domain to be a local.ses_domain which is determined based on stage
- Restricts stage to be one of dev, staging, prod in terraform
- add lifecycle rules to all ses identities to prevent becoming out of sync with DNS records
- add MAIL FROM to wrap awsses in mail.<domain> so dev would have metadata to be from mail.dev.scpca.alexslemonade.org but the sender would still be no-reply@dev.alexslemonade.org (remove dev for production example)
- also everything i touched, i reformatted based on hcl lang server

Merging this will allow us to create the records for the staging domain. After which we should merge into production to set this up ahead of cart launch.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)


## Functional tests

Created dev stack, will test tearing down after account is moved out of sandbox.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
