### PR TITLE
Fix: Update myDataset.getMyDatasetCopy to clone the data property

### DIFF
--- a/client/src/hooks/useMyDataset.js
+++ b/client/src/hooks/useMyDataset.js
@@ -304,10 +304,15 @@ export const useMyDataset = () => {
     isProjectMerged(myDataset, project)
 
   const removeProjectByIdFromMyDataset = (projectId) => {
-    const datasetCopy = getMyDatasetCopy(myDataset)
-    delete datasetCopy.data[projectId]
+    const datasetDataCopy = getMyDatasetCopy(myDataset)
+    delete datasetDataCopy[projectId]
 
-    return updateMyDataset(datasetCopy)
+    const updatedDataset = {
+      ...myDataset,
+      data: datasetDataCopy
+    }
+
+    return updateMyDataset(updatedDataset)
   }
 
   /* Sample-level */


### PR DESCRIPTION
## Issue Number

There was a bug in `myDataset.getMyDatasetCopy` (in PR #1767), which resulted in a dataset validation error during the API request. This PR addresses this bug.

## Purpose/Implementation Notes

Changes include:
- Updated the `getMyDatasetCopy` method to properly copy the `data` property, and removed its parameter, as is unnecessary.
- Adjusted the `removeProjectByIdFromMyDataset` method based on the `getMyDatasetCopy` method update (*now it returns the `data` property copy)

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
