### PR TITLE
fix certbot and nginx archival and extraction

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -40,27 +40,27 @@ apt install docker-ce docker-ce-cli -y
 sudo usermod -a -G docker ubuntu && newgrp docker
 
 if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
-  # Create and install SSL Certificate for the API.
-  # Only necessary on staging and prod.
-  # We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
-  # Certbot must be installed regardless of whether or not a cert is present because of the auto renewal cron job (see below).
-  apt-get update
-  apt install certbot python3-certbot-nginx -y
+    # Create and install SSL Certificate for the API.
+    # Only necessary on staging and prod.
+    # We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
+    # Certbot must be installed regardless of whether or not a cert is present because of the auto renewal cron job (see below).
+    apt-get update
+    apt install certbot python3-certbot-nginx -y
 
-  # Write script which syncs cert with s3 remote store
-  cat <<"EOF" > certbot_s3_sync.sh
+    # Write script which syncs cert with s3 remote store
+    cat <<"EOF" > certbot_s3_sync.sh
 ${certbot_s3_sync_script}
 EOF
-  chmod +x ./certbot_s3_sync.sh
+    chmod +x ./certbot_s3_sync.sh
 
-  # Write script responsible for certbot cert renewal
-  cat <<"EOF" > certbot_renew_deploy_hook.sh
+    # Write script responsible for certbot cert renewal
+    cat <<"EOF" > certbot_renew_deploy_hook.sh
 ${certbot_renew_deploy_hook_script}
 EOF
-  chmod +x ./certbot_renew_deploy_hook.sh
+    chmod +x ./certbot_renew_deploy_hook.sh
 
-  # Add certbot cert auto renewal entry to cron
-  (crontab -l 2>/dev/null; echo "${certbot_crontab_entry}") | crontab -
+    # Add certbot cert auto renewal entry to cron
+    (crontab -l 2>/dev/null; echo "${certbot_crontab_entry}") | crontab -
 
     # Check here for the cert in S3, if present then pull it down from s3, if not then run certbot.
     if aws s3api head-object --bucket "${scpca_portal_cert_bucket}" --key letsencrypt.zip > /dev/null 2>&1; then
@@ -70,12 +70,12 @@ EOF
         service nginx restart
         rm letsencrypt.zip
     else
-  # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
+        # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
         sleep 180
         BASE_URL="scpca.alexslemonade.org"
         PREFIX="api"
         if [[ ${stage} == "staging" ]]; then
-          PREFIX="$PREFIX.staging"
+            PREFIX="$PREFIX.staging"
         fi
         certbot --nginx -d $PREFIX.$BASE_URL -n --agree-tos --redirect -m ${slack_certbot_email}
         ./certbot_s3_sync.sh

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -40,27 +40,27 @@ apt install docker-ce docker-ce-cli -y
 sudo usermod -a -G docker ubuntu && newgrp docker
 
 if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
-	# Create and install SSL Certificate for the API.
-	# Only necessary on staging and prod.
-	# We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
-	# Certbot must be installed regardless of whether or not a cert is present because of the auto renewal cron job (see below).
-	apt-get update
-	apt install certbot python3-certbot-nginx -y
+  # Create and install SSL Certificate for the API.
+  # Only necessary on staging and prod.
+  # We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
+  # Certbot must be installed regardless of whether or not a cert is present because of the auto renewal cron job (see below).
+  apt-get update
+  apt install certbot python3-certbot-nginx -y
 
-	# Write script which syncs cert with s3 remote store
-	cat <<"EOF" > certbot_s3_sync.sh
+  # Write script which syncs cert with s3 remote store
+  cat <<"EOF" > certbot_s3_sync.sh
 ${certbot_s3_sync_script}
 EOF
-	chmod +x ./certbot_s3_sync.sh
+  chmod +x ./certbot_s3_sync.sh
 
-	# Write script responsible for certbot cert renewal
-	cat <<"EOF" > certbot_renew_deploy_hook.sh
+  # Write script responsible for certbot cert renewal
+  cat <<"EOF" > certbot_renew_deploy_hook.sh
 ${certbot_renew_deploy_hook_script}
 EOF
-	chmod +x ./certbot_renew_deploy_hook.sh
+  chmod +x ./certbot_renew_deploy_hook.sh
 
-	# Add certbot cert auto renewal entry to cron
-	(crontab -l 2>/dev/null; echo "${certbot_crontab_entry}") | crontab -
+  # Add certbot cert auto renewal entry to cron
+  (crontab -l 2>/dev/null; echo "${certbot_crontab_entry}") | crontab -
 
     # Check here for the cert in S3, if present then pull it down from s3, if not then run certbot.
     if aws s3api head-object --bucket "${scpca_portal_cert_bucket}" --key letsencrypt.zip > /dev/null 2>&1; then
