### PR TITLE
Set expires_at timestamp and tag output files on S3

### DIFF
--- a/api/scpca_portal/exceptions/__init__.py
+++ b/api/scpca_portal/exceptions/__init__.py
@@ -36,3 +36,4 @@ from scpca_portal.exceptions.job_processor_error import (
     JobProcessorHandlerStepNotImplementedError,
     JobProcessorStepNotImplementedError,
 )
+from scpca_portal.exceptions.s3_error import S3Error, S3TaggingError, S3UploadError

--- a/api/scpca_portal/exceptions/s3_error.py
+++ b/api/scpca_portal/exceptions/s3_error.py
@@ -11,7 +11,7 @@ class S3Error(Exception):
 class S3TaggingError(S3Error):
     def __init__(self, key: str, bucket_name: str, tags: dict | None = None) -> None:
         message = f"Failed to tag {key} in {bucket_name} with {tags}."
-        super().__init__(message, key, bucket_name, tags)
+        super().__init__(message, key, bucket_name)
 
 
 class S3UploadError(S3Error):

--- a/api/scpca_portal/exceptions/s3_error.py
+++ b/api/scpca_portal/exceptions/s3_error.py
@@ -1,0 +1,20 @@
+class S3Error(Exception):
+    def __init__(
+        self, message: str | None = None, key: str = None, bucket_name: str = None
+    ) -> None:
+        default_message = "An error occurred during S3 operation."
+
+        message = message or default_message
+        super().__init__(message)
+
+
+class S3UploadError(S3Error):
+    def __init__(self, key: str, bucket_name: str) -> None:
+        message = f"Failed to upload {key} to {bucket_name}."
+        super().__init__(message, key, bucket_name)
+
+
+class S3TaggingError(S3Error):
+    def __init__(self, key: str, bucket_name: str, tags: dict | None = None) -> None:
+        message = f"Failed to tag {key} in {bucket_name} with {tags}."
+        super().__init__(message, key, bucket_name, tags)

--- a/api/scpca_portal/exceptions/s3_error.py
+++ b/api/scpca_portal/exceptions/s3_error.py
@@ -8,13 +8,13 @@ class S3Error(Exception):
         super().__init__(message)
 
 
-class S3UploadError(S3Error):
-    def __init__(self, key: str, bucket_name: str) -> None:
-        message = f"Failed to upload {key} to {bucket_name}."
-        super().__init__(message, key, bucket_name)
-
-
 class S3TaggingError(S3Error):
     def __init__(self, key: str, bucket_name: str, tags: dict | None = None) -> None:
         message = f"Failed to tag {key} in {bucket_name} with {tags}."
         super().__init__(message, key, bucket_name, tags)
+
+
+class S3UploadError(S3Error):
+    def __init__(self, key: str, bucket_name: str) -> None:
+        message = f"Failed to upload {key} to {bucket_name}."
+        super().__init__(message, key, bucket_name)

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -54,8 +54,7 @@ class DatasetJobProcessor(JobProcessorABC):
 
     def on_run_done(self) -> None:
         self.job.save()
-        dataset = self.job.dataset
-        dataset.save()
+        self.job.dataset.save()
         logger.info("Job completed.")
 
     # Steps

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -110,8 +110,8 @@ class DatasetJobProcessor(JobProcessorABC):
         if not tags:
             return
 
-        if not s3.tag_output_file(key, bucket_name, self.job.dataset.tags):
-            raise S3TaggingError(key, bucket_name)
+        if not s3.tag_output_file(key, bucket_name, tags):
+            raise S3TaggingError(key, bucket_name, tags)
 
     def clean_up_local_computed_file(self) -> None:
         self.job.dataset.computed_file.clean_up_local_computed_file()

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -3,7 +3,12 @@ from datetime import timedelta
 from scpca_portal import notifications, s3, utils
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.enums import JobStates
-from scpca_portal.exceptions import DatasetLockedProjectError, DatasetMissingLibrariesError
+from scpca_portal.exceptions import (
+    DatasetLockedProjectError,
+    DatasetMissingLibrariesError,
+    S3TaggingError,
+    S3UploadError,
+)
 from scpca_portal.job_processors import JobProcessorABC
 from scpca_portal.models import ComputedFile
 
@@ -25,6 +30,8 @@ class DatasetJobProcessor(JobProcessorABC):
     exception_handlers = {
         ("create_new_computed_file", DatasetLockedProjectError): "handle_locked_project",
         ("create_new_computed_file", DatasetMissingLibrariesError): "handle_missing_libraries",
+        ("upload_new_computed_file", S3UploadError): "handle_upload_failure",
+        ("tag_new_computed_file", S3TaggingError): "handle_tag_failure",
     }
 
     # Logging
