### PR TITLE
Add spacing to pages at medium widths

### DIFF
--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -22,7 +22,10 @@ export const Footer = () => {
       elevation="medium"
       align="center"
       justify="center"
-      pad={{ vertical: 'xlarge' }}
+      pad={{
+        horizontal: responsive('medium', null, 'medium'),
+        vertical: 'xlarge'
+      }}
     >
       <Box direction={direction} justify="between" align="end" width="xlarge">
         <Box

--- a/client/src/components/ResponsiveSheet.js
+++ b/client/src/components/ResponsiveSheet.js
@@ -17,7 +17,7 @@ export const ResponsiveSheet = ({
   children
 }) => {
   const { size } = useResponsive()
-  if (size === 'large') return children
+  if (size !== 'small') return children
   return (
     <>
       <Button
@@ -25,7 +25,7 @@ export const ResponsiveSheet = ({
         label={label}
         onClick={() => setShow(!show)}
         plain={buttonStyle === 'plain'}
-        primary={buttonStyle === 'prinary'}
+        primary={buttonStyle === 'primary'}
         secondary={buttonStyle === 'secondary'}
       />
       {show && (

--- a/client/src/hooks/useResponsive.js
+++ b/client/src/hooks/useResponsive.js
@@ -9,8 +9,10 @@ export const useResponsive = () => {
     setSize(responsiveSize)
   }, [responsiveSize])
 
-  const responsive = (small, big) => {
+  // TODO: Temporarily add medium at the last for backward compatibility
+  const responsive = (small, big = null, medium = null) => {
     if (size === 'small') return small
+    if (size === 'medium') return medium || big
     return big
   }
 

--- a/client/src/pages/about/index.js
+++ b/client/src/pages/about/index.js
@@ -32,7 +32,10 @@ export const About = () => {
         <Box
           width={{ max: 'xlarge' }}
           fill
-          pad={responsive({ horizontal: 'medium' }, { top: 'large' })}
+          pad={{
+            horizontal: responsive('medium', null, 'medium'),
+            top: responsive('large')
+          }}
         >
           <Text size="xxlarge">About</Text>
         </Box>
@@ -51,7 +54,14 @@ export const About = () => {
           </Paragraph>
         </Box>
       </HeroBandReversed>
-      <Box width="full" align="center" pad={{ vertical: 'large' }}>
+      <Box
+        width="full"
+        align="center"
+        pad={{
+          vertical: 'large',
+          horizontal: responsive('medium', null, 'medium')
+        }}
+      >
         <Box
           width={{ max: 'xlarge' }}
           fill
@@ -72,7 +82,11 @@ export const About = () => {
       <Grid
         columns={responsive('1', '1/2')}
         gap="xxlarge"
-        pad={{ top: 'large', bottom: 'xlarge' }}
+        pad={{
+          top: 'large',
+          bottom: 'xlarge',
+          horizontal: responsive('medium', null, 'medium')
+        }}
         width={{ width: 'full', max: 'xlarge' }}
       >
         <Box pad={responsive({ horizontal: 'medium' })}>
@@ -140,7 +154,12 @@ export const About = () => {
           </Box>
         </Box>
       </Grid>
-      <Box background="dawn" width="full" align="center" pad={{ top: 'large' }}>
+      <Box
+        background="dawn"
+        width="full"
+        align="center"
+        pad={{ top: 'large', horizontal: responsive('medium', null, 'medium') }}
+      >
         <Box
           width={{ max: 'xlarge' }}
           fill
@@ -242,7 +261,10 @@ export const About = () => {
           </Grid>
         </Box>
       </Box>
-      <Box width={{ max: 'xlarge' }}>
+      <Box
+        width={{ max: 'xlarge' }}
+        pad={{ horizontal: responsive('medium', null, 'medium') }}
+      >
         <Grid
           align="end"
           gap="none"

--- a/client/src/pages/contribute.js
+++ b/client/src/pages/contribute.js
@@ -8,6 +8,7 @@ import {
   TableRow as GrommetTableRow,
   Text
 } from 'grommet'
+import { useResponsive } from 'hooks/useResponsive'
 import { Button } from 'components/Button'
 import { ContributeDownloadPDFButton } from 'components/ContributeDownloadPDFButton'
 import { ContributeClosedCard } from 'components/ContributeClosedCard'
@@ -40,6 +41,8 @@ const FormLinkButton = ({ href, label }) => (
 )
 
 export const Contribute = () => {
+  const { responsive } = useResponsive()
+
   const headingMargin = { top: '24px', bottom: 'small' }
   const listMargin = { bottom: 'medium', horizontal: 'medium' }
   const isOpen = process.env.CONTRIBUTIONS_OPEN === 'ON'
@@ -151,7 +154,9 @@ export const Contribute = () => {
   }
 
   return (
-    <>
+    <Box
+      pad={responsive({ horizontal: 'medium' }, null, { horizontal: 'medium' })}
+    >
       {isOpen ? (
         <Box alignSelf="end" margin={{ top: 'large' }}>
           <ContributeDownloadPDFButton />
@@ -164,7 +169,7 @@ export const Contribute = () => {
         markdown={markdown}
         width="xlarge"
       />
-    </>
+    </Box>
   )
 }
 

--- a/client/src/pages/contribute.js
+++ b/client/src/pages/contribute.js
@@ -154,9 +154,7 @@ export const Contribute = () => {
   }
 
   return (
-    <Box
-      pad={responsive({ horizontal: 'medium' }, null, { horizontal: 'medium' })}
-    >
+    <Box pad={{ horizontal: responsive('medium', null, 'medium') }}>
       {isOpen ? (
         <Box alignSelf="end" margin={{ top: 'large' }}>
           <ContributeDownloadPDFButton />

--- a/client/src/pages/datasets/[dataset_id]/[project_id].js
+++ b/client/src/pages/datasets/[dataset_id]/[project_id].js
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from 'react'
 import { Box, Text } from 'grommet'
 import { api } from 'api'
 import { ProjectSamplesTableContextProvider } from 'contexts/ProjectSamplesTableContext'
+import { useDataset } from 'hooks/useDataset'
+import { useResponsive } from 'hooks/useResponsive'
 import { useRouter } from 'next/router'
 import { useScrollRestore } from 'hooks/useScrollRestore'
-import { useDataset } from 'hooks/useDataset'
 import { ProjectSamplesTable } from 'components/ProjectSamplesTable'
 import { ProjectSamplesTableOptionsHeader } from 'components/ProjectSamplesTableOptionsHeader'
 import { Badge } from 'components/Badge'
@@ -13,6 +14,7 @@ import { Link } from 'components/Link'
 import { Loader } from 'components/Loader'
 
 export const ViewSamples = ({ dataset, project }) => {
+  const { responsive } = useResponsive()
   const { asPath, back } = useRouter()
   const { setRestoreFromDestination } = useScrollRestore()
   const { isProjectIncludeBulk, isProjectMerged, getDatasetProjectSamples } =
@@ -44,7 +46,12 @@ export const ViewSamples = ({ dataset, project }) => {
   if (loading) return <Loader />
 
   return (
-    <Box gap="large" fill margin={{ bottom: 'large' }}>
+    <Box
+      gap="large"
+      fill
+      margin={{ bottom: 'large' }}
+      pad={{ horizontal: responsive('medium', null, 'medium') }}
+    >
       <Box align="start" gap="large">
         <Button label="Back to Dataset" onClick={handleBackToDataset} />
         <Box gap="small">

--- a/client/src/pages/datasets/[dataset_id]/index.js
+++ b/client/src/pages/datasets/[dataset_id]/index.js
@@ -58,7 +58,7 @@ const Dataset = ({ dataset: initialDataset }) => {
   }, [])
 
   return (
-    <>
+    <Box pad={{ horizontal: responsive('medium', null, 'medium') }}>
       <Box pad={{ top: responsive('medium', 'xlarge') }} fill>
         <DatasetHero dataset={dataset} />
       </Box>
@@ -75,7 +75,7 @@ const Dataset = ({ dataset: initialDataset }) => {
           <DatasetProjectSummary dataset={dataset} readOnly />
         </Box>
       </Box>
-    </>
+    </Box>
   )
 }
 

--- a/client/src/pages/download/[project_id].js
+++ b/client/src/pages/download/[project_id].js
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from 'react'
 import { Box, Text } from 'grommet'
 import { api } from 'api'
 import { ProjectSamplesTableContextProvider } from 'contexts/ProjectSamplesTableContext'
+import { useMyDataset } from 'hooks/useMyDataset'
+import { useResponsive } from 'hooks/useResponsive'
 import { useRouter } from 'next/router'
 import { useScrollRestore } from 'hooks/useScrollRestore'
-import { useMyDataset } from 'hooks/useMyDataset'
 import { ProjectSamplesTable } from 'components/ProjectSamplesTable'
 import { ProjectSamplesTableOptionsHeader } from 'components/ProjectSamplesTableOptionsHeader'
 import { DatasetSaveAndGoBackButton } from 'components/DatasetSaveAndGoBackButton'
@@ -14,6 +15,7 @@ import { Link } from 'components/Link'
 import { Loader } from 'components/Loader'
 
 export const ViewEditSamples = ({ project }) => {
+  const { responsive } = useResponsive()
   const { asPath, back } = useRouter()
   const { setRestoreFromDestination } = useScrollRestore()
   const {
@@ -49,7 +51,12 @@ export const ViewEditSamples = ({ project }) => {
   if (loading) return <Loader />
 
   return (
-    <Box gap="large" fill margin={{ bottom: 'large' }}>
+    <Box
+      gap="large"
+      fill
+      margin={{ bottom: 'large' }}
+      pad={{ horizontal: responsive('medium', null, 'medium') }}
+    >
       <Box align="start" gap="large">
         <Button label="Back to My Dataset" onClick={handleBackToMyDataset} />
         <Box gap="small">

--- a/client/src/pages/download/index.js
+++ b/client/src/pages/download/index.js
@@ -64,7 +64,10 @@ const Download = () => {
   if (errors.length > 0) return <Error />
 
   return (
-    <Box width="full" pad={responsive({ horizontal: 'medium' })}>
+    <Box
+      width="full"
+      pad={{ horizontal: responsive('medium', null, 'medium') }}
+    >
       {isDatasetDataEmpty ? (
         <DatasetEmpty />
       ) : (

--- a/client/src/pages/portal-wide.js
+++ b/client/src/pages/portal-wide.js
@@ -39,9 +39,7 @@ const PortalWideDownloads = ({ datasets }) => {
         <Box
           width={{ max: 'xlarge' }}
           margin={{ top: responsive('-148px', '-132px') }}
-          pad={responsive({ horizontal: 'medium' }, null, {
-            horizontal: 'medium'
-          })}
+          pad={{ horizontal: responsive('medium', null, 'medium') }}
           fill
         >
           <Text color="white" size="xxlarge">
@@ -51,9 +49,7 @@ const PortalWideDownloads = ({ datasets }) => {
       </HeroBandPortalWide>
       <Box
         width={{ max: 'xlarge' }}
-        pad={responsive({ horizontal: 'medium' }, null, {
-          horizontal: 'medium'
-        })}
+        pad={{ horizontal: responsive('medium', null, 'medium') }}
         fill
       >
         <Box alignSelf="center" margin={{ top: 'none' }} fill>

--- a/client/src/pages/portal-wide.js
+++ b/client/src/pages/portal-wide.js
@@ -39,6 +39,9 @@ const PortalWideDownloads = ({ datasets }) => {
         <Box
           width={{ max: 'xlarge' }}
           margin={{ top: responsive('-148px', '-132px') }}
+          pad={responsive({ horizontal: 'medium' }, null, {
+            horizontal: 'medium'
+          })}
           fill
         >
           <Text color="white" size="xxlarge">
@@ -46,7 +49,13 @@ const PortalWideDownloads = ({ datasets }) => {
           </Text>
         </Box>
       </HeroBandPortalWide>
-      <Box width={{ max: 'xlarge' }} fill>
+      <Box
+        width={{ max: 'xlarge' }}
+        pad={responsive({ horizontal: 'medium' }, null, {
+          horizontal: 'medium'
+        })}
+        fill
+      >
         <Box alignSelf="center" margin={{ top: 'none' }} fill>
           <Box>
             <Text size="medium" margin={{ top: 'small' }}>

--- a/client/src/pages/privacy-policy.js
+++ b/client/src/pages/privacy-policy.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import { useResponsive } from 'hooks/useResponsive'
+import { Box } from 'grommet'
 import { MarkdownPage } from 'components/MarkdownPage'
 import { LastUpdated } from 'components/LastUpdated'
 import privacyPolicy from '../config/privacy-policy.md'
@@ -7,11 +9,19 @@ import privacyPolicy from '../config/privacy-policy.md'
 // TODO: handle this with regex
 const content = privacyPolicy.replace('Last Updated: 2021-11-03', '')
 
-export const PrivacyPolicy = () => (
-  <>
-    <MarkdownPage markdown={content} />
-    <LastUpdated date={process.env.PRIVACY_POLICY_RELEASE} />
-  </>
-)
+export const PrivacyPolicy = () => {
+  const { responsive } = useResponsive()
+
+  return (
+    <Box
+      pad={{
+        horizontal: responsive('medium', null, 'medium')
+      }}
+    >
+      <MarkdownPage markdown={content} />
+      <LastUpdated date={process.env.PRIVACY_POLICY_RELEASE} />
+    </Box>
+  )
+}
 
 export default PrivacyPolicy

--- a/client/src/pages/projects/[scpca_id].js
+++ b/client/src/pages/projects/[scpca_id].js
@@ -53,9 +53,7 @@ const Project = ({ project, ccdlDatasets }) => {
   if (!project) return '404'
 
   return (
-    <Box
-      pad={responsive({ horizontal: 'medium' }, null, { horizontal: 'medium' })}
-    >
+    <Box pad={{ horizontal: responsive('medium', null, 'medium') }}>
       <PageTitle title={project.title} />
       <Box width="xlarge">
         <CCDLDatasetDownloadModalContextProvider

--- a/client/src/pages/projects/[scpca_id].js
+++ b/client/src/pages/projects/[scpca_id].js
@@ -53,7 +53,9 @@ const Project = ({ project, ccdlDatasets }) => {
   if (!project) return '404'
 
   return (
-    <>
+    <Box
+      pad={responsive({ horizontal: 'medium' }, null, { horizontal: 'medium' })}
+    >
       <PageTitle title={project.title} />
       <Box width="xlarge">
         <CCDLDatasetDownloadModalContextProvider
@@ -214,7 +216,7 @@ const Project = ({ project, ccdlDatasets }) => {
           </Tabs>
         </Box>
       </Box>
-    </>
+    </Box>
   )
 }
 

--- a/client/src/pages/projects/index.js
+++ b/client/src/pages/projects/index.js
@@ -44,82 +44,83 @@ const Project = ({ projects, count, filters, filterOptions, ccdlDatasets }) => {
   }
 
   return (
-    <>
-      <Box width="full" pad={responsive({ horizontal: 'medium' })}>
-        <Box pad={{ bottom: 'large' }}>
-          <Text serif size="xlarge">
-            Browse Projects
-          </Text>
-        </Box>
-        <Grid
-          rows={responsive(['auto', 'auto'], ['auto'])}
-          columns={responsive(['auto'], ['small', 'auto'])}
-          areas={responsive(
-            [
-              { name: 'filters', start: [0, 0], end: [0, 0] },
-              { name: 'results', start: [0, 1], end: [0, 1] }
-            ],
-            [
-              { name: 'filters', start: [0, 0], end: [0, 0] },
-              { name: 'results', start: [1, 0], end: [1, 0] }
-            ]
-          )}
-          direction="row"
-          gap="large"
-        >
-          <Box gridArea="filters">
-            <ResponsiveSheet
-              show={showFilters}
-              setShow={setShowFilters}
-              label="Show Filters"
-              loading={loading}
-            >
-              <Box width="small">
-                <Box direction="row" justify="between">
-                  <Text serif size="large">
-                    Filters
-                  </Text>
-                  <Anchor
-                    color="brand"
-                    label="clear all"
-                    disabled={!hasFilters}
-                    onClick={clearFilters}
-                  />
-                </Box>
-                <ProjectSearchFilter
-                  filters={browseFilters}
-                  filterOptions={filterOptions}
-                  onFilterChange={onFilterChange}
-                />
-              </Box>
-            </ResponsiveSheet>
-          </Box>
-          <Box gridArea="results" pad={{ bottom: 'medium' }}>
-            <Box direction="row" justify="between">
-              <Box flex="shrink">
-                <ProjectSearchFilterPills
-                  filters={browseFilters}
-                  onFilterChange={onFilterChange}
-                />
-              </Box>
-              <Box flex="grow">
-                <Text alignSelf="end">Number of Projects: {count}</Text>
-              </Box>
-            </Box>
-            {projects.map((p) => (
-              <Box key={p.scpca_id} margin={{ top: 'medium', bottom: 'small' }}>
-                <ProjectSearchResult
-                  project={p}
-                  ccdlDatasets={ccdlDatasets.filter(
-                    (d) => d.ccdl_project_id === p.scpca_id
-                  )}
-                />
-              </Box>
-            ))}
-          </Box>
-        </Grid>
+    <Box
+      width="full"
+      pad={responsive({ horizontal: 'medium' }, null, { horizontal: 'medium' })}
+    >
+      <Box pad={{ bottom: 'large' }}>
+        <Text serif size="xlarge">
+          Browse Projects
+        </Text>
       </Box>
-    </>
+      <Grid
+        rows={responsive(['auto', 'auto'], ['auto'])}
+        columns={responsive(['auto'], ['small', 'auto'])}
+        areas={responsive(
+          [
+            { name: 'filters', start: [0, 0], end: [0, 0] },
+            { name: 'results', start: [0, 1], end: [0, 1] }
+          ],
+          [
+            { name: 'filters', start: [0, 0], end: [0, 0] },
+            { name: 'results', start: [1, 0], end: [1, 0] }
+          ]
+        )}
+        direction="row"
+        gap="large"
+      >
+        <Box gridArea="filters">
+          <ResponsiveSheet
+            show={showFilters}
+            setShow={setShowFilters}
+            label="Show Filters"
+            loading={loading}
+          >
+            <Box width="small">
+              <Box direction="row" justify="between">
+                <Text serif size="large">
+                  Filters
+                </Text>
+                <Anchor
+                  color="brand"
+                  label="clear all"
+                  disabled={!hasFilters}
+                  onClick={clearFilters}
+                />
+              </Box>
+              <ProjectSearchFilter
+                filters={browseFilters}
+                filterOptions={filterOptions}
+                onFilterChange={onFilterChange}
+              />
+            </Box>
+          </ResponsiveSheet>
+        </Box>
+        <Box gridArea="results" pad={{ bottom: 'medium' }}>
+          <Box direction="row" justify="between">
+            <Box flex="shrink">
+              <ProjectSearchFilterPills
+                filters={browseFilters}
+                onFilterChange={onFilterChange}
+              />
+            </Box>
+            <Box flex="grow">
+              <Text alignSelf="end">Number of Projects: {count}</Text>
+            </Box>
+          </Box>
+          {projects.map((p) => (
+            <Box key={p.scpca_id} margin={{ top: 'medium', bottom: 'small' }}>
+              <ProjectSearchResult
+                project={p}
+                ccdlDatasets={ccdlDatasets.filter(
+                  (d) => d.ccdl_project_id === p.scpca_id
+                )}
+              />
+            </Box>
+          ))}
+        </Box>
+      </Grid>
+    </Box>
   )
 }
 

--- a/client/src/pages/projects/index.js
+++ b/client/src/pages/projects/index.js
@@ -46,7 +46,7 @@ const Project = ({ projects, count, filters, filterOptions, ccdlDatasets }) => {
   return (
     <Box
       width="full"
-      pad={responsive({ horizontal: 'medium' }, null, { horizontal: 'medium' })}
+      pad={{ horizontal: responsive('medium', null, 'medium') }}
     >
       <Box pad={{ bottom: 'large' }}>
         <Text serif size="xlarge">

--- a/client/src/pages/terms-of-use.js
+++ b/client/src/pages/terms-of-use.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useResponsive } from 'hooks/useResponsive'
 import { Box } from 'grommet'
 import styled from 'styled-components'
 import { MarkdownPage } from 'components/MarkdownPage'
@@ -12,15 +13,21 @@ const StyledList = styled(Box)`
 `
 
 export const TermsOfUse = () => {
+  const { responsive } = useResponsive()
+
   const components = {
     ul: { component: StyledList, props: { as: 'ul' } }
     // li: { component: StyledLi, props: { as: "li" } },
   }
   return (
-    <>
+    <Box
+      pad={{
+        horizontal: responsive('medium', null, 'medium')
+      }}
+    >
       <MarkdownPage components={components} markdown={termsOfUse} />
       <LastUpdated date={process.env.TOS_RELEASE} />
-    </>
+    </Box>
   )
 }
 

--- a/client/src/theme/global.js
+++ b/client/src/theme/global.js
@@ -13,10 +13,6 @@ export default {
     xsmall: '1px'
   },
   breakpoints: {
-    large: {},
-    medium: {
-      value: '1024px'
-    },
     small: {
       borderSize: {
         large: '4px',
@@ -45,6 +41,12 @@ export default {
         xxsmall: '16px'
       },
       value: 768
+    },
+    medium: {
+      value: 1250
+    },
+    large: {
+      value: 1440
     }
   },
   colors: {


### PR DESCRIPTION
## Issue Number

Closes #886

## Purpose/Implementation Notes

I've added padding to the following pages when the viewport hits `medium` width (including the footer), as they had the same spacing issue:
- About
- Browse
- View Project (Project Details/Sample Details)
- My Dataset 
- Datasets
- Contribute
- Portal-wide Downloads
- Privacy Policy
- Terms of Use

@dvenprasad , I've also assigned you as a reviewer, since spacing for the `medium` size has been added to the UI.

See the latest preview [here](https://scpca-portal-9hm06nalr-ccdl.vercel.app/). Thank you!

Changes include:
- Defined the breakpoints value for `medium` to Grommet's theme
- Added a parameter `medium` to `useResponsive`
- Updated the UI components to render the spacing on pages at medium widths

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
