### PR TITLE
Address modal hanging on portal wide download second attempt

### DIFF
--- a/client/src/contexts/CCDLDatasetDownloadModalContext.js
+++ b/client/src/contexts/CCDLDatasetDownloadModalContext.js
@@ -180,6 +180,7 @@ export const CCDLDatasetDownloadModalContextProvider = ({
 
   // reset to selection on close
   useEffect(() => {
+    // TODO: look into persisting downloadableDataset for portal wide between modal close-opens
     if (!showing) {
       setDownloadDataset(false)
       setDownloadableDataset(null)


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1712.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR addresses the bug where the download modal was hanging on portal-wide files upon the second download attempt without a refresh in between.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)


## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
