### PR TITLE
add hotfix for legacy local storage values

### DIFF
--- a/client/src/contexts/ScPCAPortalContext.js
+++ b/client/src/contexts/ScPCAPortalContext.js
@@ -10,7 +10,6 @@ export const ScPCAPortalContext = createContext({})
 export const ScPCAPortalContextProvider = ({ children }) => {
   const [browseFilters, setBrowseFilters] = useState({})
   const [email, setEmail] = useLocalStorage('scpca-user-email')
-  const [myDataset, setMyDataset] = useLocalStorage('dataset', { data: {} })
   const [token, setToken] = useLocalStorage('scpca-api-token', false)
   const [acceptsTerms, setAcceptsTerms] = useLocalStorage(
     'scpca-api-terms',
@@ -20,6 +19,9 @@ export const ScPCAPortalContextProvider = ({ children }) => {
     'scpca-api-wants-emails',
     false
   )
+  const [myDataset, setMyDataset] = useLocalStorage('dataset', { data: {} })
+  // TODO REMOVE HOTFIX
+  if (!myDataset.data) myDataset.data = {} // hotfix
 
   const emailListForm = useHubspotForm(
     process.env.HUBSPOT_PORTAL_ID,


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We eagerly pushed a change that modifies the default dataset value that is saved in local storage and then make assumptions about that variables shape. This PR is just a temp hotfiix that can be removed at some point in the future.

It just enforces that the data attribute is defined on datasets. Worked locally, on load the dataset is updated in local storage and becomes compliant with the new session. We can extract this in to a migration step close to the entry point on application load in the future.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

ran locally with legacy dataset shape and watched it update

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