@@ -83,18 +90,28 @@ class DatasetJobProcessor(JobProcessorABC):
             logger.info("Sending dataset job error email.")
             notifications.send_dataset_job_error_email(self.job)
 
+    def handle_upload_failure(self, step: str, e: Exception) -> None:
+        pass
+
+    def handle_tag_failure(self, step: str, e: Exception) -> None:
+        pass
+
     def upload_new_computed_file(self) -> None:
-        s3.upload_output_file(
-            self.job.dataset.computed_file.s3_key, self.job.dataset.computed_file.s3_bucket
-        )
+        key = self.job.dataset.computed_file.s3_key
+        bucket_name = self.job.dataset.computed_file.s3_bucket
+        if not s3.upload_output_file(key, bucket_name):
+            raise S3UploadError(key, bucket_name)
 
     def tag_new_computed_file(self) -> None:
-        if self.job.dataset.tags:
-            s3.tag_output_file(
-                self.job.dataset.computed_file.s3_key,
-                self.job.dataset.computed_file.s3_bucket,
-                self.job.dataset.tags,
-            )
+        key = self.job.dataset.computed_file.s3_key
+        bucket_name = self.job.dataset.computed_file.s3_bucket
+        tags = self.job.dataset.tags
+
+        if not tags:
+            return
+
+        if not s3.tag_output_file(key, bucket_name, self.job.dataset.tags):
+            raise S3TaggingError(key, bucket_name)
 
     def clean_up_local_computed_file(self) -> None:
         self.job.dataset.computed_file.clean_up_local_computed_file()

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -105,7 +105,7 @@ class DatasetJobProcessor(JobProcessorABC):
     def tag_new_computed_file(self) -> None:
         key = self.job.dataset.computed_file.s3_key
         bucket_name = self.job.dataset.computed_file.s3_bucket
-        tags = self.job.dataset.tags
+        tags = self.job.dataset.s3_upload_tags
 
         if not tags:
             return

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -91,10 +91,16 @@ class DatasetJobProcessor(JobProcessorABC):
             notifications.send_dataset_job_error_email(self.job)
 
     def handle_upload_failure(self, step: str, e: Exception) -> None:
-        pass
+        self.job.apply_state(JobStates.FAILED, reason="Failed to upload the computed file to S3.")
+        self.job.save()
+        self.job.dataset.save()
+        self.job.create_retry_job()
 
     def handle_tag_failure(self, step: str, e: Exception) -> None:
-        pass
+        # Notify about S3 tagging failure via Slack to enable manual tagging
+        self.job.apply_state(JobStates.FAILED, reason="Failed to tag the computed file on S3.")
+        logger.info("Send Slack notification for manual tagging alert.")
+        notifications.send_computed_file_tagging_error_email(self.job)
 
     def upload_new_computed_file(self) -> None:
         key = self.job.dataset.computed_file.s3_key

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -17,6 +17,7 @@ class DatasetJobProcessor(JobProcessorABC):
         "purge_old_computed_file",
         "create_new_computed_file",
         "upload_new_computed_file",
+        "tag_new_computed_file",
         "clean_up_local_computed_file",
         "send_notification",
     ]
@@ -83,18 +84,17 @@ class DatasetJobProcessor(JobProcessorABC):
             notifications.send_dataset_job_error_email(self.job)
 
     def upload_new_computed_file(self) -> None:
-        if s3.upload_output_file(
+        s3.upload_output_file(
             self.job.dataset.computed_file.s3_key, self.job.dataset.computed_file.s3_bucket
-        ):
-            # Tag the computed file for S3 Lifecycle Policy Rule for object expiration
-            # Skip tagging for CCDLDatasets as they do not expire
-            if not self.job.dataset.ccdl_name:
-                tag = {"dataset_type": "user"}
-                s3.tag_output_file(
-                    self.job.dataset.computed_file.s3_key,
-                    self.job.dataset.computed_file.s3_bucket,
-                    tag,
-                )
+        )
+
+    def tag_new_computed_file(self) -> None:
+        if self.job.dataset.tags:
+            s3.tag_output_file(
+                self.job.dataset.computed_file.s3_key,
+                self.job.dataset.computed_file.s3_bucket,
+                self.job.dataset.tags,
+            )
 
     def clean_up_local_computed_file(self) -> None:
         self.job.dataset.computed_file.clean_up_local_computed_file()

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from scpca_portal import notifications, s3, utils
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.enums import JobStates
@@ -46,7 +48,11 @@ class DatasetJobProcessor(JobProcessorABC):
 
     def on_run_done(self) -> None:
         self.job.save()
