### PR TITLE
Assert that Datasets always have related ComputedFiles

### DIFF
--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -158,8 +158,7 @@ class Job(TimestampedModel):
         new_job.apply_state(JobStates.PENDING)
         if save:
             new_job.save()
-            if new_job.dataset:  # TODO: Remove after the dataset release
-                new_job.dataset.save()
+            new_job.dataset.save()
 
         return new_job
 
@@ -179,14 +178,12 @@ class Job(TimestampedModel):
         for job in jobs:
             if retry_job := job.create_retry_job(save=False):
                 retry_jobs.append(retry_job)
-                if job.dataset:  # TODO: Remove after the dataset release
-                    retry_datasets[job.dataset.get_class()].append(job.dataset)
+                retry_datasets[job.dataset.get_class()].append(job.dataset)
 
         if retry_jobs:
             cls.objects.bulk_create(retry_jobs)
-            if retry_datasets:  # TODO: Remove after the dataset release
-                for dataset_cls, datasets in retry_datasets.items():
-                    dataset_cls.bulk_update_state(datasets)
+            for dataset_cls, datasets in retry_datasets.items():
+                dataset_cls.bulk_update_state(datasets)
 
         return retry_jobs
 
@@ -257,8 +254,7 @@ class Job(TimestampedModel):
                 new_state, reason = cls.get_job_state(aws_job)
                 if job.apply_state(new_state, reason):
                     synced_jobs.append(job)
-                    if job.dataset:  # TODO: Remove after the dataset release
-                        synced_datasets[job.dataset.get_class()].append(job.dataset)
+                    synced_datasets[job.dataset.get_class()].append(job.dataset)
 
         if not synced_jobs:
             logger.info("No jobs were updated during sync.")
@@ -266,9 +262,8 @@ class Job(TimestampedModel):
 
         logger.info(f"Synced {len(synced_jobs)} jobs with AWS.")
         cls.bulk_update_state(synced_jobs)
-        if synced_datasets:  # TODO: Remove after the dataset release
-            for dataset_cls, datasets in synced_datasets.items():
-                dataset_cls.bulk_update_state(datasets)
+        for dataset_cls, datasets in synced_datasets.items():
+            dataset_cls.bulk_update_state(datasets)
 
         if failed_job_ids:
             logger.info(f"{len(failed_job_ids)} jobs failed to sync.")
@@ -321,8 +316,7 @@ class Job(TimestampedModel):
 
         if self.apply_state(new_state, reason):
             self.save()
-            if self.dataset:  # TODO: Remove after the dataset release
-                self.dataset.save()
+            self.dataset.save()
 
         return True
 
@@ -377,8 +371,7 @@ class Job(TimestampedModel):
 
         if save:
             self.save()
