### PR TITLE
Update Failed Job Handling

### DIFF
--- a/api/scpca_portal/enums/__init__.py
+++ b/api/scpca_portal/enums/__init__.py
@@ -2,6 +2,7 @@ from scpca_portal.enums.ccdl_dataset_names import CCDLDatasetNames
 from scpca_portal.enums.dataset_data_project_config import DatasetDataProjectConfig
 from scpca_portal.enums.dataset_formats import DatasetFormats
 from scpca_portal.enums.dataset_states import DatasetStates
+from scpca_portal.enums.failed_job_actions import FailedJobActions
 from scpca_portal.enums.file_formats import FileFormats
 from scpca_portal.enums.job_states import JobStates
 from scpca_portal.enums.modalities import Modalities

--- a/api/scpca_portal/enums/failed_job_actions.py
+++ b/api/scpca_portal/enums/failed_job_actions.py
@@ -1,0 +1,7 @@
+from django.db.models import TextChoices
+
+
+class FailedJobActions(TextChoices):
+    EMAIL = "EMAIL"  # Send a dataset error email for unrecoverable error
+    RETRY = "RETRY"  # Create a new retry job for recoverable error
+    SLACK = "SLACK"  # Send a Slack notification to request manual error handling

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -1,6 +1,6 @@
 from scpca_portal import notifications, s3, utils
 from scpca_portal.config.logging import get_and_configure_logger
-from scpca_portal.enums import JobStates
+from scpca_portal.enums import FailedJobActions, JobStates
 from scpca_portal.exceptions import (
     DatasetLockedProjectError,
     DatasetMissingLibrariesError,
@@ -25,6 +25,7 @@ class DatasetJobProcessor(JobProcessorABC):
         "send_notification",
     ]
 
+    # Handlers to call when steps fail
     exception_handlers = {
         ("create_new_computed_file", DatasetLockedProjectError): "handle_locked_project",
         ("create_new_computed_file", DatasetMissingLibrariesError): "handle_missing_libraries",
@@ -32,11 +33,13 @@ class DatasetJobProcessor(JobProcessorABC):
         ("tag_new_computed_file", S3TaggingError): "handle_tag_failure",
     }
 
-    # Exception types
-    # Determine the next step for failed job handling
-    retryable_exceptions = [DatasetLockedProjectError, S3UploadError]
-    slack_notification_exceptions = [S3TaggingError]
-    email_notification_exceptions = [DatasetMissingLibrariesError]
+    # Actions to take after handling each exception
+    exception_actions = {
+        ("create_new_computed_file", DatasetLockedProjectError): FailedJobActions.RETRY,
+        ("create_new_computed_file", DatasetMissingLibrariesError): FailedJobActions.EMAIL,
+        ("upload_new_computed_file", S3UploadError): FailedJobActions.RETRY,
+        ("tag_new_computed_file", S3TaggingError): FailedJobActions.SLACK,
+    }
 
     # Logging
     def on_run(self) -> None:
@@ -74,38 +77,36 @@ class DatasetJobProcessor(JobProcessorABC):
         self.job.dataset.computed_file.save()
         self.job.dataset.save()
 
-    def handle_failure(self, e: Exception):
+    def handle_failure(self, step: str, e: Exception) -> None:
         self.job.apply_state(JobStates.FAILED, reason=f"{e}")
         self.job.save()
 
-        e_type = type(e)
-        if e_type in self.retryable_exceptions:
-            self.job.create_retry_job()
-        elif e_type in self.slack_notification_exceptions:
-            logger.info("Send Slack notification for manual handling.")
-            notifications.send_slack_notification(self.job)
-        elif e_type in self.email_notification_exceptions:
-            if self.job.dataset.email:
-                logger.info("Sending dataset job error email.")
-                notifications.send_dataset_job_error_email(self.job)
-        else:
-            raise RuntimeError(f"No exception type is defined for: {e_type.__name__}")
+        action = self.exception_actions[(step, type(e))]
+
+        match action:
+            case FailedJobActions.EMAIL:
+                if self.job.dataset.email:
+                    logger.info("Sending dataset job error email.")
+                    notifications.send_dataset_job_error_email(self.job)
+            case FailedJobActions.RETRY:
+                self.job.create_retry_job()
+            case FailedJobActions.SLACK:
+                logger.info("Send Slack notification for manual handling.")
+                notifications.send_slack_notification(self.job)
+            case _:
+                raise RuntimeError(f"No action is set for {step} : {type(e).__name__}")
 
     def handle_locked_project(self, step: str, e: Exception) -> None:
