### PR TITLE
fix critical error on view dataset page

### DIFF
--- a/client/src/components/DatasetSummary.js
+++ b/client/src/components/DatasetSummary.js
@@ -1,12 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import { Box, Paragraph, Text } from 'grommet'
-import { useMyDataset } from 'hooks/useMyDataset'
 import { mapRowsWithColumns } from 'helpers/mapRowsWithColumns'
 import { DatasetSummaryTable } from 'components/DatasetSummaryTable'
 
 export const DatasetSummary = ({ dataset }) => {
-  const { myDataset } = useMyDataset()
-
   const [totalSample, setSampleTotal] = useState(0)
   const [totalProject, setTotalProject] = useState(0)
   const sampleTotalText = `${totalSample} Sample${totalSample > 1 ? 's' : ''}`
@@ -24,9 +21,9 @@ export const DatasetSummary = ({ dataset }) => {
   )
 
   useEffect(() => {
-    setSampleTotal(myDataset.total_sample_count || 0)
-    setTotalProject(Object.keys(myDataset.data).length || 0)
-  }, [myDataset])
+    setSampleTotal(dataset.total_sample_count || 0)
+    setTotalProject(Object.keys(dataset.data).length || 0)
+  }, [dataset])
 
   return (
     <Box>


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Hot fix for when a user returns to the site to see their dataset and download it.

Looks like the component only needs to care about the passed in dataset and not specifically myDataset.

This PR removes that reference to the context and derives the counts from the passed in dataset only.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A tested locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A