### PR TITLE
try to determine format of ssh key

### DIFF
--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -147,7 +147,6 @@ def create_ssh_private_key_file():
     with open(PRIVATE_KEY_FILE_PATH, "w") as private_key_file:
         private_key_file.write(os.environ["SSH_PRIVATE_KEY"])
 
-
     with open(PRIVATE_KEY_FILE_PATH, "r") as file:
         line_count = sum(1 for line in file)
         print(f"PRIVATE KEY HAS {line_count} lines.")


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We keep getting errors that the private key isnt formatted correctly for openssl. This PR prints out the number of lines to see if that matches expectations.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
