### PR TITLE
hide Remove All button when read only

### DIFF
--- a/client/src/components/DatasetProjectSummary.js
+++ b/client/src/components/DatasetProjectSummary.js
@@ -5,6 +5,7 @@ import { DatasetRemoveAllModal } from 'components/DatasetRemoveAllModal'
 
 export const DatasetProjectSummary = ({ dataset, readOnly = false }) => {
   const projectKeys = Object.keys(dataset.data) || []
+  const canRemoveAll = !readOnly && projectKeys.length > 0
 
   return (
     <Box margin={{ bottom: 'large' }}>
@@ -18,7 +19,7 @@ export const DatasetProjectSummary = ({ dataset, readOnly = false }) => {
         <Text serif size="large">
           Project Summary
         </Text>
-        {projectKeys.length > 1 && (
+        {canRemoveAll && (
           <Box>
             <DatasetRemoveAllModal />
           </Box>


### PR DESCRIPTION
## Issue Number

#1792

## Purpose/Implementation Notes

Previously we only checked if the dataset had keys when determining if we should show or hide the `Remove All` button. This PR adds the check to see if we have set the component to be read only and then also hides it in that circumstance.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