-        self.job.dataset.save()
+        dataset = self.job.dataset
+        # Skip expires_at for CCDLDatasets as they do not expire
+        if not getattr(dataset, "ccdl_name", None):
+            dataset.expires_at = dataset.succeeded_at + timedelta(days=7)
+        dataset.save()
         logger.info("Job completed.")
 
     # Steps
@@ -77,9 +83,18 @@ class DatasetJobProcessor(JobProcessorABC):
             notifications.send_dataset_job_error_email(self.job)
 
     def upload_new_computed_file(self) -> None:
-        s3.upload_output_file(
+        if s3.upload_output_file(
             self.job.dataset.computed_file.s3_key, self.job.dataset.computed_file.s3_bucket
-        )
+        ):
+            # Tag the computed file for S3 Lifecycle Policy Rule for object expiration
+            # Skip tagging for CCDLDatasets as they do not expire
+            if not self.job.dataset.ccdl_name:
+                tag = {"dataset_type": "user"}
+                s3.tag_output_file(
+                    self.job.dataset.computed_file.s3_key,
+                    self.job.dataset.computed_file.s3_bucket,
+                    tag,
+                )
 
     def clean_up_local_computed_file(self) -> None:
         self.job.dataset.computed_file.clean_up_local_computed_file()

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from scpca_portal import notifications, s3, utils
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.enums import JobStates
@@ -57,9 +55,6 @@ class DatasetJobProcessor(JobProcessorABC):
     def on_run_done(self) -> None:
         self.job.save()
         dataset = self.job.dataset
-        # Skip expires_at for CCDLDatasets as they do not expire
-        if not getattr(dataset, "ccdl_name", None):
-            dataset.expires_at = dataset.succeeded_at + timedelta(days=7)
         dataset.save()
         logger.info("Job completed.")
 

--- a/api/scpca_portal/models/datasets/base.py
+++ b/api/scpca_portal/models/datasets/base.py
@@ -563,7 +563,7 @@ class DatasetABC(TimestampedModel, models.Model):
         Updates state attributes of the given datasets in bulk.
         """
         STATE_UPDATE_ATTRS = [
-            "is_expired",
+            "expires_at",
             "is_pending",
             "pending_at",
             "is_processing",

--- a/api/scpca_portal/models/datasets/base.py
+++ b/api/scpca_portal/models/datasets/base.py
@@ -118,6 +118,11 @@ class DatasetABC(TimestampedModel, models.Model):
         return self._meta.model
 
     @property
+    def expiration_delta(self) -> datetime | None:
+        # Expiration for processed datasets
+        return None
+
+    @property
     def tags(self) -> dict[str, str] | None:
         # Tagging for S3 Lifecycle Policy Rule
         return None
@@ -192,7 +197,7 @@ class DatasetABC(TimestampedModel, models.Model):
     def get_metadata_file_contents(self) -> List[tuple[str | None, Modalities | None, str]]:
         """
         Return a list of three element tuples which includes the project_id, modality,
