### PR TITLE
Step 2 - Remove old parameter and lock version upgrades

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -7,26 +7,6 @@ data "aws_rds_certificate" "cert" {
   # latest_valid_till = true
 }
 
-resource "aws_db_parameter_group" "postgres16_parameters" {
-  name        = "scpca-portal-postgres16-parameters-${var.user}-${var.stage}"
-  description = "Postgres Parameters ${var.user} ${var.stage}"
-  family      = "postgres16"
-
-  parameter {
-    name  = "deadlock_timeout"
-    value = "60000" # 60000ms = 60s
-  }
-
-  parameter {
-    name  = "statement_timeout"
-    value = "60000" # 60000ms = 60s
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_db_parameter_group" "postgres17_parameters" {
   name        = "scpca-portal-postgres17-parameters-${var.user}-${var.stage}"
   description = "Postgres Parameters ${var.user} ${var.stage}"


### PR DESCRIPTION
## Issue Number

Parent Issue #1787

## Purpose/Implementation Notes

This is the final step, **Step 2 - Remove old parameter and lock version upgrades**,  as listed in the linked parent issue (see the list of [steps](https://github.com/AlexsLemonade/scpca-portal/issues/1787#issuecomment-3880290007)). 

Changes include:
- Remove the old DB parameter group `postgres16_parameters` from `infrastructure/database`

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A