-        # Create a new retry job
-        self.handle_failure(e)
+        self.handle_failure(step, e)
 
     def handle_missing_libraries(self, step: str, e: Exception) -> None:
-        # Send unrecoverable error email
-        self.handle_failure(e)
+        self.handle_failure(step, e)
 
     def handle_upload_failure(self, step: str, e: Exception) -> None:
-        # Create a new retry job
-        self.handle_failure(e)
+        self.handle_failure(step, e)
 
     def handle_tag_failure(self, step: str, e: Exception) -> None:
-        # Require manual tagging
-        self.handle_failure(e)
+        self.handle_failure(step, e)
 
     def upload_new_computed_file(self) -> None:
         key = self.job.dataset.computed_file.s3_key

--- a/api/scpca_portal/job_processors/dataset_job_processor.py
+++ b/api/scpca_portal/job_processors/dataset_job_processor.py
@@ -32,6 +32,12 @@ class DatasetJobProcessor(JobProcessorABC):
         ("tag_new_computed_file", S3TaggingError): "handle_tag_failure",
     }
 
+    # Exception types
+    # Determine the next step for failed job handling
+    retryable_exceptions = [DatasetLockedProjectError, S3UploadError]
+    slack_notification_exceptions = [S3TaggingError]
+    email_notification_exceptions = [DatasetMissingLibrariesError]
+
     # Logging
     def on_run(self) -> None:
         logger.info(f"Processing {self.job.id} - {self.job.batch_job_id} - {self.job.dataset}")
@@ -46,7 +52,7 @@ class DatasetJobProcessor(JobProcessorABC):
     def on_uncaught_exception(self, step: str, e: Exception) -> None:
         logger.info("Encountered uncaught exception.")
         logger.exception(e)
-        self.job.save()
+
         if self.job.dataset.email:
             logger.info("Sending dataset job error email.")
             notifications.send_dataset_job_error_email(self.job)
@@ -68,29 +74,38 @@ class DatasetJobProcessor(JobProcessorABC):
         self.job.dataset.computed_file.save()
         self.job.dataset.save()
 
-    def handle_locked_project(self, step: str, e: Exception) -> None:
-        self.job.apply_state(JobStates.FAILED, reason="Dataset contains locked project.")
+    def handle_failure(self, e: Exception):
+        self.job.apply_state(JobStates.FAILED, reason=f"{e}")
         self.job.save()
-        self.job.create_retry_job()
+
+        e_type = type(e)
+        if e_type in self.retryable_exceptions:
+            self.job.create_retry_job()
+        elif e_type in self.slack_notification_exceptions:
+            logger.info("Send Slack notification for manual handling.")
+            notifications.send_slack_notification(self.job)
+        elif e_type in self.email_notification_exceptions:
+            if self.job.dataset.email:
+                logger.info("Sending dataset job error email.")
+                notifications.send_dataset_job_error_email(self.job)
+        else:
+            raise RuntimeError(f"No exception type is defined for: {e_type.__name__}")
+
+    def handle_locked_project(self, step: str, e: Exception) -> None:
+        # Create a new retry job
+        self.handle_failure(e)
 
     def handle_missing_libraries(self, step: str, e: Exception) -> None:
-        self.job.apply_state(JobStates.FAILED, reason="Dataset contains missing libraries.")
-        self.job.save()
-        if self.job.dataset.email:
-            logger.info("Sending dataset job error email.")
-            notifications.send_dataset_job_error_email(self.job)
+        # Send unrecoverable error email
+        self.handle_failure(e)
 
     def handle_upload_failure(self, step: str, e: Exception) -> None:
-        self.job.apply_state(JobStates.FAILED, reason="Failed to upload the computed file to S3.")
-        self.job.save()
-        self.job.create_retry_job()
+        # Create a new retry job
+        self.handle_failure(e)
 
     def handle_tag_failure(self, step: str, e: Exception) -> None:
