### PR TITLE
Pass a keyword arg delete_from_s3 to ComputedFile.purge 

### DIFF
--- a/api/scpca_portal/management/commands/clean_up_expired_user_datasets.py
+++ b/api/scpca_portal/management/commands/clean_up_expired_user_datasets.py
@@ -41,8 +41,7 @@ class Command(BaseCommand):
                 dataset.is_expired = True
                 updated_fields.add("is_expired")
                 if computed_file := dataset.computed_file:
-                    delete_from_s3 = computed_file.s3_key and computed_file.s3_bucket
-                    computed_file.purge(delete_from_s3)
+                    computed_file.purge(delete_from_s3=True)
 
             updated_datasets.append(dataset)
 


### PR DESCRIPTION
## Issue Number

N/A

Related feedback:  https://github.com/AlexsLemonade/scpca-portal/pull/1997#pullrequestreview-4470692782.

## Purpose/Implementation Notes

This PR removes the locally defied `delte_from_s3` check and simply pass `delete_from_s3=True` to `ComputedFile.purge  ` in the `clean_up_expired_user_datasets` management command.



## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated any associated Storybook stories (if applicable)

## Screenshots

N/A
