### PR TITLE
fix moving existing dataset to empty dataset

### DIFF
--- a/client/src/components/DatasetMoveSamplesModal.js
+++ b/client/src/components/DatasetMoveSamplesModal.js
@@ -93,9 +93,12 @@ export const DatasetMoveSamplesModal = ({
   }
 
   const handleClick = async () => {
+    // When no data in My Dataset, move and redirect without opening modal
     if (!myDataset.data || isDatasetDataEmpty) {
+      setLoading(true)
       await request(structuredClone(dataset.data))
       redirect()
+      setLoading(false)
     } else {
       setShowing(true)
     }
@@ -103,28 +106,28 @@ export const DatasetMoveSamplesModal = ({
 
   const handleMoveToMyDataset = async () => {
     setLoading(true)
+    // Merge or replace dataset data
     const updatedData =
       action === 'append'
         ? await getMergeDatasetData(dataset)
         : structuredClone(dataset.data)
-    setLoading(false)
 
     // API failure while merging data
     if (!updatedData) {
       showErrorNotification()
+      setLoading(false)
       return
     }
 
     // Clear the data in My Dataset if the format has changed
     if (isFormatChanged) await clearDataset()
 
-    setLoading(true)
     const updatedDataset = await request(updatedData)
-    setLoading(false)
 
     // API failure while updating the dataset
     if (!updatedDataset) {
       showErrorNotification()
+      setLoading(false)
       return
     }
 
@@ -143,6 +146,7 @@ export const DatasetMoveSamplesModal = ({
         flex="grow"
         label={label}
         disabled={disabled}
+        loading={loading}
         onClick={handleClick}
       />
       <Modal title={title} showing={showing} setShowing={setShowing}>
@@ -190,8 +194,8 @@ export const DatasetMoveSamplesModal = ({
               primary
               aria-label="Move Samples"
               label="Move Samples"
-              onClick={handleMoveToMyDataset}
               loading={loading}
+              onClick={handleMoveToMyDataset}
             />
           </Box>
         </ModalBody>


### PR DESCRIPTION
## Issue Number

Closes #1634

## Purpose/Implementation Notes

@sjspielman, review the updated UI [here](https://scpca-portal-eikjqbt01-ccdl.vercel.app/) - the bug should no longer be present. Thank you!

**Steps to test:**
1. Go to https://scpca-portal-85jodk8t6-ccdl.vercel.app/datasets/1f82c989-acd0-4294-afcf-c0ded5386e81 and click the `Move to My Dataset` button
2. The modal should display a sample count of 0 and the append samples option should be disabled (when My Dataset is undefined)
3. Move the dataset to My Dataset 
4. Go to the My Dataset page and empty the data
5. Return to https://scpca-portal-85jodk8t6-ccdl.vercel.app/datasets/1f82c989-acd0-4294-afcf-c0ded5386e81 and click the `Move to My Dataset` button
6. The modal should display a sample count of 0 and the append samples option should be disabled (when My Dataset data is empty)

(Tagging @dvenprasad for feedback if any)

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

<img width="450" alt="modal-fixed" src="https://github.com/user-attachments/assets/33830967-de43-4775-bb29-7b6fdb412397" />
