### PR TITLE
Upgrade Local PostgreSQL Docker Image to v16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     image: postgres:16.11
     volumes:
       - ./api/volumes_postgres/volumes_postgres:/var/lib/postgresql/data
+    environment:
+     - POSTGRES_HOST_AUTH_METHOD=trust
   api:
     container_name: '${API_NAME}'
     network_mode: '${API_NETWORK}'


### PR DESCRIPTION
## Issue Number

Closes #1751

Merge into `feature/django-42`

## Purpose/Implementation Notes

Changes include:

In `odcker-compose.yml`:
- Upgraded the PostgreSQL Docker image from v11.6 to v16.11 
- Set the  [`POSTGRES_HOST_AUTH_METHOD`](https://hub.docker.com/_/postgres#postgres_host_auth_method) to `trust` for localhost

(@davidsmejia , ~~currently, setting [POSTGRES_PASSWORD](https://hub.docker.com/_/postgres#postgres_password) is not required and the default values for [POSTGRES_USER](https://hub.docker.com/_/postgres#postgres_user) and [POSTGRES_DB](https://hub.docker.com/_/postgres#postgres_db) are used for localhost, which are implicitly set by PostgreSQL. Let me know if you would like to set a password for the dev environment.~~ **UPDATE:** We'll omit the password for `localhost` 🗒️ )

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I took the following steps to verify this change:

1. Rebuild the Docker image
2. Removed the local data in `api/volumes_postgres/volumes_postgres` 
3. Repopulated the database on localhost via running management commands
4. Run the Docker container
5. Ensure that both the API and client work properly

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Running docker compose up would start the container without errors:

<img width="680" alt="docker-compose-up" src="https://github.com/user-attachments/assets/2001b885-ab11-44e6-8c72-f2ef72f7f358" />




