### PR TITLE
convert all json strings to hcl objects with jsonencode

### DIFF
--- a/infrastructure/batch/roles.tf
+++ b/infrastructure/batch/roles.tf
@@ -121,7 +121,9 @@ resource "aws_iam_policy" "batch_job_s3_access" {
         Action = [
           "kms:Decrypt"
         ]
-        Resource = "*"
+        Resource = [
+          "*"
+        ]
       },
       {
         Effect = "Allow"

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -77,7 +77,9 @@ resource "aws_iam_policy" "s3_access_policy" {
         Action = [
           "s3:ListAllMyBuckets"
         ]
-        Resource = "arn:aws:s3:::*"
+        Resource = [
+          "arn:aws:s3:::*"
+        ]
       },
       {
         Effect = "Allow"
@@ -123,7 +125,9 @@ resource "aws_iam_policy" "input_bucket_access_policy" {
         Action = [
           "s3:ListAllMyBuckets"
         ]
-        Resource = "arn:aws:s3:::*"
+        Resource = [
+          "arn:aws:s3:::*"
+        ]
       },
       {
         Effect = "Allow"
@@ -131,7 +135,9 @@ resource "aws_iam_policy" "input_bucket_access_policy" {
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ]
-        Resource = "arn:aws:s3:::scpca-portal-input"
+        Resource = [
+          "arn:aws:s3:::scpca-portal-input"
+        ]
       },
       {
         Effect = "Allow"
@@ -147,7 +153,9 @@ resource "aws_iam_policy" "input_bucket_access_policy" {
         Action = [
           "kms:Decrypt"
         ]
-        Resource = "*"
+        Resource = [
+          "*"
+        ]
       }
     ]
   })
@@ -171,7 +179,9 @@ resource "aws_iam_policy" "batch" {
           "batch:TerminateJob",
           "batch:DescribeJobs"
         ]
-        Resource = "*"
+        Resource = [
+          "*"
+        ]
       }
     ]
   })
@@ -194,7 +204,9 @@ resource "aws_iam_policy" "api_ses_send_email" {
           "ses:SendEmail",
           "ses:SendRawEmail"
         ]
-        Resource = data.aws_ses_domain_identity.scpca_portal.arn
+        Resource = [
+          data.aws_ses_domain_identity.scpca_portal.arn
+        ]
       }
     ]
   })


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I was frustrated with lack of auto-formatting with all of the json literal strings in the infrastructure folder. This PR just converts them to HCL objects wrapped in a `jsonencode` function so we dont have to worry about trailing commas etc. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