@@ -68,18 +68,17 @@ EOF
         unzip letsencrypt.zip -d /etc/
         mv /etc/letsencrypt/nginx.conf /etc/nginx/
         service nginx restart
-		rm letsencrypt.zip
+        rm letsencrypt.zip
     else
-		# The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
+  # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
         sleep 180
         BASE_URL="scpca.alexslemonade.org"
-		PREFIX="api"
+        PREFIX="api"
         if [[ ${stage} == "staging" ]]; then
-			PREFIX="$PREFIX.staging"
-		fi
+          PREFIX="$PREFIX.staging"
+        fi
         certbot --nginx -d $PREFIX.$BASE_URL -n --agree-tos --redirect -m ${slack_certbot_email}
-		./certbot_s3_sync.sh
-
+        ./certbot_s3_sync.sh
     fi
 fi
 

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -65,7 +65,8 @@ EOF
     # Check here for the cert in S3, if present then pull it down from s3, if not then run certbot.
     if aws s3api head-object --bucket "${scpca_portal_cert_bucket}" --key letsencrypt.zip > /dev/null 2>&1; then
         aws s3 cp "s3://${scpca_portal_cert_bucket}/letsencrypt.zip" letsencrypt.zip
-        unzip letsencrypt.zip -d /etc/
+        # -o overwrites the existing nginx.conf without prompt
+        unzip -o letsencrypt.zip -d /etc/
         service nginx restart
         rm letsencrypt.zip
     else

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -66,7 +66,6 @@ EOF
     if aws s3api head-object --bucket "${scpca_portal_cert_bucket}" --key letsencrypt.zip > /dev/null 2>&1; then
         aws s3 cp "s3://${scpca_portal_cert_bucket}/letsencrypt.zip" letsencrypt.zip
         unzip letsencrypt.zip -d /etc/
-        mv /etc/letsencrypt/nginx.conf /etc/nginx/
         service nginx restart
         rm letsencrypt.zip
     else

--- a/infrastructure/api-configuration/certbot/certbot_s3_sync.sh
+++ b/infrastructure/api-configuration/certbot/certbot_s3_sync.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Zip letsencrypt dir
-cd /home/ubuntu
-zip -r letsencrypt.zip /etc/letsencrypt/ /etc/nginx/nginx.conf
+# Build the archive with paths relative to /etc (letsencrypt/..., nginx/nginx.conf)
+# so it restores cleanly with `unzip -d /etc/`. The subshell keeps the cd local.
+(cd /etc && zip -r /home/ubuntu/letsencrypt.zip letsencrypt/ nginx/nginx.conf)
 
 # Sync with S3
-aws s3 cp letsencrypt.zip "s3://${scpca_portal_cert_bucket}/"
-rm letsencrypt.zip
+aws s3 cp /home/ubuntu/letsencrypt.zip "s3://${scpca_portal_cert_bucket}/"
+rm /home/ubuntu/letsencrypt.zip

--- a/infrastructure/api-configuration/certbot/certbot_s3_sync.sh
+++ b/infrastructure/api-configuration/certbot/certbot_s3_sync.sh
@@ -2,7 +2,8 @@
 
 # Build the archive with paths relative to /etc (letsencrypt/..., nginx/nginx.conf)
 # so it restores cleanly with `unzip -d /etc/`. The subshell keeps the cd local.
-(cd /etc && zip -r /home/ubuntu/letsencrypt.zip letsencrypt/ nginx/nginx.conf)
+# -y preserves certbot's live/ symlinks (otherwise renewal may break on restore).
+(cd /etc && zip -r -y /home/ubuntu/letsencrypt.zip letsencrypt/ nginx/nginx.conf)
 
 # Sync with S3
 aws s3 cp /home/ubuntu/letsencrypt.zip "s3://${scpca_portal_cert_bucket}/"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

On staging deploy ran into an issue where nginx wasnt loading the correct file. This was because of a double nested /etc/etc/letsencrypt|nginx folders. This PR resolves that as well as changes all tabs to double spaces.

Note: This change will require updating the archived folders in nginx before deploys. Going to do that while this gets reviewed.

This pull request refines the process for backing up and restoring SSL certificate files and the Nginx configuration for the API server. The changes ensure that the archive structure is consistent and that certificate renewals work smoothly after restoration. The main improvements are in how the archive is created and restored, and in the handling of file overwrites.

**Improvements to certificate backup and restore process:**

* The `certbot_s3_sync.sh` script now creates the `letsencrypt.zip` archive with paths relative to `/etc` and uses the `-y` flag to preserve symlinks, which is important for certbot's renewal process. The archive is created in `/home/ubuntu` and then uploaded to S3.
* When restoring the archive, the `unzip` command now uses the `-o` flag to overwrite existing files without prompting, ensuring the restored `nginx.conf` replaces the old one cleanly.

**Minor cleanup:**

* Removed an unnecessary blank line after running the certbot sync script in the user data template.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
