### PR TITLE
Add Loader to "Save & Go Back" Button 

### DIFF
--- a/client/src/components/ProjectSamplesTableOptionsHeader.js
+++ b/client/src/components/ProjectSamplesTableOptionsHeader.js
@@ -71,7 +71,9 @@ export const ProjectSamplesTableOptionsHeader = ({
     setShowChangeMergedProjectModal(false)
   }
 
+  const [saving, setSaving] = useState(false)
   const handleSaveAndGoBack = async () => {
+    setSaving(true)
     const newSamplesToAdd = {
       ...selectedSamples,
       ...(includeMerge && { SINGLE_CELL: 'MERGED' })
@@ -88,6 +90,7 @@ export const ProjectSamplesTableOptionsHeader = ({
     } else {
       // TODO: Error handling
     }
+    setSaving(false)
   }
 
   // Set up prevSelectedCount on initial load
@@ -132,6 +135,7 @@ export const ProjectSamplesTableOptionsHeader = ({
           <Button
             primary
             label="Save & Go Back"
+            loading={saving}
             onClick={handleSaveAndGoBack}
           />
         )}


### PR DESCRIPTION
## Issue Number

Closes #1691

## Purpose/Implementation Notes

We've added a `loading` state to the "Save & Go Back" button during the API call for saving the user dataset.

@dvenprasad, we made a small change to the UI. See the latest UI [here](https://scpca-portal-g31ea4c6n-ccdl.vercel.app/). Thank you! 

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A