### PR TITLE
allow cellbrowser uploaders to tag objects

### DIFF
--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -125,7 +125,8 @@ resource "aws_s3_bucket_policy" "scpca_portal_cellbrowser_bucket_policy" {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:ListBucket",
-          "s3:PutObject"
+          "s3:PutObject",
+          "s3:PutObjectTagging"
         ]
         Resource = [
           "${aws_s3_bucket.scpca_portal_cellbrowser_bucket.arn}",


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Does what it says on the label. `s3:putObjectTagging` permissions were missing from the bucket policy preventing uploaders to tag objects during upload. This resolves that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