-            if self.dataset:  # TODO: Remove after the dataset release
-                self.dataset.save()
+            self.dataset.save()
 
     def increment_attempt_or_fail(self) -> bool:
         """
@@ -411,8 +404,7 @@ class Job(TimestampedModel):
             try:
                 job.submit(save=False)  # Jobs are saved in bulk outside of the loop
                 submitted_jobs.append(job)
-                if job.dataset:  # TODO: Remove after the dataset release
-                    submitted_datasets[job.dataset.get_class()].append(job.dataset)
+                submitted_datasets[job.dataset.get_class()].append(job.dataset)
             except (JobError, DatasetError):
                 if job.increment_attempt_or_fail():
                     pending_jobs.append(job)
@@ -423,9 +415,8 @@ class Job(TimestampedModel):
             updated_batch_attrs = ["batch_job_id", "batch_job_queue", "batch_job_definition"]
             cls.objects.bulk_update(submitted_jobs, updated_batch_attrs)
             cls.bulk_update_state(submitted_jobs)
-            if submitted_datasets:  # TODO: Remove after the dataset release
-                for dataset_cls, datasets in submitted_datasets.items():
-                    dataset_cls.bulk_update_state(datasets)
+            for dataset_cls, datasets in submitted_datasets.items():
+                dataset_cls.bulk_update_state(datasets)
 
         return submitted_jobs, pending_jobs, failed_jobs
 
@@ -466,8 +457,7 @@ class Job(TimestampedModel):
 
         if save:
             self.save()
-            if self.dataset:  # TODO: Remove after the dataset release
-                self.dataset.save()
+            self.dataset.save()
 
     @classmethod
     def terminate_processing(cls, reason: str | None = "Terminated processing jobs") -> List[Self]:
@@ -486,8 +476,7 @@ class Job(TimestampedModel):
             try:
                 job.terminate(reason=reason, save=False)
                 terminated_jobs.append(job)
-                if job.dataset:  # TODO: Remove after the dataset release
-                    terminated_datasets[job.dataset.get_class()].append(job.dataset)
+                terminated_datasets[job.dataset.get_class()].append(job.dataset)
             except JobInvalidTerminateStateError:
                 final_state_jobs.append(job)
             except JobError:
@@ -496,9 +485,8 @@ class Job(TimestampedModel):
         if terminated_jobs:
             logger.info(f"Terminated {len(terminated_jobs)} jobs on AWS.")
             cls.bulk_update_state(terminated_jobs)
-            if terminated_datasets:  # TODO: Remove after the dataset release
-                for dataset_cls, datasets in terminated_datasets.items():
-                    dataset_cls.bulk_update_state(datasets)
+            for dataset_cls, datasets in terminated_datasets.items():
+                dataset_cls.bulk_update_state(datasets)
 
         if final_state_jobs:
             logger.info(f"{len(final_state_jobs)} jobs were not in a terminable state.")

--- a/api/scpca_portal/models/job.py
+++ b/api/scpca_portal/models/job.py
@@ -158,7 +158,8 @@ class Job(TimestampedModel):
         new_job.apply_state(JobStates.PENDING)
         if save:
             new_job.save()
-            new_job.dataset.save()
+            if new_job.dataset:  # TODO: Remove after the dataset release
+                new_job.dataset.save()
 
         return new_job
 
@@ -178,12 +179,14 @@ class Job(TimestampedModel):
         for job in jobs:
             if retry_job := job.create_retry_job(save=False):
                 retry_jobs.append(retry_job)
-                retry_datasets[job.dataset.get_class()].append(job.dataset)
+                if job.dataset:  # TODO: Remove after the dataset release
+                    retry_datasets[job.dataset.get_class()].append(job.dataset)
 
         if retry_jobs:
             cls.objects.bulk_create(retry_jobs)
-            for dataset_cls, datasets in retry_datasets.items():
-                dataset_cls.bulk_update_state(datasets)
+            if retry_datasets:  # TODO: Remove after the dataset release
+                for dataset_cls, datasets in retry_datasets.items():
+                    dataset_cls.bulk_update_state(datasets)
 
         return retry_jobs
 
@@ -254,7 +257,8 @@ class Job(TimestampedModel):
                 new_state, reason = cls.get_job_state(aws_job)
                 if job.apply_state(new_state, reason):
                     synced_jobs.append(job)
-                    synced_datasets[job.dataset.get_class()].append(job.dataset)
+                    if job.dataset:  # TODO: Remove after the dataset release
+                        synced_datasets[job.dataset.get_class()].append(job.dataset)
 
         if not synced_jobs:
             logger.info("No jobs were updated during sync.")
@@ -262,8 +266,9 @@ class Job(TimestampedModel):
 
         logger.info(f"Synced {len(synced_jobs)} jobs with AWS.")
         cls.bulk_update_state(synced_jobs)
-        for dataset_cls, datasets in synced_datasets.items():
-            dataset_cls.bulk_update_state(datasets)
+        if synced_datasets:  # TODO: Remove after the dataset release
+            for dataset_cls, datasets in synced_datasets.items():
+                dataset_cls.bulk_update_state(datasets)
 
         if failed_job_ids:
             logger.info(f"{len(failed_job_ids)} jobs failed to sync.")
@@ -316,7 +321,8 @@ class Job(TimestampedModel):
 
         if self.apply_state(new_state, reason):
             self.save()
-            self.dataset.save()
+            if self.dataset:  # TODO: Remove after the dataset release
+                self.dataset.save()
 
         return True
 
@@ -371,7 +377,8 @@ class Job(TimestampedModel):
 
         if save:
             self.save()
-            self.dataset.save()
+            if self.dataset:  # TODO: Remove after the dataset release
+                self.dataset.save()
 
     def increment_attempt_or_fail(self) -> bool:
         """
@@ -404,7 +411,8 @@ class Job(TimestampedModel):
             try:
                 job.submit(save=False)  # Jobs are saved in bulk outside of the loop
                 submitted_jobs.append(job)
-                submitted_datasets[job.dataset.get_class()].append(job.dataset)
+                if job.dataset:  # TODO: Remove after the dataset release
+                    submitted_datasets[job.dataset.get_class()].append(job.dataset)
             except (JobError, DatasetError):
                 if job.increment_attempt_or_fail():
                     pending_jobs.append(job)
