### PR TITLE
explicitly purge old computed file on s3

### DIFF
--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -55,7 +55,7 @@ class DatasetJobProcessor(JobProcessorABC):
 
     def purge_old_computed_file(self):
         if self.job.dataset.computed_file:
-            self.job.dataset.comptued_file.purge(delete_from_s3=True)
+            self.job.dataset.computed_file.purge(delete_from_s3=True)
 
     def create_new_computed_file(self):
         self.job.dataset.computed_file = ComputedFile.get_dataset_file(self.job.dataset)


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Fixes issue with undefined DatasetJobProcessor attr. Explicitly deletes computed files when re-generating. This may change in the future as we may want to keep the record but just purge the file on s3.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
