### PR TITLE
remove padding from email header

### DIFF
--- a/api/scpca_portal/templates/emails/_dataset_header.html
+++ b/api/scpca_portal/templates/emails/_dataset_header.html
@@ -1,6 +1,6 @@
 <tr>
   <td style="padding: 0; position: relative; height: 90px; overflow: hidden;">
-    <div style="position: relative; z-index: 2; padding: 20px 30px 45px;">
+    <div style="position: relative; z-index: 2;">
       <img src="https://staging.scpca.alexslemonade.org/email-header.png" alt="ScPCA Portal" width="600" />
     </div>
   </td>


### PR DESCRIPTION
## Issue Number

#1709 

## Purpose/Implementation Notes

- Remove the padding from the header, this should be the last item then we are good to remove the staging prefix from the email template.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
