### PR TITLE
Prevent Users From Accessing myDataset on Dataset Page

### DIFF
--- a/client/src/pages/datasets/[dataset_id]/index.js
+++ b/client/src/pages/datasets/[dataset_id]/index.js
@@ -33,7 +33,7 @@ const Dataset = ({ dataset }) => {
     if (dataset.id === myDataset.id) {
       push(`/download`)
     }
-  }, [])
+  }, [dataset, myDataset])
 
   return (
     <>


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1674.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR adds a safeguard so that users cannot access the currently active dataset on the `/datasets` url.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

How to test:
1. Go to the browse page.
2. Add a project to your cart (any project or group of samples is fine)
3. Open up local storage, and grab the dataset id from the `dataset` object
4. Append `/dataset/<dataset_id>`  to the home url and hit enter
5. Check that the browser redirects to the `/download` page

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes


## Screenshots

N/A