### PR TITLE
Step 2 - Remove old parameter and lock version upgrades

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -7,26 +7,6 @@ data "aws_rds_certificate" "cert" {
   # latest_valid_till = true
 }
 
-resource "aws_db_parameter_group" "postgres17_parameters" {
-  name        = "scpca-portal-postgres17-parameters-${var.user}-${var.stage}"
-  description = "Postgres Parameters ${var.user} ${var.stage}"
-  family      = "postgres17"
-
-  parameter {
-    name  = "deadlock_timeout"
-    value = "60000" # 60000ms = 60s
-  }
-
-  parameter {
-    name  = "statement_timeout"
-    value = "60000" # 60000ms = 60s
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_db_parameter_group" "postgres18_parameters" {
   name        = "scpca-portal-postgres18-parameters-${var.user}-${var.stage}"
   description = "Postgres Parameters ${var.user} ${var.stage}"
@@ -60,8 +40,8 @@ resource "aws_db_instance" "postgres_db" {
   # to apply changes immediately to allow for subsequent deployments.
   # `allow_major_version_upgrade` and `apply_immediately`
   # should be set to false when the old parameter group is removed.
-  allow_major_version_upgrade = true
-  apply_immediately           = true
+  allow_major_version_upgrade = false
+  apply_immediately           = false
 
   auto_minor_version_upgrade = false
   instance_class             = var.database_instance_type


### PR DESCRIPTION
## Issue Number

Parent Issue #1788

## Purpose/Implementation Notes

This is the final step, **Step 2 - Remove old parameter and lock version upgrades**, as listed in the linked parent issue (see the list of [steps](https://github.com/AlexsLemonade/scpca-portal/issues/1788#issuecomment-3880587374)). 

Changes include:
- Removed the old DB parameter group `postgres17_parameters` from `infrastructure/database`
- Set the `allow_major_version_upgrade` and `apply_immediately` flags to `false`

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

-  [x] Re-deploy the `dev` server with the cleanup without errors

<img width="228" height="16" alt="redeploy-completed" src="https://github.com/user-attachments/assets/d47bd1fa-0cc1-4a0f-9361-56f41035ba72" />

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A