### PR TITLE
Update the reference to display Info message in DatasetAddProjectModal

### DIFF
--- a/client/src/components/DatasetAddProjectModal.js
+++ b/client/src/components/DatasetAddProjectModal.js
@@ -197,7 +197,7 @@ export const DatasetAddProjectModal = ({ project, disabled = false }) => {
               <Heading level="3" size="small" margin={{ top: '0' }}>
                 Download Options
               </Heading>
-              {myDatasetProjectData && (
+              {myDataset.data?.[project.scpca_id] && (
                 <DatasetAddProjectModalRemainingContent project={project} />
               )}
               <Box pad={{ top: 'large' }}>


### PR DESCRIPTION
## Issue Number

Closes #1708 

## Purpose/Implementation Notes

This PR address a bug in  `DatasetAddProjectModal` (see linked Issue).

@dvenprasad, see the latest UI [here](https://scpca-portal-pdibnc4fo-ccdl.vercel.app/). Thank you!

Change includes:

Updated the reference for checking the existence of project data in My Dataset to `myDataset`, as the value assigned to `myDatasetProjectData` (via `useMyDataset.getDatasetProjectData`, which returns an empty object) is truthy.

## Types of changes

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A 

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
