### PR TITLE
remove shared title from dataset detail page

### DIFF
--- a/client/src/components/DatasetSummary.js
+++ b/client/src/components/DatasetSummary.js
@@ -3,7 +3,7 @@ import { Box, Paragraph, Text } from 'grommet'
 import { mapRowsWithColumns } from 'helpers/mapRowsWithColumns'
 import { DatasetSummaryTable } from 'components/DatasetSummaryTable'
 
-export const DatasetSummary = ({ dataset, children }) => {
+export const DatasetSummary = ({ dataset, titleSize = 'large', children }) => {
   const [totalSample, setSampleTotal] = useState(0)
   const [totalProject, setTotalProject] = useState(0)
   const sampleTotalText = `${totalSample} Sample${totalSample > 1 ? 's' : ''}`
@@ -35,7 +35,7 @@ export const DatasetSummary = ({ dataset, children }) => {
         fill
       >
         <Box gap="medium" pad={{ bottom: 'medium' }}>
-          <Text serif size="large">
+          <Text serif size={titleSize}>
             Dataset Summary
           </Text>
           <Paragraph>

--- a/client/src/pages/datasets/[dataset_id]/index.js
+++ b/client/src/pages/datasets/[dataset_id]/index.js
@@ -64,7 +64,7 @@ const Dataset = ({ dataset: initialDataset }) => {
       </Box>
       <Box pad={responsive({ horizontal: 'medium' })} fill>
         <Box margin={{ bottom: 'large' }}>
-          <DatasetSummary dataset={dataset}>
+          <DatasetSummary titleSize="xlarge" dataset={dataset}>
             <DatasetMoveSamplesModal dataset={dataset} />
           </DatasetSummary>
         </Box>


### PR DESCRIPTION
## Issue Number

#1756 

## Purpose/Implementation Notes

- Removes "Shared Dataset" title
- Allows dataset summary to render children next to header for future flexibility

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)


## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

<img width="1282" height="1018" alt="Screenshot 2026-01-29 at 1 48 50 PM" src="https://github.com/user-attachments/assets/5e364dd5-c747-4276-9b1e-bbada08ae061" />
