### PR TITLE
add manual release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create datever release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="v$(date -u +'%Y.%m.%d')"
+          VERSION="$BASE"
+          COUNT=0
+          while gh release view "$VERSION" &>/dev/null; do
+            COUNT=$((COUNT + 1))
+            VERSION="$BASE.$COUNT"
+          done
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --generate-notes \
+            --target main


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We need to start cutting releases for posterity reasons. Ultimately we will want to tie this into the API versioning as well but for now we can start with manually creating them by invoking a GHA.

Note:
- The content for the release will be auto generated based on the diff between releases
- The version format for now will be `vYYYY.MM.DD`
- It will be cut from main (what is currently landed in prod)
- We will probably want to edit the initial release description because the message will be large and unhelpful.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
