### PR TITLE
Fix mismatch id prop hydration error

### DIFF
--- a/client/.babelrc.js
+++ b/client/.babelrc.js
@@ -23,6 +23,10 @@ module.exports = {
             {
               name: 'removeAttrs',
               params: { attrs: '(data-name)' }
+            },
+            {
+              name: 'cleanupIDs',
+              active: false
             }
           ]
         }

--- a/client/src/components/Badge.js
+++ b/client/src/components/Badge.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Box, Paragraph } from 'grommet'
 import Kit from '../images/badges/kit.svg'
 import Modality from '../images/badges/modality.svg'
@@ -14,21 +14,10 @@ const badges = {
 
 export const Badge = ({ badge, label, className, children }) => {
   const BadgeSVG = badges[badge]
-  const [id, setId] = useState('')
-
-  useEffect(() => {
-    setId(`${Math.random().toString(36).substr(2, 9)}-${Date.now()}`)
-  }, [])
-
   return (
     <Box direction="row" align="center" className={className}>
       <Box width="24px">
-        <BadgeSVG
-          id={id}
-          role="presentation"
-          aria-hidden="true"
-          focusable="false"
-        />
+        <BadgeSVG role="presentation" aria-hidden="true" focusable="false" />
       </Box>
       <Paragraph margin={{ left: 'small' }}>{label}</Paragraph>
       {children}


### PR DESCRIPTION
## Issue Number

N/A

Target branch: `feature/dataset-integration`

(This PR currently targets the dataset feature branch since the error is present. However, it does not affect QA testing and can be merged after the Dataset launch.)

## Purpose/Implementation Notes

This PR addresses the following console error message generated on `localhost` for a better development experience:

> Prop `id` did not match. Server: "8iqic292wa" Client: "gpkvfdwmha"
> circle
> defs
> svg
> Samples
> ...
> See more info here: https://nextjs.org/docs/messages/react-hydration-error

**Change includes:**
- Replaced the `cleanupIDs` plugin with run-time generated dynamical IDs (using `useState` and `useEffect`) to prevent the hydration error.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

<img width="606" height="304" alt="Screenshot 2025-12-17 at 2 14 02 PM" src="https://github.com/user-attachments/assets/0e0734aa-5de1-4fe3-8320-1ca23585debb" />

---

After the change: 

e.g., For the "Guidelines" SVG, the `id` value is unique for each instance of the SVG:

<img width="587" height="139" alt="Screenshot 2025-12-18 at 10 58 55 AM" src="https://github.com/user-attachments/assets/23a0a06a-9873-4bc5-9191-8e0ea9d745ef" />


<img width="589" height="157" alt="Screenshot 2025-12-18 at 10 58 35 AM" src="https://github.com/user-attachments/assets/6c4f734e-1f6c-4a42-b216-4ea656e2fc4f" />


