### PR TITLE
Fix Portal Wide Files Initial Download Bug

### DIFF
--- a/client/src/contexts/CCDLDatasetDownloadModalContext.js
+++ b/client/src/contexts/CCDLDatasetDownloadModalContext.js
@@ -46,9 +46,6 @@ export const CCDLDatasetDownloadModalContextProvider = ({
       setIncludesMerged(null)
       setExcludeMultiplexed(null)
 
-      setDownloadDataset(false)
-      setDownloadableDataset(null)
-
       setIsMergedObjectsAvailable(null)
       setIsMultiplexedAvailable(null)
 
@@ -72,6 +69,10 @@ export const CCDLDatasetDownloadModalContextProvider = ({
         datasets.some((dataset) => dataset.includes_files_multiplexed)
       )
     }
+
+    // reset download state vars on datasets change
+    setDownloadDataset(false)
+    setDownloadableDataset(null)
   }, [datasets])
 
   // on modality change, set format and merged available defaults


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1678.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

After careful debugging, it was determined that the portal wide initial file bug was a result of the `downloadDataset` state variable being set a few render cycles before the `selectedDataset` was being set. This resulted in the `asyncFetch` function attempting to request a download link from the API while the selectedDataset was undefined, yielding an undesirable API response. This PR resolves this issue by coupling the setting of the `downloadDataset` state variable with `selectedDataset` for portal wide files (where `datasets.length === 1`).

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes

## Screenshots

N/A