### PR TITLE
Move the totals out of the dataset summary table and put them under the "Dataset Summary" title

### DIFF
--- a/client/src/components/DatasetSummary.js
+++ b/client/src/components/DatasetSummary.js
@@ -11,7 +11,7 @@ export const DatasetSummary = ({ dataset }) => {
   const [totalProject, setTotalProject] = useState(0)
   const sampleTotalText = `${totalSample} Sample${totalSample > 1 ? 's' : ''}`
   const projectTotalText = `${totalProject} Project${
-    totalProject > 0 ? 's' : ''
+    totalProject > 1 ? 's' : ''
   }`
 
   const diagnosesSummary = dataset.diagnoses_summary


### PR DESCRIPTION
## Issue Number

Closes  #1666

## Purpose/Implementation Notes

I've rendered the total sample and project counts under the `"Dataset Summary"` heading in the **Dataset Summary** section.

@dvenprasad , see the latest UI [here](https://scpca-portal-jq6eabczx-ccdl.vercel.app/). Thank you!

Changes include:
Using the `useMyDataset` hook and new local states for counts, display the total sample and project text under the section heading in the `DatasetSummary` component.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

e.g. ) 

<img width="1222" height="351" alt="counts-2" src="https://github.com/user-attachments/assets/321d84c7-5ff4-4b47-8431-6bce17d77543" />

e.g. )

<img width="1232" height="354" alt="counts" src="https://github.com/user-attachments/assets/8c711c5b-2b62-496c-ac9c-0afad5a933b5" />



