### PR TITLE
Rename the loading prop with show for the sub-components of Button

### DIFF
--- a/client/src/components/Button.js
+++ b/client/src/components/Button.js
@@ -8,9 +8,9 @@ import { useWaitForAsync } from 'hooks/useWaitForAsync'
 import styled, { css } from 'styled-components'
 
 const ButtonText = styled(Text)`
-  ${({ loading }) =>
+  ${({ show }) =>
     css`
-      visibility: ${loading ? 'hidden' : 'visible'};
+      visibility: ${show ? 'hidden' : 'visible'};
     `}
 `
 
@@ -22,16 +22,16 @@ const ButtonSpinner = styled(GrommetSpinner)`
   top: 10%;
   left: 40%;
   transform: translate(-10%, -40%);
-  ${({ loading }) =>
+  ${({ show }) =>
     css`
-      visibility: ${loading ? 'visible' : 'hidden'};
+      visibility: ${show ? 'visible' : 'hidden'};
     `}
 `
 
-const ButtonLabel = ({ label, loading }) => (
+const ButtonLabel = ({ label, show }) => (
   <>
-    <ButtonText loading={loading}>{label}</ButtonText>
-    <ButtonSpinner loading={loading} />
+    <ButtonText show={show}>{label}</ButtonText>
+    <ButtonSpinner show={show} />
   </>
 )
 
@@ -48,7 +48,7 @@ export const Button = ({
     <GrommetButton
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
-      label={<ButtonLabel label={label} loading={loading} />}
+      label={<ButtonLabel label={label} show={loading} />}
       disabled={disabled}
       onClick={asyncOnClick}
     />


### PR DESCRIPTION
## Issue Number

Closes #1785 

## Purpose/Implementation Notes

Changes include:

Renamed the `loading` prop for the sub-components of `components/Button` to `show`.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've verified that there are no longer error warning logs in the browser console on `localhost`.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
