### PR TITLE
fix prod state managing staging domain identity 

### DIFF
--- a/infrastructure/ses.tf
+++ b/infrastructure/ses.tf
@@ -5,17 +5,17 @@
 resource "aws_ses_domain_identity" "scpca_portal" {
   domain = local.ses_domain
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 }
 
 resource "aws_ses_domain_dkim" "scpca_portal" {
   domain = aws_ses_domain_identity.scpca_portal.domain
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 }
 
 resource "aws_ses_domain_mail_from" "scpca_portal" {
@@ -23,7 +23,7 @@ resource "aws_ses_domain_mail_from" "scpca_portal" {
   mail_from_domain       = "mail.${local.ses_domain}"
   behavior_on_mx_failure = "UseDefaultValue"
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Because staging and prod were using the same domain before we can have lifecycle prevent destroy we need to go up the pipeline and have prod and staging not try to manage the same resource. After this is merged into prod we can add it back and we should be good.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