-        # Notify about S3 tagging failure via Slack to enable manual tagging
-        self.job.apply_state(JobStates.FAILED, reason="Failed to tag the computed file on S3.")
-        self.job.save()
-        logger.info("Send Slack notification for manual tagging alert.")
-        notifications.send_computed_file_tagging_error_email(self.job)
+        # Require manual tagging
+        self.handle_failure(e)
 
     def upload_new_computed_file(self) -> None:
         key = self.job.dataset.computed_file.s3_key

--- a/api/scpca_portal/management/commands/submit_pending.py
+++ b/api/scpca_portal/management/commands/submit_pending.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 
+from scpca_portal import common
 from scpca_portal.config.logging import get_and_configure_logger
 from scpca_portal.models import Job
 
@@ -21,6 +22,12 @@ class Command(BaseCommand):
             logger.info("No jobs were submitted to AWS Batch")
 
         if pending_jobs:
-            logger.info(f"{len(pending_jobs)} jobs were not submitted but are still pending.")
+            logger.info(
+                f"{len(pending_jobs)} jobs were not submitted and"
+                f"will be retried on the next cron run"
+            )
         if failed_jobs:
-            logger.info(f"{len(failed_jobs)} jobs failed to submit.")
+            logger.info(
+                f"{len(failed_jobs)} jobs failed due to max submission attempts"
+                f"({common.MAX_JOB_ATTEMPTS}) exceeded"
+            )

--- a/api/scpca_portal/notifications.py
+++ b/api/scpca_portal/notifications.py
@@ -75,10 +75,11 @@ def send_dataset_job_error_email(job: Job) -> None:
     return send_email(job.dataset.email, subject, body_text, body_html)
 
 
-def send_computed_file_tagging_error_email(job: Job) -> None:
-    subject = f"Failed to tag the computed file on S3 for {job.dataset.id}"
+def send_slack_notification(job: Job) -> None:
+    subject = f"Failed S3 operation for {job.dataset.id}"
     body_text = (
-        f"Tagging failure on the computed file {job.dataset.computed_file.s3_key} "
+        f"Failed reason: {job.failed_reason}"
+        f"{job.dataset.computed_file.s3_key} "
         f"on bucket {job.dataset.computed_file.s3_bucket} for the dataset {job.dataset.id}"
     )
 

--- a/api/scpca_portal/test/job_processors/test_dataset_job_processor.py
+++ b/api/scpca_portal/test/job_processors/test_dataset_job_processor.py
@@ -5,13 +5,19 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.utils.timezone import make_aware
 
-from scpca_portal.enums import DatasetStates, JobStates
+from scpca_portal.enums import DatasetStates, FailedJobActions, JobStates
 from scpca_portal.exceptions import DatasetMissingLibrariesError, S3TaggingError, S3UploadError
 from scpca_portal.job_processors import DatasetJobProcessor
 from scpca_portal.test.factories import CCDLDatasetFactory, JobFactory, UserDatasetFactory
 
 
 class TestDatasetJobProcessor(TestCase):
+    def setUp(self):
+        self.exception_actions = {
+            ("create_new_computed_file", DatasetMissingLibrariesError): FailedJobActions.EMAIL,
+            ("upload_new_computed_file", S3UploadError): FailedJobActions.RETRY,
+            ("tag_new_computed_file", S3TaggingError): FailedJobActions.SLACK,
+        }
 
     def test_on_run_done_expires_at_for_user_dataset(self):
         succeeded_at = make_aware(datetime.now())
@@ -47,9 +53,10 @@ class TestDatasetJobProcessor(TestCase):
         )
 
         processor = DatasetJobProcessor(job)
+        step = "create_new_computed_file"
         exception = DatasetMissingLibrariesError()
 
-        processor.handle_failure(exception)
+        processor.handle_failure(step, exception)
 
         self.assertEqual(job.state, JobStates.FAILED)
         self.assertEqual(job.failed_reason, f"{exception}")
@@ -62,9 +69,10 @@ class TestDatasetJobProcessor(TestCase):
         )
 
         processor = DatasetJobProcessor(job)
+        step = "tag_new_computed_file"
         exception = S3TaggingError("MOCK_KEY", "MOCK_BUCKET_NAME")
 
-        processor.handle_failure(exception)
+        processor.handle_failure(step, exception)
 
         self.assertEqual(job.state, JobStates.FAILED)
         self.assertEqual(job.failed_reason, f"{exception}")
@@ -76,12 +84,12 @@ class TestDatasetJobProcessor(TestCase):
         )
 
         processor = DatasetJobProcessor(job)
