### PR TITLE
Remove old parameter and lock version upgrades for v17.xx

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -7,26 +7,6 @@ data "aws_rds_certificate" "cert" {
   # latest_valid_till = true
 }
 
-resource "aws_db_parameter_group" "postgres16_parameters" {
-  name        = "scpca-portal-postgres16-parameters-${var.user}-${var.stage}"
-  description = "Postgres Parameters ${var.user} ${var.stage}"
-  family      = "postgres16"
-
-  parameter {
-    name  = "deadlock_timeout"
-    value = "60000" # 60000ms = 60s
-  }
-
-  parameter {
-    name  = "statement_timeout"
-    value = "60000" # 60000ms = 60s
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_db_parameter_group" "postgres17_parameters" {
   name        = "scpca-portal-postgres17-parameters-${var.user}-${var.stage}"
   description = "Postgres Parameters ${var.user} ${var.stage}"
@@ -58,8 +38,8 @@ resource "aws_db_instance" "postgres_db" {
   # to apply changes immediately to allow for subsequent deployments.
   # `allow_major_version_upgrade` and `apply_immediately`
   # should be set to false when the old parameter group is removed.
-  allow_major_version_upgrade = true
-  apply_immediately           = true
+  allow_major_version_upgrade = false
+  apply_immediately           = false
 
   auto_minor_version_upgrade = false
   instance_class             = var.database_instance_type


### PR DESCRIPTION
## Issue Number

Parent Issue #1787

Stacked PR from #1815

## Purpose/Implementation Notes

This is the **Step 4 Remove old parameter and lock version upgrades for v17.xx** as listed in the linked parent issue (see the list of [steps](https://github.com/AlexsLemonade/scpca-portal/issues/1787#issuecomment-3880290007)). 

Changes include:
- Set the `allow_major_version_upgrade` and `apply_immediately` flags to `false` in infrastructure/database
- Remove the old DB parameter group, `postgres16_parameters`, in infrastructure/database


## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
