### PR TITLE
Remove distDir Declaration For Custom Build Artifact Location

### DIFF
--- a/client/app/next.config.js
+++ b/client/app/next.config.js
@@ -51,7 +51,6 @@ module.exports = () => {
 
 	return {
 		env,
-		distDir: '../.next',
 		productionBrowserSourceMaps: true,
 		webpack: (baseConfig) => {
 			const config = { ...baseConfig }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

<!-- For changes that impact the frontend and user interactions, please ensure there's a vercel preview and tag a designer (@dvenprasad) for review  -->

This PR removes the distDir declaration from the webpack config, which we had implemented in order to house build artifacts in the `client/` dir even though the application runs in `client/app/`. Moving forward, we're going to treat `client/app/` as the root of the project.

> [!NOTE]
> Vercel will fail to build until we update the Vercel config option which points to the root of the project, changing it from `client/` to `client/app/`.


## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)
- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated any associated Storybook stories (if applicable)

## Screenshots

N/A