### PR TITLE
Remove FEATURE_PREVIEW conditional from urls.py

### DIFF
--- a/api/scpca_portal/urls.py
+++ b/api/scpca_portal/urls.py
@@ -20,14 +20,14 @@ from scpca_portal.views import (
 router = ExtendedDefaultRouter()
 router.trailing_slash = "/?"
 
-router.register(r"ccdl-datasets", CCDLDatasetViewSet, basename="ccdl-datasets")
-router.register(r"datasets", DatasetViewSet, basename="datasets")
-router.register(r"computed-files", ComputedFileViewSet, basename="computed-files")
+router.register(r"tokens", APITokenViewSet, basename="tokens")
 router.register(r"projects", ProjectViewSet, basename="projects")
 router.register(r"samples", SampleViewSet, basename="samples")
-router.register(r"tokens", APITokenViewSet, basename="tokens")
+router.register(r"computed-files", ComputedFileViewSet, basename="computed-files")
 router.register(r"project-options", FilterOptionsViewSet, basename="project-options")
 router.register(r"stats", StatsViewSet, basename="stats")
+router.register(r"ccdl-datasets", CCDLDatasetViewSet, basename="ccdl-datasets")
+router.register(r"datasets", DatasetViewSet, basename="datasets")
 
 urlpatterns = [
     path(


### PR DESCRIPTION
## Issue Number

Closes #1721 

## Purpose/Implementation Notes

I've removed the `if` block for `ENABLE_FEATURE_PREVIEW` in urls.py to make the dataset-related endpoints available in all environments, including production.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