-        and their associatied metadata file contents as a string.
+        and their associated metadata file contents as a string.
         """
         # We only return one metadata file for all metadata datasets
         # TODO: if we need to put project metadata files in a project folder,
@@ -544,6 +549,11 @@ class DatasetABC(TimestampedModel, models.Model):
 
         setattr(self, f"is_{state_str}", True)
         setattr(self, f"{state_str}_at", make_aware(datetime.now()))
+
+        # Populate the expiration date if required
+        if state == JobStates.SUCCEEDED and self.expiration_delta:
+            self.expires_at = self.expiration_delta
+
         if hasattr(self, f"{state_str}_reason"):
             setattr(self, f"{state_str}_reason", getattr(job, reason_attr))
 
@@ -553,6 +563,7 @@ class DatasetABC(TimestampedModel, models.Model):
         Updates state attributes of the given datasets in bulk.
         """
         STATE_UPDATE_ATTRS = [
+            "is_expired",
             "is_pending",
             "pending_at",
             "is_processing",

--- a/api/scpca_portal/models/datasets/base.py
+++ b/api/scpca_portal/models/datasets/base.py
@@ -123,8 +123,7 @@ class DatasetABC(TimestampedModel, models.Model):
         return None
 
     @property
-    def tags(self) -> dict[str, str] | None:
-        # Tagging for S3 Lifecycle Policy Rule
+    def s3_upload_tags(self) -> dict[str, str] | None:
         return None
 
     # HASHING AND CACHED ATTR LOGIC

--- a/api/scpca_portal/models/datasets/base.py
+++ b/api/scpca_portal/models/datasets/base.py
@@ -117,6 +117,11 @@ class DatasetABC(TimestampedModel, models.Model):
     def get_class(self) -> models.Model:
         return self._meta.model
 
+    @property
+    def tags(self) -> dict[str, str] | None:
+        # Tagging for S3 Lifecycle Policy Rule
+        return None
+
     # HASHING AND CACHED ATTR LOGIC
     def get_hashes(self) -> tuple[str, str, str, str]:
         """Computes and returns data, metadata, readme, and combined hashes."""

--- a/api/scpca_portal/models/datasets/ccdl_dataset.py
+++ b/api/scpca_portal/models/datasets/ccdl_dataset.py
@@ -46,6 +46,10 @@ class CCDLDataset(DatasetABC):
         return dataset, False
 
     @property
+    def tags(self) -> dict[str, str] | None:
+        return None
+
+    @property
     def current_data(self) -> Dict:
         projects = Project.objects.all()
         if self.ccdl_project_id:

--- a/api/scpca_portal/models/datasets/ccdl_dataset.py
+++ b/api/scpca_portal/models/datasets/ccdl_dataset.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict, List
 
 from django.db import models
@@ -44,6 +45,10 @@ class CCDLDataset(DatasetABC):
         dataset.format = dataset.ccdl_type["format"]
         dataset.data = dataset.current_data
         return dataset, False
+
+    @property
+    def expiration_delta(self) -> datetime | None:
+        return None
 
     @property
     def tags(self) -> dict[str, str] | None:

--- a/api/scpca_portal/models/datasets/ccdl_dataset.py
+++ b/api/scpca_portal/models/datasets/ccdl_dataset.py
@@ -51,7 +51,7 @@ class CCDLDataset(DatasetABC):
         return None
 
     @property
-    def tags(self) -> dict[str, str] | None:
+    def s3_upload_tags(self) -> dict[str, str] | None:
         return None
 
     @property

--- a/api/scpca_portal/models/datasets/ccdl_dataset.py
+++ b/api/scpca_portal/models/datasets/ccdl_dataset.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Dict, List
 
 from django.db import models
@@ -45,14 +44,6 @@ class CCDLDataset(DatasetABC):
         dataset.format = dataset.ccdl_type["format"]
         dataset.data = dataset.current_data
         return dataset, False
-
-    @property
-    def expiration_delta(self) -> datetime | None:
-        return None
-
-    @property
-    def s3_upload_tags(self) -> dict[str, str] | None:
-        return None
 
     @property
     def current_data(self) -> Dict:

--- a/api/scpca_portal/models/datasets/user_dataset.py
+++ b/api/scpca_portal/models/datasets/user_dataset.py
@@ -70,6 +70,11 @@ class UserDataset(DatasetABC):
 
         return validated_data
 
+    @property
+    def tags(self) -> dict[str, str] | None:
+        # Tagging the computed file for S3 object expiration
+        return {"dataset_type": "user"}
+
     # CACHED ATTRIBUTES LOGIC
     def get_total_sample_count(self) -> int:
         """

--- a/api/scpca_portal/models/datasets/user_dataset.py
+++ b/api/scpca_portal/models/datasets/user_dataset.py
@@ -1,4 +1,5 @@
 from collections import Counter, defaultdict
+from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
 from django.contrib.postgres.fields import ArrayField
@@ -69,6 +70,10 @@ class UserDataset(DatasetABC):
         validated_data = DatasetDataModelRelations.validate(structured_data)
 
         return validated_data
+
+    @property
+    def expiration_delta(self) -> datetime | None:
+        return self.succeeded_at + timedelta(days=7)
 
     @property
     def tags(self) -> dict[str, str] | None:

--- a/api/scpca_portal/models/datasets/user_dataset.py
+++ b/api/scpca_portal/models/datasets/user_dataset.py
@@ -76,7 +76,7 @@ class UserDataset(DatasetABC):
         return self.succeeded_at + timedelta(days=7)
 
     @property
-    def tags(self) -> dict[str, str] | None:
+    def s3_upload_tags(self) -> dict[str, str] | None:
         # Tagging the computed file for S3 object expiration
         return {"dataset_type": "user"}
 

--- a/api/scpca_portal/notifications.py
+++ b/api/scpca_portal/notifications.py
@@ -75,6 +75,16 @@ def send_dataset_job_error_email(job: Job) -> None:
     return send_email(job.dataset.email, subject, body_text, body_html)
 
 
+def send_computed_file_tagging_error_email(job: Job) -> None:
+    subject = f"Failed to tag the computed file on S3 for {job.dataset.id}"
+    body_text = (
+        f"Tagging failure on the computed file {job.dataset.computed_file.s3_key} "
+        f"on bucket {job.dataset.computed_file.s3_bucket} for the dataset {job.dataset.id}"
+    )
+
+    return send_email(settings.SLACK_NOTIFICATIONS_EMAIL, subject, body_text, body_text)
+
+
 # TODO: Remove this is just for computed files
 def send_project_files_completed_email(project_id: str) -> None:
     subject = f"All files generated for {project_id}"

--- a/api/scpca_portal/s3.py
+++ b/api/scpca_portal/s3.py
@@ -231,7 +231,7 @@ def tag_output_file(key: str, bucket_name: str, tags: Dict[str, str]) -> bool:
     if not tags:
         raise ValueError("Tags cannot be empty.")
     if len(tags) > 10:
-        raise ValueError("Tags cannot be more than 10 per object.")
+        raise ValueError("A maximum of 10 tags is allowed per object.")
 
     tagging = {"TagSet": [{"Key": k, "Value": v} for k, v in tags.items()]}
 

--- a/api/scpca_portal/s3.py
+++ b/api/scpca_portal/s3.py
@@ -225,7 +225,7 @@ def upload_output_file(key: str, bucket_name: str) -> bool:
     return True
 
 
-def tag_output_file(key: str, bucket_name: str, tags: Dict[str, str]):
+def tag_output_file(key: str, bucket_name: str, tags: Dict[str, str]) -> bool:
     """Apply tags to the output file for S3 Lifecycle Policy Rule."""
 
     if not tags:
@@ -233,13 +233,12 @@ def tag_output_file(key: str, bucket_name: str, tags: Dict[str, str]):
     if len(tags) > 10:
         raise ValueError("Tags cannot be more than 10 per object.")
 
-    bucket = f"s3://{bucket_name}"
     tagging = {"TagSet": [{"Key": k, "Value": v} for k, v in tags.items()]}
 
     try:
-        aws_s3.put_object_tagging(Bucket=bucket, Key=key, Tagging=tagging)
+        aws_s3.put_object_tagging(Bucket=bucket_name, Key=key, Tagging=tagging)
     except Exception as error:
-        logger.error(f"Failed tag computed file {key} due to the following error:\n\t{error}")
+        logger.error(f"Failed to tag computed file {key} due to the following error:\n\t{error}")
         return False
 
     return True

--- a/api/scpca_portal/s3.py
+++ b/api/scpca_portal/s3.py
@@ -230,28 +230,15 @@ def tag_output_file(key: str, bucket_name: str, tags: Dict[str, str]):
 
     if not tags:
         raise ValueError("Tags cannot be empty.")
-    if len(tags) > 1:
+    if len(tags) > 10:
         raise ValueError("Tags cannot be more than 10 per object.")
 
     bucket = f"s3://{bucket_name}"
-    tag_set = [{"Key": k, "Value": v} for k, v in tags.items()]
-    tagging = json.dumps({"TagSet": tag_set})
-
-    command_parts = [
-        "aws",
-        "s3api",
-        "put-object-tagging",
-        "--bucket",
-        bucket,
-        "--key",
-        key,
-        "--tagging",
-        tagging,
-    ]
+    tagging = {"TagSet": [{"Key": k, "Value": v} for k, v in tags.items()]}
 
     try:
-        subprocess.check_call(command_parts)
-    except subprocess.CalledProcessError as error:
+        aws_s3.put_object_tagging(Bucket=bucket, Key=key, Tagging=tagging)
+    except Exception as error:
         logger.error(f"Failed tag computed file {key} due to the following error:\n\t{error}")
         return False
 

--- a/api/scpca_portal/s3.py
+++ b/api/scpca_portal/s3.py
@@ -225,6 +225,39 @@ def upload_output_file(key: str, bucket_name: str) -> bool:
     return True
 
 
+def tag_output_file(key: str, bucket_name: str, tags: Dict[str, str]):
+    """Apply tags to the output file for S3 Lifecycle Policy Rule."""
+
+    if not tags:
+        raise ValueError("Tags cannot be empty.")
+    if len(tags) > 1:
+        raise ValueError("Tags cannot be more than 10 per object.")
+
+    bucket = f"s3://{bucket_name}"
+    tag_set = [{"Key": k, "Value": v} for k, v in tags.items()]
+    tagging = json.dumps({"TagSet": tag_set})
+
+    command_parts = [
+        "aws",
+        "s3api",
+        "put-object-tagging",
+        "--bucket",
+        bucket,
+        "--key",
+        key,
+        "--tagging",
+        tagging,
+    ]
+
+    try:
+        subprocess.check_call(command_parts)
+    except subprocess.CalledProcessError as error:
+        logger.error(f"Failed tag computed file {key} due to the following error:\n\t{error}")
+        return False
+
+    return True
+
+
 def generate_pre_signed_link(filename: str, key: str, bucket_name: str) -> str:
     return aws_s3.generate_presigned_url(
         ClientMethod="get_object",

--- a/api/scpca_portal/s3.py
+++ b/api/scpca_portal/s3.py
@@ -233,10 +233,10 @@ def tag_output_file(key: str, bucket_name: str, tags: Dict[str, str]) -> bool:
     if len(tags) > 10:
         raise ValueError("A maximum of 10 tags is allowed per object.")
 
-    tagging = {"TagSet": [{"Key": k, "Value": v} for k, v in tags.items()]}
+    tag_set = {"TagSet": [{"Key": k, "Value": v} for k, v in tags.items()]}
 
     try:
-        aws_s3.put_object_tagging(Bucket=bucket_name, Key=key, Tagging=tagging)
+        aws_s3.put_object_tagging(Bucket=bucket_name, Key=key, Tagging=tag_set)
     except Exception as error:
         logger.error(f"Failed to tag computed file {key} due to the following error:\n\t{error}")
         return False

--- a/api/scpca_portal/test/job_processors/test_dataset_job_processor.py
+++ b/api/scpca_portal/test/job_processors/test_dataset_job_processor.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+
+# from django.conf import settings
+from django.test import TestCase
+from django.utils.timezone import make_aware
+
+from scpca_portal.enums import JobStates
+from scpca_portal.job_processors import DatasetJobProcessor
+from scpca_portal.test.factories import CCDLDatasetFactory, JobFactory, UserDatasetFactory
+
+
+class TestDatasetJobProcessor(TestCase):
+
+    def test_on_run_done_expires_at_for_user_dataset(self):
+        succeeded_at = make_aware(datetime.now())
+
+        job = JobFactory(
+            state=JobStates.SUCCEEDED, dataset=UserDatasetFactory(succeeded_at=succeeded_at)
+        )
+        processor = DatasetJobProcessor(job)
+        processor.on_run_done()
+
+        expected_value = succeeded_at + timedelta(days=7)
+        self.assertEqual(job.dataset.expires_at, expected_value)
+
+    def test_on_run_done_no_expires_at_for_ccdl_dataset(self):
+        succeeded_at = make_aware(datetime.now())
+
+        job = JobFactory(
+            state=JobStates.SUCCEEDED, dataset=CCDLDatasetFactory(succeeded_at=succeeded_at)
+        )
+        processor = DatasetJobProcessor(job)
+        processor.on_run_done()
+
+        expected_value = None
+        self.assertIsNone(job.dataset.expires_at, expected_value)


### PR DESCRIPTION
## Issue Number

Closes #1951

Feature branch: `feature/user-dataset-expiration`

## Purpose/Implementation Notes

Changes include: 
- Dataset state management:
   - Set the expires_at timestamp in `DatasetABC.apply_job_state`
   - Added the new property `expiration_delta` to the Dataset base class
- Dataset Tagging:
   - Added the new step `tag_new_computed_file` to `DatasetJobProcessor` for tagging `UserDataset` computed files 
   -  Added the new property `tags` to the Dataset base class
   - Added a new generic method `s3.tag_output_file` for tagging objects
   - Added new exceptions for S3 operations when uploading or tagging failure (🗒️ we'll refactor the `s3` modules later)
      - Sent Slack alert on tag failure so that the team can manually tag the S3 object (rarely occurs, e.g., AWS error).

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

- Added a new test `test_dataset_job_processor`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated any associated Storybook stories (if applicable)

## Screenshots
N/A