### PR TITLE
Display "Added to Dataset" when adding projects with multiplexed samples to ANN_DATA datasets

### DIFF
--- a/client/src/hooks/useDataset.js
+++ b/client/src/hooks/useDataset.js
@@ -221,16 +221,18 @@ export const useDataset = () => {
       if (addedSampleId === 'MERGED') {
         acc[m] = []
       } else {
-        // Exclude multiplexed samples for a dataset with AnnData format
-        const samplesForAnnData = differenceArray(
-          project.modality_samples[m],
-          project.multiplexed_samples
-        )
-
-        acc[m] =
+        // Exclude multiplexed samples for datasets in AnnData format
+        const isMultiplexedExcluded =
           dataset.format === 'ANN_DATA' && project.has_multiplexed_data
-            ? differenceArray(samplesForAnnData, addedSampleId)
-            : differenceArray(project.modality_samples[m], addedSampleId)
+
+        const projectModalitySampleIds = isMultiplexedExcluded
+          ? differenceArray(
+              project.modality_samples[m],
+              project.multiplexed_samples
+            )
+          : project.modality_samples[m]
+
+        acc[m] = differenceArray(projectModalitySampleIds, addedSampleId)
       }
       return acc
     }, {})


### PR DESCRIPTION
## Issue Number

Closes #1786

## Purpose/Implementation Notes

I've excluded the multiplexed samples for datasets in AnnData format to display the correct `"Add to Dataset"` button state (the "Added to Dataset" text in green) after all non-multiplexed samples of the project (i.e., SCPCP000009) have been added to My Dataset.

Changes include:
Filter out the multiplexed single samples when the project has multiplexed data and the dataset format is AnnData in `useDataset.getRemainingProjectSampleIds`.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A