### PR TITLE
Disable the include bulk checkbox in DatasetSamplesProjectOptions if already included in My Dataset

### DIFF
--- a/client/src/components/DatasetSamplesProjectOptions.js
+++ b/client/src/components/DatasetSamplesProjectOptions.js
@@ -25,7 +25,7 @@ export const DatasetSamplesProjectOptions = ({
           checked={includeBulk}
           disabled={
             !project.has_bulk_rna_seq ||
-            myDataset.data?.[project.scpca_id]?.includes_bulk
+            !!myDataset.data?.[project.scpca_id]?.includes_bulk
           }
           onChange={({ target: { checked } }) => onIncludeBulkChange(checked)}
         />


### PR DESCRIPTION
## Issue Number

Closes #1685

## Purpose/Implementation Notes

Changes include:

- Disabled the include bulk option in the `DatasetSamplesProjectOptions` component if the project data is already set to include bulk data in `myDataset`, to prevent users from making changes to My Dataset's `data` via `DatasetAddSamplesModal`

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