@@ -415,8 +423,9 @@ class Job(TimestampedModel):
             updated_batch_attrs = ["batch_job_id", "batch_job_queue", "batch_job_definition"]
             cls.objects.bulk_update(submitted_jobs, updated_batch_attrs)
             cls.bulk_update_state(submitted_jobs)
-            for dataset_cls, datasets in submitted_datasets.items():
-                dataset_cls.bulk_update_state(datasets)
+            if submitted_datasets:  # TODO: Remove after the dataset release
+                for dataset_cls, datasets in submitted_datasets.items():
+                    dataset_cls.bulk_update_state(datasets)
 
         return submitted_jobs, pending_jobs, failed_jobs
 
@@ -457,7 +466,8 @@ class Job(TimestampedModel):
 
         if save:
             self.save()
-            self.dataset.save()
+            if self.dataset:  # TODO: Remove after the dataset release
+                self.dataset.save()
 
     @classmethod
     def terminate_processing(cls, reason: str | None = "Terminated processing jobs") -> List[Self]:
@@ -476,7 +486,8 @@ class Job(TimestampedModel):
             try:
                 job.terminate(reason=reason, save=False)
                 terminated_jobs.append(job)
-                terminated_datasets[job.dataset.get_class()].append(job.dataset)
+                if job.dataset:  # TODO: Remove after the dataset release
+                    terminated_datasets[job.dataset.get_class()].append(job.dataset)
             except JobInvalidTerminateStateError:
                 final_state_jobs.append(job)
             except JobError:
@@ -485,8 +496,9 @@ class Job(TimestampedModel):
         if terminated_jobs:
             logger.info(f"Terminated {len(terminated_jobs)} jobs on AWS.")
             cls.bulk_update_state(terminated_jobs)
-            for dataset_cls, datasets in terminated_datasets.items():
-                dataset_cls.bulk_update_state(datasets)
+            if terminated_datasets:  # TODO: Remove after the dataset release
+                for dataset_cls, datasets in terminated_datasets.items():
+                    dataset_cls.bulk_update_state(datasets)
 
         if final_state_jobs:
             logger.info(f"{len(final_state_jobs)} jobs were not in a terminable state.")

--- a/api/scpca_portal/test/models/test_computed_file.py
+++ b/api/scpca_portal/test/models/test_computed_file.py
@@ -95,6 +95,10 @@ class TestGetFile(TestCase):
             msg = f"The actual and expected `{attribute}` values differ in {computed_file}"
             self.assertEqual(getattr(computed_file, attribute), value, msg)
 
+        # CHECK COMPUTED FILE AND DATASET RELATIONSHIP
+        self.assertIsNotNone(dataset.computed_file)
+        self.assertEqual(dataset.computed_file, computed_file)
+
     def test_original_file_zip_namelist(self):
         self.maxDiff = None
 
@@ -104,7 +108,7 @@ class TestGetFile(TestCase):
         )
         dataset.save()
 
-        ComputedFile.get_dataset_file(dataset)
+        computed_file = ComputedFile.get_dataset_file(dataset)
 
         with ZipFile(dataset.computed_file_local_path) as project_zip:
             # Check if file list is as expected
@@ -112,3 +116,7 @@ class TestGetFile(TestCase):
                 sorted(project_zip.namelist()),
                 sorted(test_data.UserDatasetSingleCellExperiment.COMPUTED_FILE_LIST),
             )
+
+        # CHECK COMPUTED FILE AND DATASET RELATIONSHIP
+        self.assertIsNotNone(dataset.computed_file)
+        self.assertEqual(dataset.computed_file, computed_file)

--- a/api/scpca_portal/test/models/test_job.py
+++ b/api/scpca_portal/test/models/test_job.py
@@ -146,6 +146,11 @@ class TestJob(TestCase):
         self.assertEqual(saved_job.state, JobStates.PROCESSING)
         self.assertIsInstance(saved_job.processing_at, datetime)
 
+        # Make sure that the submitted job is linked to the dataset
+        self.assertTrue(dataset.jobs.exists())
+        self.assertGreaterEqual(dataset.jobs.count(), 1)
+        self.assertIn(job, dataset.jobs.all())
+
     @patch(
         "scpca_portal.models.datasets.ccdl_dataset.CCDLDataset.has_locked_projects",
         new_callable=PropertyMock,


### PR DESCRIPTION
## Issue Number

Closes #2032 

Stacked from #2038 

## Purpose/Implementation Notes

This PR adds assertions to the existing tests to ensure that processed datasets at most one job and one computed file.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

Updated:
- `test/models/test_computed_file.py`
- `test/models/test_job.py`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated any associated Storybook stories (if applicable)

## Screenshots
N/A

