### PR TITLE
add correct closing tag for partial include

### DIFF
--- a/api/scpca_portal/templates/emails/dataset_job_error.html
+++ b/api/scpca_portal/templates/emails/dataset_job_error.html
@@ -14,7 +14,7 @@
         <table role="presentation"
           style="width: 100%; max-width: 600px; margin: 0 auto; background-color: #ffffff; border-collapse: collapse;">
           <!-- Header with blue gradient -->
-          {% include "emails/_dataset_header.html"}
+          {% include "emails/_dataset_header.html" %}
 
           <!-- Main Content -->
           <tr>
@@ -38,7 +38,7 @@
           </tr>
 
           <!-- Footer -->
-          {% include "emails/_dataset_footer.html"}
+          {% include "emails/_dataset_footer.html" %}
         </table>
       </td>
     </tr>

--- a/api/scpca_portal/templates/emails/dataset_job_success.html
+++ b/api/scpca_portal/templates/emails/dataset_job_success.html
@@ -14,7 +14,7 @@
         <table role="presentation"
           style="width: 100%; max-width: 600px; margin: 0 auto; background-color: #ffffff; border-collapse: collapse;">
           <!-- Header with blue gradient -->
-          {% include "emails/_dataset_header.html"}
+          {% include "emails/_dataset_header.html" %}
 
           <!-- Main Content -->
           <tr>
@@ -46,7 +46,7 @@
           </tr>
 
           <!-- Footer -->
-          {% include "emails/_dataset_footer.html"}
+          {% include "emails/_dataset_footer.html" %}
         </table>
       </td>
     </tr>


### PR DESCRIPTION
## Issue Number

#1709 

## Purpose/Implementation Notes

- In a rush I forgot the closing tags for the partial which prevented the images from rendering. This PR fixes that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
