### PR TITLE
prevent concatination of components arrays

### DIFF
--- a/client/app/src/components/DetailsTable.js
+++ b/client/app/src/components/DetailsTable.js
@@ -23,13 +23,16 @@ const DetailsTableDetail = ({ datum, emptyString = 'Not Specified' }) => {
   const isEmpty = !value || value.length === 0
   if (isEmpty) return <Text italic>{emptyString}</Text>
 
+  // check if it is already a component
+  const isComponent = React.isValidElement(value)
+  if (isComponent) return value
+
   // check if it is an array of values
+  const isComponentsArray = Array.isArray(value) && value.every(React.isValidElement)
+  if (isComponentsArray) return value
+
   const isArray = Array.isArray(value)
   if (isArray) return <Paragraph>{value.join(', ')}</Paragraph>
-
-  // check if it is already a component
-  const isObject = typeof value === 'object'
-  if (isObject) return value
 
   return <Paragraph>{value}</Paragraph>
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

In the `DetailsTable` component we were treating arrays of strings the same as arrays of components. This caused a rendering bug where the browser didnt know how to render the stringified object.

This PR explicitly checks for that and then renders either case correctly.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
