### PR TITLE
Retain original Button width during loading state

### DIFF
--- a/client/src/components/Button.js
+++ b/client/src/components/Button.js
@@ -49,9 +49,8 @@ export const Button = ({
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
       label={<ButtonLabel label={label} loading={loading} />}
-      onClick={asyncOnClick}
       disabled={disabled}
-      loading={loading}
+      onClick={asyncOnClick}
     />
   )
 }

--- a/client/src/theme/button.js
+++ b/client/src/theme/button.js
@@ -47,11 +47,13 @@ export default {
     background: { color: 'brand' },
     disabled: undefined
   },
-  extend: ({ danger, plain, disabled, loading, theme }) => `
+  extend: ({ danger, plain, disabled, theme }) => `
     position: relative;
     white-space: nowrap;
+    ${disabled ? 'cursor: not-allowed;' : ''}
     ${
       danger &&
+      !disabled &&
       `
       border: ${theme.global.colors.error} 1px solid;
       color: ${theme.global.colors.error};
@@ -61,20 +63,9 @@ export default {
       }
     `
     }
-    ${disabled ? 'cursor: not-allowed;' : ''}
     ${plain && disabled ? 'opacity: 0.7;' : ''}
     &:active:not([disabled]) {
       box-shadow: 0 3px 4px 0 rgba(0,0,0,0.5);
-    }
-    ${
-      loading &&
-      `
-      background: ${theme.global.colors['black-tint-90']};
-      border: ${theme.global.colors['black-tint-90']} 1px solid;
-      &:hover {
-        background: ${theme.global.colors['black-tint-90']};
-      }
-      `
     }
   `
 }


### PR DESCRIPTION
## Issue Number

Closes #1697

## Purpose/Implementation Notes

I've added the styled components for the `loading` state of the `Button` component and retained the original button width during loading.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