+        step = "upload_new_computed_file"
         exception = S3UploadError("MOCK_KEY", "MOCK_BUCKET_NAME")
 
-        processor.handle_failure(exception)
+        processor.handle_failure(step, exception)
 
         self.assertEqual(job.state, JobStates.FAILED)
         self.assertEqual(job.failed_reason, f"{exception}")
-        self.assertEqual(
-            job.dataset.latest_job.state, JobStates.PENDING
-        )  # a new retry job is created
+        # Should create a new retry job
+        self.assertEqual(job.dataset.latest_job.state, JobStates.PENDING)

--- a/api/scpca_portal/test/job_processors/test_dataset_job_processor.py
+++ b/api/scpca_portal/test/job_processors/test_dataset_job_processor.py
@@ -1,10 +1,12 @@
 from datetime import datetime
+from unittest.mock import patch
 
 # from django.conf import settings
 from django.test import TestCase
 from django.utils.timezone import make_aware
 
 from scpca_portal.enums import DatasetStates, JobStates
+from scpca_portal.exceptions import DatasetMissingLibrariesError, S3TaggingError, S3UploadError
 from scpca_portal.job_processors import DatasetJobProcessor
 from scpca_portal.test.factories import CCDLDatasetFactory, JobFactory, UserDatasetFactory
 
@@ -37,3 +39,49 @@ class TestDatasetJobProcessor(TestCase):
 
         expected_value = None
         self.assertIsNone(job.dataset.expires_at, expected_value)
+
+    @patch("scpca_portal.notifications.send_dataset_job_error_email")
+    def test_handle_email_notification_exceptions(self, mock_send_email):
+        job = JobFactory(
+            state=JobStates.PROCESSING, dataset=CCDLDatasetFactory(email="user@example.com")
+        )
+
+        processor = DatasetJobProcessor(job)
+        exception = DatasetMissingLibrariesError()
+
+        processor.handle_failure(exception)
+
+        self.assertEqual(job.state, JobStates.FAILED)
+        self.assertEqual(job.failed_reason, f"{exception}")
+        mock_send_email.assert_called_once_with(job)
+
+    @patch("scpca_portal.notifications.send_slack_notification")
+    def test_handle_slack_notification_exceptions(self, mock_send_slack):
+        job = JobFactory(
+            state=JobStates.PROCESSING, dataset=CCDLDatasetFactory(email="user@example.com")
+        )
+
+        processor = DatasetJobProcessor(job)
+        exception = S3TaggingError("MOCK_KEY", "MOCK_BUCKET_NAME")
+
+        processor.handle_failure(exception)
+
+        self.assertEqual(job.state, JobStates.FAILED)
+        self.assertEqual(job.failed_reason, f"{exception}")
+        mock_send_slack.assert_called_once_with(job)
+
+    def test_handle_retryable_exceptions(self):
+        job = JobFactory(
+            state=JobStates.PROCESSING, dataset=CCDLDatasetFactory(state=DatasetStates.PROCESSING)
+        )
+
+        processor = DatasetJobProcessor(job)
+        exception = S3UploadError("MOCK_KEY", "MOCK_BUCKET_NAME")
+
+        processor.handle_failure(exception)
+
+        self.assertEqual(job.state, JobStates.FAILED)
+        self.assertEqual(job.failed_reason, f"{exception}")
+        self.assertEqual(
+            job.dataset.latest_job.state, JobStates.PENDING
+        )  # a new retry job is created


### PR DESCRIPTION
## Issue Number

Closes #2035
Stacked from PR #2053

Feature branch: `feature/job-dataset-state-reconciliation`

## Purpose/Implementation Notes

I've refactored the failed job handling during dataset job processing. 

Changes include:
- Grouped dataset job processing exceptions into the following categories (the group names indicate the next step for failed jobs):
   - `retryable_exceptions`
   - `slack_notification_exceptions`
   - `email_notification_exceptions`
- Added a `handle_failure` method, which handles failed job state updates and triggers the next step based on the exception types. All exception handlers call this method.
- Made the `notifications.send_slack_notification` function (previously `send_computed_file_tagging_error_email` generic

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

Added the new tests in `test/job_processors/test_dataset_job_processor.py`

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated any associated Storybook stories (if applicable)

## Screenshots

N/A
