### PR TITLE
Add Custom Filterset to CCDL Dataset View

### DIFF
--- a/api/scpca_portal/filter.py
+++ b/api/scpca_portal/filter.py
@@ -38,8 +38,9 @@ class ArrayFieldContainsFilter(django_filters.BaseInFilter, django_filters.CharF
 def build_auto_filterset(
     model,
     auto_fields: list[str] = [],
-    extra_fields: dict[str, list[str]] = None,
-    extra_filters: dict = None,
+    extended_auto_field_lookups: dict[str, list[str]] = {},
+    extra_fields: dict[str, list[str]] = {},
+    extra_filters: dict = {},
 ):
     """
     Introspects a model and builds a FilterSet with sensible lookup expressions
@@ -48,6 +49,9 @@ def build_auto_filterset(
         model:          The Django model class to build a FilterSet for.
         auto_fields:    Optional allowlist of field names. Use this
                         to keep your public API surface intentional.
+        extended_auto_field_lookups:
+                        Optional dict of filters for specific auto fields
+                        as an extension from the per data type defaults
         extra_fields:   Additional model fields included in the public API
                         e.g. {"project__scpca_id": ["exact"]}.
         extra_filters:  Optional dict of additional filter instances to mix in,
@@ -78,6 +82,8 @@ def build_auto_filterset(
         for field_type, lookups in FILTER_LOOKUPS.items():
             if isinstance(field, field_type):
                 meta_fields[field.name] = lookups
+                if extended_lookup := extended_auto_field_lookups.get(field.name):
+                    meta_fields[field.name] += extended_lookup
                 break
 
     if extra_fields:

--- a/api/scpca_portal/filter.py
+++ b/api/scpca_portal/filter.py
@@ -38,7 +38,6 @@ class ArrayFieldContainsFilter(django_filters.BaseInFilter, django_filters.CharF
 def build_auto_filterset(
     model,
     auto_fields: list[str] = [],
-    extended_auto_field_lookups: dict[str, list[str]] = {},
     extra_fields: dict[str, list[str]] = {},
     extra_filters: dict = {},
 ):
@@ -49,9 +48,6 @@ def build_auto_filterset(
         model:          The Django model class to build a FilterSet for.
         auto_fields:    Optional allowlist of field names. Use this
                         to keep your public API surface intentional.
-        extended_auto_field_lookups:
-                        Optional dict of filters for specific auto fields
-                        as an extension from the per data type defaults
         extra_fields:   Additional model fields included in the public API
                         e.g. {"project__scpca_id": ["exact"]}.
         extra_filters:  Optional dict of additional filter instances to mix in,
@@ -81,9 +77,10 @@ def build_auto_filterset(
         # Standard field types: use dict-style meta fields for multi-lookup support
         for field_type, lookups in FILTER_LOOKUPS.items():
             if isinstance(field, field_type):
-                meta_fields[field.name] = lookups
-                if extended_lookup := extended_auto_field_lookups.get(field.name):
-                    meta_fields[field.name] += extended_lookup
+                # create deep copy to accommodate mutability of the list
+                meta_fields[field.name] = list(lookups)
+                if field.null:
+                    meta_fields[field.name].append("isnull")
                 break
 
     if extra_fields:

--- a/api/scpca_portal/filter.py
+++ b/api/scpca_portal/filter.py
@@ -77,7 +77,7 @@ def build_auto_filterset(
         # Standard field types: use dict-style meta fields for multi-lookup support
         for field_type, lookups in FILTER_LOOKUPS.items():
             if isinstance(field, field_type):
-                # create deep copy to accommodate mutability of the list
+                # create copy to accommodate mutability of the list
                 meta_fields[field.name] = list(lookups)
                 if field.null:
                     meta_fields[field.name].append("isnull")

--- a/api/scpca_portal/test/test_filter.py
+++ b/api/scpca_portal/test/test_filter.py
@@ -27,6 +27,16 @@ class FilterTest(TestCase):
 
         self.assertEqual(expected_fields, actual_fields)
 
+    def test_extended_auto_field_lookups(self):
+        SampleFilterSet = filter.build_auto_filterset(
+            Sample,
+            auto_fields=["scpca_id", "diagnosis"],  # TextFields
+            extended_auto_field_lookups={"diagnosis": ["isnull"]},
+        )
+        actual_filters = SampleFilterSet.base_filters.keys()
+        self.assertIn("diagnosis__isnull", actual_filters)
+        self.assertNotIn("scpca_id__isnull", actual_filters)
+
     def test_only_extra_fields(self):
         SampleFilterSet = filter.build_auto_filterset(
             Sample, extra_fields={"project__scpca_id": ["exact"]}

--- a/api/scpca_portal/test/test_filter.py
+++ b/api/scpca_portal/test/test_filter.py
@@ -27,11 +27,10 @@ class FilterTest(TestCase):
 
         self.assertEqual(expected_fields, actual_fields)
 
-    def test_extended_auto_field_lookups(self):
+    def test_nullable_auto_fields(self):
         SampleFilterSet = filter.build_auto_filterset(
             Sample,
-            auto_fields=["scpca_id", "diagnosis"],  # TextFields
-            extended_auto_field_lookups={"diagnosis": ["isnull"]},
+            auto_fields=["scpca_id", "diagnosis"],  # non-nullable TextField  # nullable TextField
         )
         actual_filters = SampleFilterSet.base_filters.keys()
         self.assertIn("diagnosis__isnull", actual_filters)

--- a/api/scpca_portal/test/test_filter.py
+++ b/api/scpca_portal/test/test_filter.py
@@ -30,7 +30,8 @@ class FilterTest(TestCase):
     def test_nullable_auto_fields(self):
         SampleFilterSet = filter.build_auto_filterset(
             Sample,
-            auto_fields=["scpca_id", "diagnosis"],  # non-nullable TextField  # nullable TextField
+            # while both fields are TextFields, scpca_id is non-nullable while diagnosis is nullable
+            auto_fields=["scpca_id", "diagnosis"],
         )
         actual_filters = SampleFilterSet.base_filters.keys()
         self.assertIn("diagnosis__isnull", actual_filters)

--- a/api/scpca_portal/views/ccdl_dataset.py
+++ b/api/scpca_portal/views/ccdl_dataset.py
@@ -22,7 +22,6 @@ CCDLDatasetFilterSet = filter.build_auto_filterset(
         "includes_files_multiplexed",
         "estimated_size_in_bytes",
     ],
-    extended_auto_field_lookups={"ccdl_project_id": ["isnull"]},
 )
 
 

--- a/api/scpca_portal/views/ccdl_dataset.py
+++ b/api/scpca_portal/views/ccdl_dataset.py
@@ -3,8 +3,27 @@ from rest_framework.exceptions import PermissionDenied
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
 
+from scpca_portal import filter
 from scpca_portal.models import APIToken, CCDLDataset
 from scpca_portal.serializers import CCDLDatasetDetailSerializer, CCDLDatasetSerializer
+
+CCDLDatasetFilterSet = filter.build_auto_filterset(
+    CCDLDataset,
+    auto_fields=[
+        "id",
+        "format",
+        "ccdl_name",
+        "ccdl_project_id",
+        "ccdl_modality",
+        "ccdl_is_merged",
+        "includes_files_bulk",
+        "includes_files_cite_seq",
+        "includes_files_merged",
+        "includes_files_multiplexed",
+        "estimated_size_in_bytes",
+    ],
+    extended_auto_field_lookups={"ccdl_project_id": ["isnull"]},
+)
 
 
 @extend_schema_view(
@@ -24,14 +43,7 @@ from scpca_portal.serializers import CCDLDatasetDetailSerializer, CCDLDatasetSer
 class CCDLDatasetViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = CCDLDataset.objects.order_by("ccdl_project_id")
     ordering_fields = "__all__"
-    filterset_fields = {
-        "id": ["exact"],
-        "ccdl_name": ["exact"],
-        "ccdl_project_id": ["exact", "isnull"],
-        "ccdl_modality": ["exact"],
-        "ccdl_is_merged": ["exact"],
-        "format": ["exact"],
-    }
+    filterset_class = CCDLDatasetFilterSet
 
     def get_serializer_class(self):
         if self.action == "list":


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/scpca-portal/issues/1917.

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

In this PR:
- A custom filterset is added to the CCDL Dataset view
- A null property check is added to build_auto_filter function to enable passing of isnull filter

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

- `test_filter::FilterTest::test_nullable_auto_fields`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A