### PR TITLE
Disable Add Samples to Dataset button if no samples are selected

### DIFF
--- a/client/src/components/DatasetAddSamplesModal.js
+++ b/client/src/components/DatasetAddSamplesModal.js
@@ -15,7 +15,7 @@ import { WarningAnnDataMultiplexed } from 'components/WarningAnnDataMultiplexed'
 export const DatasetAddSamplesModal = ({
   project,
   samples,
-  label = 'Add to Dataset',
+  label = 'Add Samples to Dataset',
   title = 'Add Samples to Dataset',
   disabled = false
 }) => {
@@ -85,6 +85,7 @@ export const DatasetAddSamplesModal = ({
     userFormat === 'ANN_DATA'
       ? totalSamples - selectedMulstiplexedSamples.length > 0
       : totalSamples > 0
+  const isDisabled = disabled || !canClickAddSamples
 
   const handleAddSamples = async () => {
     setLoading(true)
@@ -154,7 +155,7 @@ export const DatasetAddSamplesModal = ({
         flex="grow"
         primary
         label={label}
-        disabled={disabled}
+        disabled={isDisabled}
         onClick={() => setShowing(true)}
       />
       <Modal title={title} showing={showing} setShowing={setShowing}>
@@ -222,7 +223,7 @@ export const DatasetAddSamplesModal = ({
                   primary
                   aria-label={label}
                   label={label}
-                  disabled={!canClickAddSamples}
+                  disabled={isDisabled}
                   onClick={handleAddSamples}
                   loading={loading}
                 />


### PR DESCRIPTION
## Issue Number

Closes #1723

## Purpose/Implementation Notes

I've renamed the `Add to Dataset` button to `Add Samples to Dataset` for the project samples table, and disabled it when no samples are selected in the table.

@dvenprasad  See the latest UI [here](https://scpca-portal-c9dgn0kar-ccdl.vercel.app/). Thank you!

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
