### PR TITLE
use ecs optimized ami for amazon linux 2023

### DIFF
--- a/infrastructure/batch/compute_environment.tf
+++ b/infrastructure/batch/compute_environment.tf
@@ -90,14 +90,14 @@ resource "aws_launch_template" "scpca_portal_ec2" {
   }
 }
 
-# aws ami which is ecs optimized for amazon linux
+# aws ami which is ecs optimized for amazon linux 2023
 data "aws_ami" "ecs_optimized_amazon_linux" {
   most_recent = true
   owners = ["591542846629"] # ECS team account
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-ecs-hvm-*-x86_64-ebs"]
+    values = ["al2023-ami-ecs-hvm-*-x86_64"]
   }
 
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This pull request updates the Amazon Machine Image (AMI) used for ECS-optimized instances in the batch compute environment to use Amazon Linux 2023 instead of Amazon Linux 2.

Infrastructure update:

* Updated the `aws_ami.ecs_optimized_amazon_linux` data source to select Amazon Linux 2023 ECS-optimized AMIs by changing the filter value from `amzn2-ami-ecs-hvm-*-x86_64-ebs` to `al2023-ami-ecs-hvm-*-x86_64`.

My understanding is that the ebs suffix was dropped because they are ebs backed by default.

For reference 
```bash
aws ec2 describe-images \
    --owners 591542846629 \
    --filters "Name=name,Values=al2023-ami-ecs-hvm-*-x86_64*" \
    --query "Images[*].Name" \
    --output text | tr '\t' '\n' | sort | tail -10

al2023-ami-ecs-hvm-2023.0.20260408-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260414-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260424-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260504-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260506-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260511-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260514-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260518-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260525-kernel-6.1-x86_64
al2023-ami-ecs-hvm-2023.0.20260527-kernel-6.1-x86_64
```

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
