### PR TITLE
remove extra comma from json policy

### DIFF
--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -153,7 +153,7 @@ resource "aws_iam_policy" "input_bucket_access_policy" {
       {
          "Effect": "Allow",
          "Action": [
-           "kms:Decrypt",
+           "kms:Decrypt"
          ],
          "Resource": "*"
       }


### PR DESCRIPTION
## Issue Number

#1831 

## Purpose/Implementation Notes

Remove extra comma from JSON policy, we should change all of these EOF's to jsonencode to allow for linting

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
