### PR TITLE
rename bulk output dir suffic from bulk_rna to bulk

### DIFF
--- a/api/scpca_portal/models/computed_file.py
+++ b/api/scpca_portal/models/computed_file.py
@@ -112,7 +112,7 @@ class ComputedFile(CommonDataAttributes, TimestampedModel):
     ) -> Path:
         """Return the correct output file parent directory of the passed original_file."""
         if original_file.is_bulk:
-            return Path(f"{original_file.project_id}_bulk_rna")
+            return Path(f"{original_file.project_id}_bulk")
 
         # spatial / unmerged single cell
         modality = Modalities.SINGLE_CELL if original_file.is_single_cell else Modalities.SPATIAL

--- a/api/scpca_portal/test/expected_values/ccdl_dataset_single_cell_single_cell_experiment_SCPCP999990.py
+++ b/api/scpca_portal/test/expected_values/ccdl_dataset_single_cell_single_cell_experiment_SCPCP999990.py
@@ -46,8 +46,8 @@ class CCDLDatasetSingleCellSingleCellExperimentSCPCP999990:
     }
     COMPUTED_FILE_LIST = [
         "README.md",
-        "SCPCP999990_bulk_rna/SCPCP999990_bulk_metadata.tsv",
-        "SCPCP999990_bulk_rna/SCPCP999990_bulk_quant.tsv",
+        "SCPCP999990_bulk/SCPCP999990_bulk_metadata.tsv",
+        "SCPCP999990_bulk/SCPCP999990_bulk_quant.tsv",
         "SCPCP999990_single-cell/SCPCS999990/SCPCL999990_celltype-report.html",
         "SCPCP999990_single-cell/SCPCS999990/SCPCL999990_filtered.rds",
         "SCPCP999990_single-cell/SCPCS999990/SCPCL999990_processed.rds",
@@ -69,7 +69,7 @@ class CCDLDatasetSingleCellSingleCellExperimentSCPCP999990:
         "modality": Modalities.SINGLE_CELL.value,
         "metadata_only": False,
         "s3_bucket": settings.AWS_S3_OUTPUT_BUCKET_NAME,
-        "size_in_bytes": 7496,
+        "size_in_bytes": 7480,
         "workflow_version": "v0.8.8",
         "includes_celltype_report": True,
     }

--- a/api/scpca_portal/test/expected_values/user_dataset_single_cell_experiment.py
+++ b/api/scpca_portal/test/expected_values/user_dataset_single_cell_experiment.py
@@ -52,8 +52,8 @@ class UserDatasetSingleCellExperiment:
     }
     COMPUTED_FILE_LIST = [
         "README.md",
-        "SCPCP999990_bulk_rna/SCPCP999990_bulk_metadata.tsv",
-        "SCPCP999990_bulk_rna/SCPCP999990_bulk_quant.tsv",
+        "SCPCP999990_bulk/SCPCP999990_bulk_metadata.tsv",
+        "SCPCP999990_bulk/SCPCP999990_bulk_quant.tsv",
         "SCPCP999990_single-cell/SCPCS999990/SCPCL999990_celltype-report.html",
         "SCPCP999990_single-cell/SCPCS999990/SCPCL999990_filtered.rds",
         "SCPCP999990_single-cell/SCPCS999990/SCPCL999990_processed.rds",


### PR DESCRIPTION
## Issue Number

#2004 

## Purpose/Implementation Notes

This pull request updates the naming convention for bulk RNA output directories and files, changing them from the `_bulk_rna` suffix to just `_bulk`. It also updates related test expectations to match the new directory structure and corrects a minor file size value.

Directory and file naming updates:

* Changed the output directory for bulk RNA files from `{project_id}_bulk_rna` to `{project_id}_bulk` in the `get_output_file_parent_dir` function in `computed_file.py`.
* Updated expected file paths in test files (`ccdl_dataset_single_cell_single_cell_experiment_SCPCP999990.py` and `user_dataset_single_cell_experiment.py`) to use the new `_bulk` directory naming. [[1]](diffhunk://#diff-0004da49d320ae396679597446286dcb69e081d23eb6fa34a11eec73cd98ac27L49-R50) [[2]](diffhunk://#diff-a06776f741e0412235760ca8686ed31f4364b687a7513f4d2bd258f11f26e523L55-R56)

Test data correction:

* Adjusted the expected `size_in_bytes` value for a test computed file from 7496 to 7480 to reflect the current test data.


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
