### PR TITLE
Verify README content

### DIFF
--- a/api/scpca_portal/readme_file.py
+++ b/api/scpca_portal/readme_file.py
@@ -65,6 +65,19 @@ PORTAL_CCDL_DATASET_LINKS = {
 # used in get_content_table_rows and in 2_contents.md
 ContentRow = namedtuple("ContentRow", ["project", "modality", "format", "docs"])
 
+# used to map the human-readable values to the corresponding format and modality tokens
+FORMAT_STRING = {
+    "SINGLE_CELL_EXPERIMENT": FileFormats.SINGLE_CELL_EXPERIMENT.label,
+    "ANN_DATA": FileFormats.ANN_DATA.label,
+    "BULK_FORMAT": "Bulk Format",
+    "SPATIAL_SPACERANGER": FileFormats.SPATIAL_SPACERANGER.label,
+}
+MODALITY_STRING = {
+    Modalities.BULK_RNA_SEQ: Modalities.BULK_RNA_SEQ.label,
+    Modalities.SINGLE_CELL: Modalities.SINGLE_CELL.label,
+    Modalities.SPATIAL: Modalities.SPATIAL.label,
+}
+
 
 def add_ann_data_content_rows(content_rows: set, dataset) -> set:
     """
@@ -87,7 +100,14 @@ def add_ann_data_content_rows(content_rows: set, dataset) -> set:
             if project.has_cite_seq_data:
                 docs_link = ANN_DATA_MERGED_WITH_CITE_SEQ_LINK
 
-        content_rows.add(ContentRow(project, Modalities.SINGLE_CELL, dataset.format, docs_link))
+        content_rows.add(
+            ContentRow(
+                project,
+                MODALITY_STRING[Modalities.SINGLE_CELL],
+                FORMAT_STRING[dataset.format],
+                docs_link,
+            )
+        )
 
     return content_rows
 
@@ -113,7 +133,14 @@ def add_single_cell_experiment_content_rows(content_rows: set, dataset) -> set:
         ):
             docs_link = SINGLE_CELL_EXPERIMENT_MULTIPLEXED_LINK
 
-        content_rows.add(ContentRow(project, Modalities.SINGLE_CELL, dataset.format, docs_link))
+        content_rows.add(
+            ContentRow(
+                project,
+                MODALITY_STRING[Modalities.SINGLE_CELL],
+                FORMAT_STRING[dataset.format],
+                docs_link,
+            )
+        )
 
     return content_rows
 
@@ -140,8 +167,8 @@ def get_content_table_rows(dataset) -> list[ContentRow]:
         content_rows.add(
             ContentRow(
                 project,
-                Modalities.SPATIAL,
-                FileFormats.SPATIAL_SPACERANGER,
+                MODALITY_STRING[Modalities.SPATIAL],
+                FORMAT_STRING[FileFormats.SPATIAL_SPACERANGER],
                 SPATIAL_SPATIAL_SPACERANGER_LINK,
             )
         )
@@ -149,7 +176,14 @@ def get_content_table_rows(dataset) -> list[ContentRow]:
     # BULK get their own row when data is present
     if dataset.format != DatasetFormats.METADATA:
         for project in dataset.bulk_single_cell_projects:
-            content_rows.add(ContentRow(project, Modalities.BULK_RNA_SEQ, "BULK_FORMAT", BULK_LINK))
+            content_rows.add(
+                ContentRow(
+                    project,
+                    MODALITY_STRING[Modalities.BULK_RNA_SEQ],
+                    FORMAT_STRING["BULK_FORMAT"],
+                    BULK_LINK,
+                )
+            )
 
     return sorted(
         content_rows,

--- a/api/scpca_portal/test/models/test_dataset.py
+++ b/api/scpca_portal/test/models/test_dataset.py
@@ -336,7 +336,7 @@ class TestDataset(TestCase):
             format=DatasetFormats.SINGLE_CELL_EXPERIMENT,
             ccdl_name=CCDLDatasetNames.SINGLE_CELL_SINGLE_CELL_EXPERIMENT,
         )
-        expected_readme_hash = "30945e57ac2478eb6a1c7704344b3c76"
+        expected_readme_hash = "cb0d4d6c2c8027276de69b78a5ac0629"
         self.assertEqual(dataset.current_readme_hash, expected_readme_hash)
 
     def test_get_metadata_file_contents(self):


### PR DESCRIPTION
## Issue Number

Closes #1676

## Purpose/Implementation Notes

I've ensured that the human-readable values are correctly assigned to the format and modality tokens in the Contents section of the downloadable file's `README.md`. 

Additionally, I've verified locally that the correct project and URL values are rendered in `README.md` for various user dataset types (see the **Functional tests** section for more details).

Changes include:
- Added the mapping dictionaries, `FORMAT_STRING` and `MODALITY_STRING`, in `readme_file`
- Used the mapping dictionaries to assign the human-readable strings to the corresponding format and modality fields in the table

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

#### Locally tested My Dataset Types

- Adjusted the `expected_readme_hash` value in `test_dataset`

### Includes Bulk RNA-seq
- **Format:** `SINGLE_CELL_EXPERIMENT` 
- **Project(s)**: SCPCP000001
- **Data:** Contains single-cell samples, includes bulk data

```md
| Project ID | Modality | Format | Link to Documentation |
|:----------|:----------|:-------|:------------------------|
| [SCPCP000001](https://scpca.alexslemonade.org/projects/SCPCP000001) | Bulk RNA-seq | Bulk Format | [Documentation Link](https://scpca.readthedocs.io/en/development/processing_information.html#bulk-rna-samples) |
| [SCPCP000001](https://scpca.alexslemonade.org/projects/SCPCP000001) | Single-cell | Single-cell experiment | [Documentation Link](https://scpca.readthedocs.io/en/development/sce_file_contents.html#components-of-a-singlecellexperiment-object) |
```

### Includes Merged Objects
- **Format:** `SINGLE_CELL_EXPERIMENT` 
- **Project(s):** SCPCP000001
- **Data:** Contains single-cell samples as 1 merged object

```md
| Project ID  | Modality | Format | Link to Documentation  |
|:-----------|:---------|:--------|:------------------------|
| [SCPCP000001](https://scpca.alexslemonade.org/projects/SCPCP000001) | Single-cell | Single-cell experiment | [Documentation Link](https://scpca.readthedocs.io/en/development/merged_objects.html#components-of-a-singlecellexperiment-merged-object) |
```

- **Format:** `ANN_DATA` 
- **Project(s):** SCPCP000001
- **Data:** Contains single-cell samples as 1 merged object

```md
| Project ID | Modality | Format | Link to Documentation |
|:----------|:---------|:--------|:------------------------|
| [SCPCP000001](https://scpca.alexslemonade.org/projects/SCPCP000001) | Single-cell | AnnData | [Documentation Link](https://scpca.readthedocs.io/en/development/merged_objects.html#components-of-an-anndata-merged-object) |
```

### Includes Multiplexed Samples, Bulk RNA-seq, and Both Modalities
- **Format:** `SINGLE_CELL_EXPERIMENT` 
- **Project(s):** SCPCP000006, SCPCP000009
- **Data:** SCPCP000006 contains both single-cell and spatial modalities, SCPCP000009 includes both non-multiplexed and multiplexed samples and bulk data

```md
| Project ID | Modality | Format | Link to Documentation |
|:----------|:---------|:--------|:------------------------|
| [SCPCP000006](https://scpca.alexslemonade.org/projects/SCPCP000006) | Single-cell | Single-cell experiment| [Documentation Link](https://scpca.readthedocs.io/en/development/sce_file_contents.html#components-of-a-singlecellexperiment-object) |
| [SCPCP000006](https://scpca.alexslemonade.org/projects/SCPCP000006) | Spatial Data | Spatial Spaceranger   | [Documentation Link](https://scpca.readthedocs.io/en/development/processing_information.html#spatial-transcriptomics) |
| [SCPCP000009](https://scpca.alexslemonade.org/projects/SCPCP000009) | Bulk RNA-seq | Bulk Format | [Documentation Link](https://scpca.readthedocs.io/en/development/processing_information.html#bulk-rna-samples) |
| [SCPCP000009](https://scpca.alexslemonade.org/projects/SCPCP000009) | Single-cell | Single-cell experiment| [Documentation Link](https://scpca.readthedocs.io/en/development/sce_file_contents.html#additional-singlecellexperiment-components-for-multiplexed-libraries) |
```

### SCPCP000009 with AnnData Format 
- F**ormat:** `ANN_DATA` 
- **Project(s):** SCPCP000001, SCPCP000006, SCPCP000009
- **Data:** All projects include bulk data, SCPCP000006 contains both single-cell and spatial modalities

(*Multiplexed samples are not supported in the AnnData format.)

```md
| Project ID | Modality | Format | Link to Documentation |
|:----------|:---------|:--------|:------------------------|
| [SCPCP000001](https://scpca.alexslemonade.org/projects/SCPCP000001) | Bulk RNA-seq | Bulk Format | [Documentation Link](https://scpca.readthedocs.io/en/development/processing_information.html#bulk-rna-samples) |
| [SCPCP000001](https://scpca.alexslemonade.org/projects/SCPCP000001) | Single-cell  | AnnData  | [Documentation Link](https://scpca.readthedocs.io/en/development/sce_file_contents.html#components-of-an-anndata-object) |
| [SCPCP000006](https://scpca.alexslemonade.org/projects/SCPCP000006) | Bulk RNA-seq | Bulk Format | [Documentation Link](https://scpca.readthedocs.io/en/development/processing_information.html#bulk-rna-samples) |
| [SCPCP000006](https://scpca.alexslemonade.org/projects/SCPCP000006) | Single-cell  | AnnData  | [Documentation Link](https://scpca.readthedocs.io/en/development/sce_file_contents.html#components-of-an-anndata-object) |
| [SCPCP000006](https://scpca.alexslemonade.org/projects/SCPCP000006) | Spatial Data | Spatial Spaceranger | [Documentation Link](https://scpca.readthedocs.io/en/development/processing_information.html#spatial-transcriptomics) |
| [SCPCP000009](https://scpca.alexslemonade.org/projects/SCPCP000009) | Bulk RNA-seq | Bulk Format | [Documentation Link](https://scpca.readthedocs.io/en/development/processing_information.html#bulk-rna-samples) |
| [SCPCP000009](https://scpca.alexslemonade.org/projects/SCPCP000009) | Single-cell  | AnnData  | [Documentation Link](https://scpca.readthedocs.io/en/development/sce_file_contents.html#components-of-an-anndata-object) |
```

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
