### PR TITLE
Don't flash the empty dataset page when user triggers the download

### DIFF
--- a/client/src/components/DatasetProcessModal.js
+++ b/client/src/components/DatasetProcessModal.js
@@ -10,7 +10,8 @@ import { Modal, ModalBody } from 'components/Modal'
 export const DatasetProcessModal = ({
   label = 'Download Dataset',
   title = 'Download Dataset',
-  disabled = false
+  disabled = false,
+  onRedirecting = () => {}
 }) => {
   const { push } = useRouter()
   const { processMyDataset } = useMyDataset()
@@ -22,10 +23,12 @@ export const DatasetProcessModal = ({
     const submit = async () => {
       const datasetRequest = await processMyDataset()
       if (datasetRequest) {
+        onRedirecting(true)
         push(`/datasets/${datasetRequest.id}`)
       } else {
         // TODO: Error handling
         setSubmitting(false)
+        setShowing(false)
       }
     }
 

--- a/client/src/pages/download/index.js
+++ b/client/src/pages/download/index.js
@@ -27,6 +27,7 @@ const Download = () => {
   const { responsive } = useResponsive()
 
   const [loading, setLoading] = useState(true)
+  const [redirecting, setRedirecting] = useState(false)
   const [isFormatChanged, setIsFormatChanged] = useState(false)
 
   const { hideNotification } = useNotification()
@@ -55,7 +56,8 @@ const Download = () => {
     }
   }, [loading])
 
-  if (loading) return <Loader />
+  // Show a loader while restoring scroll position or redirecting users
+  if (loading || redirecting) return <Loader />
 
   // TODO: Replace this once error handling is finalized
   // Show error page if there are any API errors
@@ -82,7 +84,7 @@ const Download = () => {
               )}
             </Box>
             <Box>
-              <DatasetProcessModal />
+              <DatasetProcessModal onRedirecting={setRedirecting} />
               <Text weight="bold">
                 Uncompressed size:{' '}
                 {formatBytes(myDataset.estimated_size_in_bytes)}


### PR DESCRIPTION
## Issue Number

Closes #1809

## Purpose/Implementation Notes

I've updated the UI to display a loader before the redirect during the download processing to prevent the empty dataset UI flash.

@dvenprasad, See the latest UI [here](https://scpca-portal-d2bq9i9fs-ccdl.vercel.app/). Thank you!

Changes include:
- Added a new state `redirecting` state to `pages/download/index`
- Add a new prop `onRedirecting` to `DatasetProcessModal`, which will be set upon dataset processing submission

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
